### PR TITLE
Move indexing and errors into reuseable modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "files": [
     "zarrita.js",
     "core.js",
-    "fsstore.js"
+    "fsstore.js",
+    "src"
   ],
   "exports": {
     ".": "./zarrita.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zarrita",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A minimal, exploratory implementation of the Zarr version 3.0 core protocol.",
   "main": "zarrita.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test:ci": "npm run lint && npm test | tap-set-exit",
     "lint": "eslint src test --ext .js"
   },
+  "sideEffects": false,
   "files": [
     "zarrita.js",
     "core.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zarrita",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A minimal, exploratory implementation of the Zarr version 3.0 core protocol.",
   "main": "zarrita.js",
   "type": "module",
@@ -25,7 +25,9 @@
   "author": "Trevor Manz",
   "license": "MIT",
   "eslintConfig": {
-    "extends": ["eslint:recommended"],
+    "extends": [
+      "eslint:recommended"
+    ],
     "env": {
       "es6": true,
       "browser": true,
@@ -36,14 +38,34 @@
       "sourceType": "module"
     },
     "rules": {
-      "comma-dangle": ["error", "always-multiline"],
+      "comma-dangle": [
+        "error",
+        "always-multiline"
+      ],
       "no-console": "error",
       "no-cond-assign": "off",
-      "no-fallthrough": ["error", { "commentPattern": "break omitted" }],
+      "no-fallthrough": [
+        "error",
+        {
+          "commentPattern": "break omitted"
+        }
+      ],
       "semi": "error",
-      "quotes": ["error", "single", { "avoidEscape": true }],
+      "quotes": [
+        "error",
+        "single",
+        {
+          "avoidEscape": true
+        }
+      ],
       "prefer-const": "error",
-      "sort-imports": ["error", { "ignoreCase": false, "ignoreDeclarationSort": true }]
+      "sort-imports": [
+        "error",
+        {
+          "ignoreCase": false,
+          "ignoreDeclarationSort": true
+        }
+      ]
     }
   },
   "dependencies": {},

--- a/src/core.js
+++ b/src/core.js
@@ -1,39 +1,4 @@
-export class NotImplementedError extends Error {
-  constructor(msg) {
-    super(msg);
-    this.name = 'NotImplementedError';
-  }
-}
-export class NodeNotFoundError extends Error {
-  constructor(msg) {
-    super(msg);
-    this.name = 'NodeNotFoundError';
-  }
-}
-export class IndexError extends Error {
-  constructor(msg) {
-    super(msg);
-    this.name = 'IndexError';
-  }
-}
-export class KeyError extends Error {
-  constructor(msg) {
-    super(msg);
-    this.name = 'KeyError';
-  }
-}
-export class ZarrAssertionError extends Error {
-  constructor(msg) {
-    super(msg);
-    this.name = 'ZarrAssertionError';
-  }
-}
-
-export function assert(condition, msg = 'Assertion failed') {
-  if (!condition) {
-    throw new ZarrAssertionError(msg);
-  }
-}
+import { KeyError, NodeNotFoundError, NotImplementedError, assert } from './errors.js';
 
 function _json_encode_object(o) {
   const str = JSON.stringify(o, null, 2);

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,37 @@
+export class NotImplementedError extends Error {
+  constructor(msg) {
+    super(msg);
+    this.name = 'NotImplementedError';
+  }
+}
+export class NodeNotFoundError extends Error {
+  constructor(msg) {
+    super(msg);
+    this.name = 'NodeNotFoundError';
+  }
+}
+export class IndexError extends Error {
+  constructor(msg) {
+    super(msg);
+    this.name = 'IndexError';
+  }
+}
+export class KeyError extends Error {
+  constructor(msg) {
+    super(msg);
+    this.name = 'KeyError';
+  }
+}
+
+export class ZarrAssertionError extends Error {
+  constructor(msg) {
+    super(msg);
+    this.name = 'ZarrAssertionError';
+  }
+}
+
+export function assert(condition, msg = 'Assertion failed') {
+  if (!condition) {
+    throw new ZarrAssertionError(msg);
+  }
+}

--- a/src/fsstore.js
+++ b/src/fsstore.js
@@ -1,6 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
-import { KeyError, ListDirResult, Store, assert } from './core.js';
+import { ListDirResult, Store } from './core.js';
+import { KeyError, assert } from './errors.js';
 
 export default class FileSystemStore extends Store {
   constructor(fp) {

--- a/src/indexing.js
+++ b/src/indexing.js
@@ -1,36 +1,8 @@
-import { IndexError, KeyError, ZarrArray, assert } from './core.js';
+import { IndexError, KeyError, assert } from './errors.js';
 import { set } from './ops.js';
 
-// This module mutates the ZarrArray prototype to add chunk indexing and slicing
-
-Object.defineProperties(ZarrArray.prototype, {
-  get: {
-    value(selection) {
-      return this.get_basic_selection(selection);
-    },
-  },
-  get_basic_selection: {
-    value(selection) {
-      const indexer = new _BasicIndexer({ selection, ...this });
-      return _get_selection.call(this, indexer);
-    },
-  },
-  set: {
-    value(selection, value) {
-      return this.set_basic_selection(selection, value);
-    },
-  },
-  set_basic_selection: {
-    value(selection, value) {
-      const indexer = new _BasicIndexer({ selection, ...this });
-      return _set_selection.call(this, indexer, value);
-    },
-  },
-});
-
 // ZarrArray GET
-
-async function _get_selection(indexer) {
+export async function _get_selection(indexer) {
   // setup output array
   const outsize = indexer.shape.reduce((a, b) => a * b, 1);
   const out = {
@@ -65,7 +37,7 @@ async function _chunk_getitem(chunk_coords, chunk_selection, out, out_selection)
   }
 }
 
-async function _set_selection(indexer, value) {
+export async function _set_selection(indexer, value) {
   // We iterate over all chunks which overlap the selection and thus contain data
   // that needs to be replaced. Each chunk is processed in turn, extracting the
   // necessary data from the value array and storing into the chunk array.
@@ -381,7 +353,7 @@ function _normalize_selection(selection, shape) {
 }
 
 
-class _BasicIndexer {
+export class _BasicIndexer {
   constructor({ selection, shape, chunk_shape }) {
     // handle normalize selection 
     selection = _normalize_selection(selection, shape);

--- a/src/zarrita.js
+++ b/src/zarrita.js
@@ -1,2 +1,32 @@
 export * from './core.js';
-export * from './indexing.js';
+export { slice } from './indexing.js';
+
+import { ZarrArray } from './core.js';
+import { _BasicIndexer, _get_selection, _set_selection } from './indexing.js';
+
+// This module mutates the ZarrArray prototype to add chunk indexing and slicing
+
+Object.defineProperties(ZarrArray.prototype, {
+  get: {
+    value(selection) {
+      return this.get_basic_selection(selection);
+    },
+  },
+  get_basic_selection: {
+    value(selection) {
+      const indexer = new _BasicIndexer({ selection, ...this });
+      return _get_selection.call(this, indexer);
+    },
+  },
+  set: {
+    value(selection, value) {
+      return this.set_basic_selection(selection, value);
+    },
+  },
+  set_basic_selection: {
+    value(selection, value) {
+      const indexer = new _BasicIndexer({ selection, ...this });
+      return _set_selection.call(this, indexer, value);
+    },
+  },
+});


### PR DESCRIPTION
Moves the core of indexing into a separate modules so that they can be reused (e.g. in `zarr-lite`).

Also, the logic in `opts.js` logic requires that the `out_shape` not be squeezed. This PR makes it so that the `out` array is initialize to the "unsqueezed" shape and then integer dim selections are only "squeezed" after it is filled.