### PR TITLE
Mark top level exports as having side effects

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,10 @@
     "test:ci": "npm run lint && npm test | tap-set-exit",
     "lint": "eslint src test --ext .js"
   },
-  "sideEffects": false,
+  "sideEffects": [
+    "zarrita.js",
+    "src/zarrita.js"
+  ],
   "files": [
     "zarrita.js",
     "core.js",


### PR DESCRIPTION
Since we mutate the `ZarrArray.prototype` in `src/zarrita.js`, we need to mark this module as having sideEffects and that it shouldn't be tree-shaken.