### PR TITLE
Separate core module and add indexing & slicing

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "test": "node test/index.test.js",
     "test:ci": "npm run lint && npm test | tap-set-exit",
-    "lint": "eslint zarrita.js fsstore.js test --ext .js"
+    "lint": "eslint src test --ext .js"
   },
   "files": [
     "zarrita.js",

--- a/package.json
+++ b/package.json
@@ -21,9 +21,7 @@
   "author": "Trevor Manz",
   "license": "MIT",
   "eslintConfig": {
-    "extends": [
-      "eslint:recommended"
-    ],
+    "extends": ["eslint:recommended"],
     "env": {
       "es6": true,
       "browser": true,
@@ -34,34 +32,14 @@
       "sourceType": "module"
     },
     "rules": {
-      "comma-dangle": [
-        "error",
-        "always-multiline"
-      ],
+      "comma-dangle": ["error", "always-multiline"],
       "no-console": "error",
       "no-cond-assign": "off",
-      "no-fallthrough": [
-        "error",
-        {
-          "commentPattern": "break omitted"
-        }
-      ],
+      "no-fallthrough": ["error", { "commentPattern": "break omitted" }],
       "semi": "error",
-      "quotes": [
-        "error",
-        "single",
-        {
-          "avoidEscape": true
-        }
-      ],
+      "quotes": ["error", "single", { "avoidEscape": true }],
       "prefer-const": "error",
-      "sort-imports": [
-        "error",
-        {
-          "ignoreCase": false,
-          "ignoreDeclarationSort": true
-        }
-      ]
+      "sort-imports": ["error", { "ignoreCase": false, "ignoreDeclarationSort": true }]
     }
   },
   "dependencies": {},

--- a/src/core.js
+++ b/src/core.js
@@ -77,7 +77,6 @@ export async function get_hierarchy(store) {
   // instantiate hierarchy
   const meta_key_suffix = meta.metadata_key_suffix;
   const hierarchy = new Hierarchy({ store, meta_key_suffix });
-
   return hierarchy;
 }
 
@@ -124,7 +123,6 @@ function _check_shape(shape) {
   if (Number.isInteger(shape)) {
     shape = [shape];
   }
-
   assert(shape.every(i => Number.isInteger(i)), `Invalid array shape, got: ${shape}`);
   return shape;
 }
@@ -192,7 +190,11 @@ async function _decode_codec_metadata(meta) {
   if (meta.codec !== 'https://purl.org/zarr/spec/codec/gzip/1.0') {
     throw new NotImplementedError();
   }
-  const GZip = await registry.get('gzip')();
+  const importer = registry.get('gzip');
+  if (!importer) {
+    throw Error('Codec not in registry');
+  }
+  const GZip = await importer();
   const codec = new GZip(meta.configuration.level);
   return codec;
 }

--- a/src/core.js
+++ b/src/core.js
@@ -127,15 +127,16 @@ function _check_shape(shape) {
   return shape;
 }
 
-// no support for >u8, <u8, |b1
+// no support for >u8, <u8, |b1, <f2, >f2
 const DTYPE_STRS = new Set([
-   'i1',  'u1', // '|b1'
-  '<i2', '<i4', '<i8',
-  '>i2', '>i4', '>i8',
-  '<u2', '<u4', // 'u8'
-  '>u2', '>u4', // '>u8'
-  '<f2', '<f4', '<f8',
-  '>f2', '>f4', '>f8',
+   'i1',  'u1',
+  '<i2', '<i4',
+  '<i8', '>i8',
+  '>i2', '>i4',
+  '<u2', '<u4',
+  '>u2', '>u4',
+  '<f4', '<f8',
+  '>f4', '>f8',
 ]);
 
 function _check_dtype(dtype) {

--- a/src/core.js
+++ b/src/core.js
@@ -131,11 +131,11 @@ function _check_shape(shape) {
 
 // no support for >u8, <u8, |b1
 const DTYPE_STRS = new Set([
-  'i1', 'u1', 
+   'i1',  'u1', // '|b1'
   '<i2', '<i4', '<i8',
   '>i2', '>i4', '>i8',
-  '<u2', '<u4',
-  '>u2', '>u4',
+  '<u2', '<u4', // 'u8'
+  '>u2', '>u4', // '>u8'
   '<f2', '<f4', '<f8',
   '>f2', '>f4', '>f8',
 ]);
@@ -722,20 +722,8 @@ export class ZarrArray extends Node {
 
   async get_chunk(chunk_coords) {
     const chunk_key = this._chunk_key(chunk_coords);
-    let data;
-    try {
-      const buffer = await this.store.get(chunk_key);
-      data = await this._decode_chunk(buffer);
-    } catch (err) {
-      if (!(err instanceof KeyError)) {
-        throw err;
-      }
-      const size = this.chunk_shape.reduce((a, b) => a * b, 1);
-      data = new this.TypedArray(size);
-      if (typeof this.fill_value === 'number') {
-        data.fill(this.fill_value);
-      }
-    }
+    const buffer = await this.store.get(chunk_key);
+    const data = await this._decode_chunk(buffer);
     return { data, shape: this.chunk_shape };
   }
 

--- a/src/fsstore.js
+++ b/src/fsstore.js
@@ -1,6 +1,6 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { KeyError, ListDirResult, Store, assert } from './zarrita.js';
+import { KeyError, ListDirResult, Store, assert } from './core.js';
 
 export default class FileSystemStore extends Store {
   constructor(fp) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,2 @@
+export * from './core.js';
+import './indexing.js';

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
 export * from './core.js';
-import './indexing.js';
+export * from './indexing.js';

--- a/src/indexing.js
+++ b/src/indexing.js
@@ -189,6 +189,7 @@ export function slice(start, stop, step = null) {
     start = null;
   }
   const indices = length => {
+    assert(typeof length === 'number', 'must provide sized length for slice indices.');
     const istep = step ?? 1;
     let start_ix = start ?? (istep < 0 ? length - 1 : 0);
     let end_ix = stop ?? (istep < 0 ? -1 : length);

--- a/src/indexing.js
+++ b/src/indexing.js
@@ -1,0 +1,412 @@
+import { IndexError, KeyError, NotImplementedError, ZarrArray, assert } from './core.js';
+
+// This module mutates the ZarrArray prototype to add chunk indexing and slicing
+
+Object.defineProperties(ZarrArray.prototype, {
+  get: {
+    value(selection) {
+      return this.get_basic_selection(selection);
+    },
+  },
+  get_basic_selection: {
+    value(selection) {
+      const indexer = new _BasicIndexer({ selection, ...this });
+      return _get_selection.call(this, indexer);
+    },
+  },
+  set: {
+    value(selection, value) {
+      return this.set_basic_selection(selection, value);
+    },
+  },
+  set_basic_selection: {
+    value(selection, value) {
+      const indexer = new _BasicIndexer(selection, this);
+      return _set_selection.call(this, indexer, value);
+    },
+  },
+  chunk_size: {
+    get() {
+      return this.chunk_shape.reduce((a, b) => a * b, 1);
+    },
+  },
+});
+
+// ZarrArray GET
+
+async function _get_selection(indexer) {
+  // setup output array
+  const outsize = indexer.shape.reduce((a, b) => a * b, 1);
+  const out = {
+    data: new this.TypedArray(outsize),
+    shape: indexer.shape,
+    strides: get_strides(indexer.shape),
+  };
+  // iterator over chunks
+  for (const { chunk_coords, chunk_selection, out_selection } of indexer) {
+    // TODO: Make concurrent!
+    // load chunk selection into output array
+    await _chunk_getitem.call(this, chunk_coords, chunk_selection, out, out_selection);
+  }
+  // Return scalar if no shape ?
+  return out.shape ? out : out.data[0];
+}
+
+async function _chunk_getitem(chunk_coords, chunk_selection, out, out_selection) {
+  try {
+    // decode chunk
+    const chunk = await this.get_chunk(chunk_coords);
+    chunk.strides = get_strides(chunk.shape);
+    // store selected data in output
+    _set_arr_direct(out, out_selection, chunk, chunk_selection);
+  } catch (err) {
+    if (!(err instanceof KeyError)) {
+      throw err;
+    }
+    if (this.fill_value !== null) {
+      _set_arr_scalar(out, out_selection, this.fill_value);
+    }
+  }
+}
+
+function _set_arr_scalar(out, out_selection, value) {
+  throw new NotImplementedError();
+}
+
+function _set_arr_direct(out, out_selection, chunk, chunk_selection) {
+  throw new NotImplementedError();
+}
+
+
+async function _set_selection(indexer, value) {
+  // We iterate over all chunks which overlap the selection and thus contain data
+  // that needs to be replaced. Each chunk is processed in turn, extracting the
+  // necessary data from the value array and storing into the chunk array.
+
+  // N.B., it is an important optimisation that we only visit chunks which overlap
+  // the selection. This minimises the number of iterations in the main for loop.
+
+  // determine indices of chunks overlapping the selection
+  const sel_shape = indexer.shape;
+  // check value shape
+  if (sel_shape?.length === 0) {
+      assert(_isscalar(value), `value not scalar for scalar selection, got ${value}`);
+  }
+
+  // If input is missing strides, compute from array shape
+  if (!Array.isArray(value.strides)) {
+    // Don't mutate input object
+    value = {
+      data: value.data,
+      shape: value.shape,
+      strides: get_strides(value.shape),
+    };
+  }
+  // iterate over chunks in range
+  for (const { chunk_coords, chunk_selection, out_selection } of indexer) {
+    // put data
+    await _chunk_setitem.call(this, chunk_coords, chunk_selection, value, out_selection);
+  }
+}
+
+async function _chunk_setitem(chunk_coords, chunk_selection, value, out_selection) {
+  // obtain key for chunk storage
+  const chunk_key = self._chunk_key(chunk_coords);
+
+  let cdata;
+  if (_is_total_slice(chunk_selection, this.chunk_shape)) {
+    // totally replace chunk
+
+    // optimization: we are completely replacing the chunk, so no need 
+    // to access the exisiting chunk data
+    if (_isscalar(value)) {
+      cdata = new this.TypedArray(this.chunk_size).fill(value);
+    }
+    // Otherwise data just contiguous TypedArray
+    cdata = value.data;
+  } else {
+    // partially replace the contents of this chunk
+
+    let chunk;
+    const strides = get_strides(this.chunk_shape);
+    try {
+      // decode previous chunk from store
+      chunk = await this.get_chunk(chunk_coords);
+      chunk.strides = strides;
+    } catch (err) {
+      if (!(err instanceof KeyError)) {
+        throw err;
+      }
+      chunk = {
+        data: this.TypedArray(this.chunk_size),
+        shape: this.chunk_shape,
+        strides,
+      };
+      if (typeof this.fill_value === 'number') {
+        chunk.data.fill(this.fill_value);
+      }
+    }
+
+    // Modify chunk data
+    if (typeof value === 'number') {
+      _set_arr_scalar(chunk, chunk_selection, value);
+    } else {
+      _set_arr_direct(chunk, chunk_selection, value, out_selection);
+    }
+
+    cdata = chunk.data;
+  }
+  // encode chunk
+  const encoded_chunk_data = await this._encode_chunk(cdata);
+  // store 
+  await this.store.set(chunk_key, encoded_chunk_data);
+}
+
+function _isscalar(value) {
+  // TODO: better check ?
+  return typeof value === 'number';
+}
+
+// compute strides for 'C' ordered ndarray from shape
+function get_strides(shape) {
+  const ndim = shape.length;
+  const strides = Array(ndim);
+  let step = 1; // init step
+  for (let i = ndim - 1; i >= 0; i--) {
+    strides[i] = step;
+    step *= shape[i];
+  }
+  return strides;
+}
+
+// PYTHON UTILS
+
+// python-like slices
+export function slice(start, stop, step = null) {
+  assert(start !== undefined, 'Invalid slice. First argumnet must not be undefined.');
+  if (stop === undefined) {
+    stop = start;
+    start = null;
+  }
+  const indices = size => {
+    let [start_ix, end_ix] = [start ?? 0, stop ?? size];
+    if (start_ix < 0) start_ix = size + start_ix;
+    if (end_ix < 0) end_ix = size + end_ix;
+    return [start_ix, end_ix, step ?? 1];
+  };
+  return { start, stop, step, indices, _slice: true };
+}
+
+// python-like range generator
+function *range(start, stop, step = 1) {
+  if (stop == undefined) {
+    stop = start;
+    start = 0;
+  }
+  for (let i = start; i < stop; i += step) {
+    yield i;
+  }
+}
+
+// python-like itertools.product generator
+function* product(...iterables) {
+  if (iterables.length === 0) { return; }
+  // make a list of iterators from the iterables
+  const iterators = iterables.map(it => it[Symbol.iterator]());
+  const results = iterators.map(it => it.next());
+  if (results.some(r => r.done)) {
+    throw new Error('Input contains an empty iterator.');
+  }
+  for (let i = 0;;) {
+    if (results[i].done) {
+      // reset the current iterator
+      iterators[i] = iterables[i][Symbol.iterator]();
+      results[i] = iterators[i].next();
+      // advance, and exit if we've reached the end
+      if (++i >= iterators.length) { return; }
+    } else {
+      yield results.map(({ value }) => value);
+      i = 0;
+    }
+    results[i] = iterators[i].next();
+  }
+}
+
+function _is_null_slice(s) {
+  const { start, stop, step, _slice } = s;
+  return _slice && [start, stop, step].every(i => i === null);
+}
+
+function _is_total_slice(item, shape) {
+  // assume shape is normalized
+  if (item === null) return true;
+  if (_is_null_slice(item)) return true;
+  if (item._slice) item = [item];
+  if (Array.isArray(item)) {
+    return item.every((s, i) => {
+      if (!s._slice) return false; // not a slice
+      const full_slice = (s.stop - s.start === shape[i]) && (s.step === 1 || s.step === null);
+      return _is_null_slice(s) || full_slice;
+    });
+  } else {
+    throw TypeError(`Expected slice or Array of slices, found: ${JSON.stringify(item)}`);
+  }
+}
+
+function _err_too_many_indices(selection, shape) {
+  throw new IndexError(
+    `too many indicies for array; expected ${shape.length}, got ${selection.length}`,
+  );
+}
+
+function _err_boundscheck(dim_len) {
+  throw new IndexError(
+    `index out of bounds for dimension with length ${dim_len}`,
+  );
+}
+
+function _err_negative_step() {
+  throw new IndexError('only slices with step >= 1 are supported');
+}
+
+
+function _check_selection_length(selection, shape) {
+  if (selection.length > shape.length) {
+    _err_too_many_indices(selection, shape);
+  }
+}
+
+// INDEXING 
+
+function _normalize_integer_selection(dim_sel, dim_len) {
+  // normalize type to int
+  dim_sel = Math.trunc(dim_sel);
+  // handle wraparound
+  if (dim_sel < 0) {
+    dim_sel = dim_len + dim_sel;
+  }
+  // handle out of bounds
+  if (dim_sel >= dim_len || dim_sel < 0) {
+    _err_boundscheck(dim_len);
+  }
+  return dim_sel;
+}
+
+
+class _IntDimIndexer {
+  constructor({ dim_sel, dim_len, dim_chunk_len }) {
+    // normalize
+    dim_sel = _normalize_integer_selection(dim_sel, dim_len);
+    // store properties
+    this.dim_sel = dim_sel;
+    this.dim_len = dim_len;
+    this.dim_chunk_len = dim_chunk_len;
+    this.nitems = 1;
+  }
+
+  *[Symbol.iterator]() {
+    const dim_chunk_ix = Math.floor(this.dim_sel / this.dim_chunk_len);
+    const dim_offset = dim_chunk_ix * this.dim_chunk_len;
+    const dim_chunk_sel = this.dim_sel - dim_offset;
+    const dim_out_sel = null;
+    // ChunkDimProjection
+    yield { dim_chunk_ix, dim_chunk_sel, dim_out_sel };
+  }
+}
+
+class _SliceDimIndexer {
+
+  constructor({ dim_sel, dim_len, dim_chunk_len }) {
+    // normalize
+    const [start, stop, step] = dim_sel.indices(dim_len);
+    this.start = start;
+    this.stop = stop;
+    this.step = step;
+    if (this.step < 1) _err_negative_step();
+    // store properties
+    this.dim_len = dim_len;
+    this.dim_chunk_len = dim_chunk_len;
+    this.nitems = Math.max(0, Math.ceil((this.stop - this.start) / this.step));
+    this.nchunks = Math.ceil(this.dim_len / this.dim_chunk_len);
+  }
+
+  *[Symbol.iterator]() {
+    // figure out the range of chunks we need to visit
+    const dim_chunk_ix_from = Math.floor(this.start / this.dim_chunk_len);
+    const dim_chunk_ix_to = Math.ceil(this.stop / this.dim_chunk_len);
+    for (const dim_chunk_ix of range(dim_chunk_ix_from, dim_chunk_ix_to)) {
+      // compute offsets for chunk within overall array
+      const dim_offset = dim_chunk_ix * this.dim_chunk_len;
+      const dim_limit = Math.min(this.dim_len, (dim_chunk_ix + 1) * this.dim_chunk_len);
+      // determine chunk length, accounting for trailing chunk
+      const dim_chunk_len = dim_limit - dim_offset;
+
+      let dim_out_offset = 0;
+      let dim_chunk_sel_start = 0;
+      if (this.start < dim_offset) {
+        // selection start before current chunk
+        const remainder = (dim_offset - this.start) % this.step;
+        if (remainder) dim_chunk_sel_start += this.step - remainder;
+        // compute number of previous items, provides offset into output array
+        dim_out_offset = Math.ceil((dim_offset - this.start) / this.step);
+      } else {
+        // selection starts within current chunk
+        dim_chunk_sel_start = this.start - dim_offset;
+      }
+      // selection starts within current chunk if true, 
+      // otherwise selection ends after current chunk.
+      const dim_chunk_sel_stop = this.stop > dim_limit ? dim_chunk_len : this.stop - dim_offset;
+
+      const dim_chunk_sel = slice(dim_chunk_sel_start, dim_chunk_sel_stop, this.step);
+      const dim_chunk_nitems = Math.ceil((dim_chunk_sel_stop - dim_chunk_sel_start) / this.step);
+      const dim_out_sel = slice(dim_out_offset, dim_out_offset + dim_chunk_nitems, 1);
+      // ChunkDimProjection      
+      yield { dim_chunk_ix, dim_chunk_sel, dim_out_sel };
+    }
+  }
+}
+
+function _normalize_selection(selection, shape) {
+  if (selection === null) {
+    // eslint-disable-next-line no-unused-vars
+    selection = shape.map(_ => slice(null));
+  } else if (Array.isArray(selection)) {
+    selection = selection.map(s => s ?? slice(null));
+  }
+  _check_selection_length(selection, shape);
+  return selection;
+}
+
+
+class _BasicIndexer {
+  constructor({ selection, shape, chunk_shape }) {
+    // handle normalize selection 
+    selection = _normalize_selection(selection, shape);
+    
+    // setup per-dimension indexers
+    this.dim_indexers = selection.map((dim_sel, i) => {
+      const config = { dim_sel, dim_len: shape[i], dim_chunk_len: chunk_shape[i] };
+      if (typeof dim_sel === 'number') {
+        return new _IntDimIndexer(config);
+      } else if (dim_sel._slice) {
+        return new _SliceDimIndexer(config);
+      }
+      throw IndexError(
+        `unsupported selection item for basic indexing; 
+        expected integer or slice, got ${JSON.stringify(dim_sel)}`,
+      );
+    });
+    this.shape = this.dim_indexers
+      .filter(ixr => !(ixr instanceof _IntDimIndexer))
+      .map(sixr => sixr.nitems);
+    
+  }
+  *[Symbol.iterator]() {
+    for (const dim_projections of product(...this.dim_indexers)) {
+      const chunk_coords = dim_projections.map(p => p.dim_chunk_ix);
+      const chunk_selection = dim_projections.map(p => p.dim_chunk_sel);
+      const out_selection = dim_projections.map(p => p.dim_out_sel);
+      yield { chunk_coords, chunk_selection, out_selection };
+    }
+  }
+}

--- a/src/indexing.js
+++ b/src/indexing.js
@@ -311,7 +311,7 @@ class _IntDimIndexer {
     const dim_chunk_ix = Math.floor(this.dim_sel / this.dim_chunk_len);
     const dim_offset = dim_chunk_ix * this.dim_chunk_len;
     const dim_chunk_sel = this.dim_sel - dim_offset;
-    const dim_out_sel = this.dim_sel;
+    const dim_out_sel = null;
     // ChunkDimProjection
     yield { dim_chunk_ix, dim_chunk_sel, dim_out_sel };
   }

--- a/src/indexing.js
+++ b/src/indexing.js
@@ -36,7 +36,7 @@ async function _get_selection(indexer) {
   const out = {
     data: new this.TypedArray(outsize),
     shape: indexer.shape,
-    strides: get_strides(indexer.shape),
+    stride: get_strides(indexer.shape),
   };
   // iterator over chunks
   for (const { chunk_coords, chunk_selection, out_selection } of indexer) {
@@ -52,7 +52,7 @@ async function _chunk_getitem(chunk_coords, chunk_selection, out, out_selection)
   try {
     // decode chunk
     const chunk = await this.get_chunk(chunk_coords);
-    chunk.strides = get_strides(chunk.shape);
+    chunk.stride = get_strides(chunk.shape);
     // store selected data in output
     set(out, out_selection, chunk, chunk_selection);
   } catch (err) {
@@ -81,12 +81,12 @@ async function _set_selection(indexer, value) {
   }
 
   // If input is missing strides, compute from array shape
-  if (!Array.isArray(value.strides)) {
+  if (!Array.isArray(value.stride)) {
     // Don't mutate input object
     value = {
       data: value.data,
       shape: value.shape,
-      strides: get_strides(value.shape),
+      stride: get_strides(value.shape),
     };
   }
   // iterate over chunks in range
@@ -115,11 +115,11 @@ async function _chunk_setitem(chunk_coords, chunk_selection, value, out_selectio
     // partially replace the contents of this chunk
 
     let chunk;
-    const strides = get_strides(this.chunk_shape);
+    const stride = get_strides(this.chunk_shape);
     try {
       // decode previous chunk from store
       chunk = await this.get_chunk(chunk_coords);
-      chunk.strides = strides;
+      chunk.stride = stride;
     } catch (err) {
       if (!(err instanceof KeyError)) {
         throw err;
@@ -127,7 +127,7 @@ async function _chunk_setitem(chunk_coords, chunk_selection, value, out_selectio
       chunk = {
         data: this.TypedArray(this.chunk_shape.reduce((a, b) => a * b, 1)),
         shape: this.chunk_shape,
-        strides,
+        stride,
       };
       if (typeof this.fill_value === 'number') {
         chunk.data.fill(this.fill_value);

--- a/src/ops.js
+++ b/src/ops.js
@@ -1,0 +1,94 @@
+// private utitlites to fill strided output array
+export function set(out, out_selection, value, value_selection) {
+  if (typeof value === 'number') {
+    return set_scalar(out, out_selection, value);
+  }
+  return set_from_chunk(out, out_selection, value, value_selection);
+}
+
+function set_scalar(out, out_selection, value) {
+  const [slice, ...slices] = out_selection;
+  const [stride, ...strides] = out.strides;
+  const [out_len, ...shape] = out.shape;
+  /* eslint-disable no-unused-vars */
+  const [from, _to, step, len] = slice.indices(out_len);
+  /* eslint-enable no-unused-vars */
+  if (slices.length === 1) {
+    if (step === 1 && stride === 1) {
+      out.data.fill(value, from, from + len);
+    } else {
+      for (let i = 0; i < len; i++) {
+        out.data[stride * (from + (step * i))] = value;
+      }
+    }
+    return;
+  }
+  for (let i = 0; i < len; i++) {
+    const data = out.data.subarray(stride * (from + (step * i)));
+    set_scalar({ data, strides, shape }, slices, value);
+  }
+}
+
+function set_from_chunk(out, out_selection, chunk, chunk_selection) {
+  if (chunk_selection.length === 0) {
+    // Case when last chunk dim is squeezed
+    out.data.set(chunk.data.subarray(0, out.data.length));
+    return;
+  }
+  // Get current indicies and strides for both destination and source arrays
+  const [out_slice, ...out_slices] = out_selection;
+  const [chunk_slice, ...chunk_slices] = chunk_selection;
+
+  const [chunk_stride, ...chunk_strides] = chunk.strides;
+  const [chunk_len, ...chunk_shape] = chunk.shape;
+
+  // This source dimension is squeezed
+  if (typeof chunk_slice === 'number') {
+    /*
+    Sets dimension offset for squeezed dimension.
+    Ex. if 0th dimension is squeezed to 2nd index (numpy : arr[2,i])
+        sourceArr[stride[0]* 2 + i] --> sourceArr.subarray(stride[0] * 2)[i] (sourceArr[i] in next call)
+    Thus, subsequent squeezed dims are appended to the source offset.
+    */
+    // Don't update destination offset/slices, just source
+    const chunk_view = {
+      data: chunk.data.subarray(chunk_stride * chunk_slice),
+      shape: chunk_shape, 
+      strides: chunk_strides,
+    };
+    set_from_chunk(out, out_selection, chunk_view, chunk_slices);
+    return;
+  }
+
+  const [out_stride, ...out_strides] = out.strides;
+  const [out_len, ...out_shape] = out.shape;
+
+  /* eslint-disable no-unused-vars */
+  const [from, _to, step, len] = out_slice.indices(out_len); // only need len of out slice since chunk subset
+  const [cfrom, _cto, cstep] = chunk_slice.indices(chunk_len);
+  /* eslint-enable no-unused-vars */
+
+  if (out_slices.length === 0 && chunk_slices.length === 0) {
+    if (step === 1 && out_stride === 1 && cstep === 1 && chunk_stride === 1) {
+      out.data.set(chunk.data.subarray(cfrom, cfrom + len), from);
+    } else {
+      for (let i = 0; i < len; i++) {
+        out.data[out_stride * (from + (step * i))] = chunk.data[chunk_stride * (cfrom + (cstep * i))];
+      }
+    }
+    return;
+  }
+  for (let i = 0; i < len; i++) {
+    const out_view = {
+      data: out.data.subarray(out_stride * (from + (i * step))),
+      shape: out_shape,
+      strides: out_strides,
+    };
+    const chunk_view = {
+      data: chunk.data.subarray(chunk_stride * (cfrom + (i * cstep))),
+      shape: chunk_shape,
+      strides: chunk_strides,
+    };
+    set_from_chunk(out_view, out_slices, chunk_view, chunk_slices);
+  }
+}

--- a/src/ops.js
+++ b/src/ops.js
@@ -79,6 +79,18 @@ function set_from_chunk(out, out_selection, chunk, chunk_selection) {
     return;
   }
 
+  if (out_slice === null) {
+    const out_view = { data: out.data, shape: out_shape, stride: out_strides };
+    set_from_chunk(out_view, out_slices, chunk, chunk_selection);
+    return;
+  }
+
+  if (chunk_slice === null) {
+    const chunk_view = { data: chunk.data, shape: chunk_shape, stride: chunk_strides };
+    set_from_chunk(out, out_selection, chunk_view, chunk_slices);
+    return;
+  }
+
   const [from, to, step] = out_slice.indices(out_len); // only need len of out slice since chunk subset
   const [cfrom, _cto, cstep] = chunk_slice.indices(chunk_len); // eslint-disable-line no-unused-vars
 

--- a/src/ops.js
+++ b/src/ops.js
@@ -14,23 +14,23 @@ function indices_len(start, stop, step) {
 
 function set_scalar(out, out_selection, value) {
   const [slice, ...slices] = out_selection;
-  const [stride, ...strides] = out.strides;
+  const [curr_stride, ...stride] = out.stride;
   const [out_len, ...shape] = out.shape;
   const [from, to, step] = slice.indices(out_len);
   const len = indices_len(from, to, step);
   if (slices.length === 1) {
-    if (step === 1 && stride === 1) {
+    if (step === 1 && curr_stride === 1) {
       out.data.fill(value, from, from + len);
     } else {
       for (let i = 0; i < len; i++) {
-        out.data[stride * (from + (step * i))] = value;
+        out.data[curr_stride * (from + (step * i))] = value;
       }
     }
     return;
   }
   for (let i = 0; i < len; i++) {
-    const data = out.data.subarray(stride * (from + (step * i)));
-    set_scalar({ data, strides, shape }, slices, value);
+    const data = out.data.subarray(curr_stride * (from + (step * i)));
+    set_scalar({ data, stride, shape }, slices, value);
   }
 }
 
@@ -44,7 +44,7 @@ function set_from_chunk(out, out_selection, chunk, chunk_selection) {
   const [out_slice, ...out_slices] = out_selection;
   const [chunk_slice, ...chunk_slices] = chunk_selection;
 
-  const [chunk_stride, ...chunk_strides] = chunk.strides;
+  const [chunk_stride, ...chunk_strides] = chunk.stride;
   const [chunk_len, ...chunk_shape] = chunk.shape;
 
   // This source dimension is squeezed
@@ -59,13 +59,13 @@ function set_from_chunk(out, out_selection, chunk, chunk_selection) {
     const chunk_view = {
       data: chunk.data.subarray(chunk_stride * chunk_slice),
       shape: chunk_shape, 
-      strides: chunk_strides,
+      stride: chunk_strides,
     };
     set_from_chunk(out, out_selection, chunk_view, chunk_slices);
     return;
   }
 
-  const [out_stride, ...out_strides] = out.strides;
+  const [out_stride, ...out_strides] = out.stride;
   const [out_len, ...out_shape] = out.shape;
 
   const [from, to, step] = out_slice.indices(out_len); // only need len of out slice since chunk subset
@@ -86,12 +86,12 @@ function set_from_chunk(out, out_selection, chunk, chunk_selection) {
     const out_view = {
       data: out.data.subarray(out_stride * (from + (i * step))),
       shape: out_shape,
-      strides: out_strides,
+      stride: out_strides,
     };
     const chunk_view = {
       data: chunk.data.subarray(chunk_stride * (cfrom + (i * cstep))),
       shape: chunk_shape,
-      strides: chunk_strides,
+      stride: chunk_strides,
     };
     set_from_chunk(out_view, out_slices, chunk_view, chunk_slices);
   }

--- a/src/ops.js
+++ b/src/ops.js
@@ -74,7 +74,7 @@ function set_from_chunk(out, out_selection, chunk, chunk_selection) {
       data: out.data.subarray(out_stride * out_slice),
       shape: out_shape,
       stride: out_strides,
-    }
+    };
     set_from_chunk(out_view, out_slices, chunk, chunk_selection);
     return;
   }

--- a/src/ops.js
+++ b/src/ops.js
@@ -1,13 +1,11 @@
 // private utitlites to fill strided output array
 export function set(out, out_selection, value, value_selection) {
-  if (typeof value === 'number') {
-    return set_scalar(out, out_selection, value);
-  }
+  if (typeof value === 'number') return set_scalar(out, out_selection, value);
   return set_from_chunk(out, out_selection, value, value_selection);
 }
 
 function indices_len(start, stop, step) {
-  if (step < 0 && stop < start) return Math.floor((start - stop - 1) / (-step) + 1);
+  if (step < 0 && stop < start) return Math.floor((start - stop - 1) / (-step)) + 1;
   if (start < stop) return Math.floor((stop - start - 1) / step) + 1;
   return 0;
 }
@@ -18,7 +16,7 @@ function set_scalar(out, out_selection, value) {
   const [out_len, ...shape] = out.shape;
   const [from, to, step] = slice.indices(out_len);
   const len = indices_len(from, to, step);
-  if (slices.length === 1) {
+  if (slices.length === 0) {
     if (step === 1 && curr_stride === 1) {
       out.data.fill(value, from, from + len);
     } else {

--- a/src/ops.js
+++ b/src/ops.js
@@ -51,8 +51,8 @@ function set_from_chunk(out, out_selection, chunk, chunk_selection) {
   const [out_slice, ...out_slices] = out_selection;
   const [chunk_slice, ...chunk_slices] = chunk_selection;
 
-  const [chunk_stride, ...chunk_strides] = chunk.stride;
-  const [chunk_len, ...chunk_shape] = chunk.shape;
+  const [chunk_stride = 1, ...chunk_strides] = chunk.stride;
+  const [chunk_len = chunk.data.length, ...chunk_shape] = chunk.shape;
 
   if (typeof chunk_slice === 'number') {
     // chunk dimension is squeezed
@@ -65,26 +65,26 @@ function set_from_chunk(out, out_selection, chunk, chunk_selection) {
     return;
   }
 
-  const [out_stride, ...out_strides] = out.stride;
-  const [out_len, ...out_shape] = out.shape;
+  const [out_stride = 1, ...out_strides] = out.stride;
+  const [out_len = out.data.length, ...out_shape] = out.shape;
 
   if (typeof out_slice === 'number') {
-    // chunk dimension is squeezed
+    // out dimension is squeezed
     const out_view = {
       data: out.data.subarray(out_stride * out_slice),
-      shape: out_shape, 
+      shape: out_shape,
       stride: out_strides,
-    };
+    }
     set_from_chunk(out_view, out_slices, chunk, chunk_selection);
     return;
   }
 
   const [from, to, step] = out_slice.indices(out_len); // only need len of out slice since chunk subset
-  const [cfrom, _to, cstep] = chunk_slice.indices(chunk_len); // eslint-disable-line no-unused-vars
+  const [cfrom, _cto, cstep] = chunk_slice.indices(chunk_len); // eslint-disable-line no-unused-vars
 
   const len = indices_len(from, to, step);
   if (out_slices.length === 0 && chunk_slices.length === 0) {
-    if (step === 1 && out_stride === 1 && cstep === 1 && chunk_stride === 1) {
+    if (step === 1 && cstep === 1 && out_stride === 1 && chunk_stride === 1) {
       out.data.set(chunk.data.subarray(cfrom, cfrom + len), from);
     } else {
       for (let i = 0; i < len; i++) {

--- a/test/common.js
+++ b/test/common.js
@@ -305,14 +305,15 @@ export function run_test_suite({ name, setup }) {
       expected.fill(42);
       t.deepEqual((await a.get(null)).data, expected, 'should entirely fill with 42.');
 
-      let arr = { data: new Int32Array([...Array(10).keys()]), shape: [1, 10] };
+      let arr = { data: new Int32Array([...Array(10).keys()]), shape: [10] };
       expected.set(arr.data, 0, arr.data.length);
       await a.set([0, null], arr);
-      t.deepEqual((await a.get(null)).data, expected, 'should fill first row with arrange.');
+      res = await a.get(null);
+      t.deepEqual(res.data, expected, 'should fill first row with arange.');
 
       arr = { data: new Int32Array([...Array(50).keys()]), shape: [5, 10] };
       await a.set(null, arr);
-      t.deepEqual((await a.get(null)).data, arr.data, 'should fill entire with arrange.');
+      t.deepEqual((await a.get(null)).data, arr.data, 'should fill entire with arange.');
 
 
       // Read array slices

--- a/test/common.js
+++ b/test/common.js
@@ -1,6 +1,6 @@
 import { test } from 'zora';
 
-import { create_hierarchy, registry } from '../zarrita.js';
+import { create_hierarchy, registry } from '../src/index.js';
 // add dynamic codec to registry
 registry.set('gzip', async () => (await import('numcodecs/gzip')).default);
 

--- a/test/common.js
+++ b/test/common.js
@@ -1,6 +1,6 @@
 import { test } from 'zora';
 
-import { create_hierarchy, registry } from '../src/index.js';
+import { create_hierarchy, registry, slice } from '../src/index.js';
 // add dynamic codec to registry
 registry.set('gzip', async () => (await import('numcodecs/gzip')).default);
 
@@ -65,7 +65,7 @@ export function run_test_suite({ name, setup }) {
     await t.test('Create an array with no compressor', async t => {
       const a = await h.create_array('/deep/thought', {
         shape: 7500000,
-        dtype: '>f2',
+        dtype: '>f8',
         chunk_shape: 42,
         compressor: null,
       });
@@ -74,7 +74,7 @@ export function run_test_suite({ name, setup }) {
       t.equal(a.name, 'thought', 'should have name thought.');
       t.equal(a.ndim, 1, 'should have ndim of 1`.');
       t.deepEqual(a.shape, [7500000], 'should have shape: [7500000].');
-      t.equal(a.dtype, '>f2', 'should have dtype >f2.');
+      t.equal(a.dtype, '>f8', 'should have dtype >f8.');
       t.equal(a.chunk_shape, [42], 'should have chunk_shape [42].');
       t.equal(a.compressor, null, 'should have null compressor.');
       t.equal(a.attrs, {}, 'should have empty attrs.');
@@ -83,7 +83,7 @@ export function run_test_suite({ name, setup }) {
     await t.test('Verify /deep/thought metadata', async t => {
       const m = await get_json('meta/root/deep/thought.array.json');
       t.equal(m.shape, [7500000], 'should have shape [7500000].');
-      t.equal(m.data_type, '>f2', 'should have dtype >f2.');
+      t.equal(m.data_type, '>f8', 'should have dtype >f8.');
       t.equal(m.chunk_grid.type, 'regular', 'chunk_grid should be regular.');
       t.equal(m.chunk_grid.chunk_shape, [42], 'should have chunk_shape [42].');
       t.equal(m.chunk_grid.separator, '/', 'should have chunk separator of "/".');
@@ -282,5 +282,99 @@ export function run_test_suite({ name, setup }) {
       ];
       t.equal(keys, root_keys);
     });
+
+    await t.test('Read and write array data', async t => {
+      const a = await h.get('/arthur/dent');
+      let res = await a.get([null, null]);
+      t.equal(res.shape, [5, 10], 'should have full shape [5, 10].');
+      t.deepEqual(res.data, new Int32Array(50), 'should be empty typed array (size = 50).');
+
+      res = await a.get(null);
+      t.equal(res.shape, [5, 10], 'should have full shape [5, 10].');
+      t.deepEqual(res.data, new Int32Array(50), 'should be empty typed array (size = 50).');
+
+      await a.set([0, null], 42);
+      t.deepEqual((await a.get(null)).data, new Int32Array(50).fill(42, 0, 10), 'should fill 42 in first row.');
+      
+      const expected = new Int32Array(50).fill(42, 0, 10);
+      [10, 20, 30, 40].forEach(i => expected[i] = 42);
+      await a.set([null, 0], 42);
+      t.deepEqual((await a.get(null)).data, expected, 'should fill 42 in first row & col.');
+
+      await a.set(null, 42);
+      expected.fill(42);
+      t.deepEqual((await a.get(null)).data, expected, 'should entirely fill with 42.');
+
+      let arr = { data: new Int32Array([...Array(10).keys()]), shape: [1, 10] };
+      expected.set(arr.data, 0, arr.data.length);
+      await a.set([0, null], arr);
+      t.deepEqual((await a.get(null)).data, expected, 'should fill first row with arrange.');
+
+      arr = { data: new Int32Array([...Array(50).keys()]), shape: [5, 10] };
+      await a.set(null, arr);
+      t.deepEqual((await a.get(null)).data, arr.data, 'should fill entire with arrange.');
+
+
+      // Read array slices
+      res = await a.get([null, 0]);
+      t.equal(res.shape, [5], 'should be vertical column');
+      t.deepEqual(res.data, new Int32Array([0, 10, 20, 30, 40]), 'should be first column.');
+
+      res = await a.get([null, 1]);
+      t.equal(res.shape, [5], 'should be vertical column');
+      t.deepEqual(res.data, new Int32Array([1, 11, 21, 31, 41]), 'should be second column.');
+
+      res = await a.get([0, null]);
+      t.equal(res.shape, [10], 'should be first row.');
+      t.deepEqual(res.data, new Int32Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]), 'should be first row.');
+
+      res = await a.get([1, null]);
+      t.equal(res.shape, [10], 'should be second row.');
+      t.deepEqual(res.data, new Int32Array([10, 11, 12, 13, 14, 15, 16, 17, 18, 19]), 'should be second row.');
+
+      res = await a.get([null, slice(0, 7)]);
+      t.equal(res.shape, [5, 7]);
+      t.deepEqual(res.data, new Int32Array([
+         0,  1,  2,  3,  4,  5,  6,
+        10, 11, 12, 13, 14, 15, 16,
+        20, 21, 22, 23, 24, 25, 26,
+        30, 31, 32, 33, 34, 35, 36,
+        40, 41, 42, 43, 44, 45, 46,
+      ]));
+
+      res = await a.get([slice(0, 3), null]);
+      t.equal(res.shape, [3, 10]);
+      t.deepEqual(res.data, new Int32Array([
+         0,  1,  2,  3,  4,  5,  6,  7,  8,  9,
+        10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+        20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
+      ]));
+
+      res = await a.get([slice(0, 3), slice(0, 7)]);
+      t.equal(res.shape, [3, 7]);
+      t.deepEqual(res.data, new Int32Array([
+         0,  1,  2,  3,  4,  5,  6,
+        10, 11, 12, 13, 14, 15, 16,
+        20, 21, 22, 23, 24, 25, 26,
+      ]));
+
+      res = await a.get([slice(1, 4), slice(2, 7)]);
+      t.equal(res.shape, [3, 5]);
+      t.deepEqual(res.data, new Int32Array([
+        12, 13, 14, 15, 16,
+        22, 23, 24, 25, 26,
+        32, 33, 34, 35, 36,
+      ]));
+
+      const b = await h.get('deep/thought');
+      res = await b.get([slice(10)]);
+      t.equal(res.shape, [10]);
+      t.deepEqual(res.data, new Float64Array(10));
+
+      expected.fill(1, 0, 5);
+      await b.set([slice(5)], 1);
+      t.deepEqual((await b.get([slice(10)])).data, new Float64Array(10).fill(1, 0, 5));
+    });
+
   });
 } 

--- a/test/fsstore.test.js
+++ b/test/fsstore.test.js
@@ -1,7 +1,7 @@
 import fsp from 'fs/promises';
 import fs from 'fs';
 
-import FileSystemStore from '../fsstore.js';
+import FileSystemStore from '../src/fsstore.js';
 import { run_test_suite } from './common.js';
 
 const config = {

--- a/test/memstore.test.js
+++ b/test/memstore.test.js
@@ -1,4 +1,4 @@
-import { MemoryStore } from '../zarrita.js';
+import { MemoryStore } from '../src/index.js';
 import { run_test_suite } from './common.js';
 
 const config = {


### PR DESCRIPTION
Mutates the `ZarrArray` prototype to add indexing/slicing + `get`/`set` methods for the array. Thus, the library is totally tree-shakeable:

### Core module is ~3.4kb (gzipped + minified)
```javascript
import { get_hierarchy } from 'zarrita/core'; // minimal hierarchy code + get_chunk by key for arrays
const h = await get_hierarchy(store);
const a = await h.get('/arr');
a.get(null) // throws NotImplementedError
const chunk_coords = [0, 0];
a.get_chunk(chunk_coords) // returns Promise for decoded chunk
```

### Top-level import adds ~2.4kb (gzipped + minified) to core module and adds indexing/slicing full zarr array
```javascript
import { get_hierarchy, slice } from 'zarrita';
const h = await get_hierarchy(store);
const a = await h.get('/arr');
a.get([slice(null), slice(null, null, 2)]) // returns promise for array
```