### PR TITLE
feat: support `b1` boolean, `S` &  `U` string data-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "test": "node ./test/index.test.js",
-    "type-check": "tsc --noEmit"
+    "check": "tsc --noEmit"
   },
   "dependencies": {
     "ndarray": "^1.0.19",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@types/ndarray-ops": "^1.2.1",
     "ndarray": "^1.0.19",
     "ndarray-ops": "^1.2.2",
     "numcodecs": "^0.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,6 @@
 lockfileVersion: 5.3
 
 specifiers:
-  '@types/ndarray-ops': ^1.2.1
   '@types/node': ^16.10.2
   ndarray: ^1.0.19
   ndarray-ops: ^1.2.2
@@ -9,7 +8,6 @@ specifiers:
   zora: ^5.0.0
 
 dependencies:
-  '@types/ndarray-ops': 1.2.1
   ndarray: 1.0.19
   ndarray-ops: 1.2.2
   numcodecs: 0.2.2
@@ -19,16 +17,6 @@ devDependencies:
   zora: 5.0.0
 
 packages:
-
-  /@types/ndarray-ops/1.2.1:
-    resolution: {integrity: sha512-7/YLEgLjdaKL+M9uvajyL0yJOXYOqEL/i7BCnnw2sQSahy1yJjtt60RKw5gAtuD+GHUGMMHcWlUmnPQM7YLJkA==}
-    dependencies:
-      '@types/ndarray': 1.0.10
-    dev: false
-
-  /@types/ndarray/1.0.10:
-    resolution: {integrity: sha512-UMQxmWA9V0hHqMntIItRVVc6sHmut9E4tBIv811EBPucuyMbAG70KgEdrhnEoD5L3BrLTpnWiCSxQA1HnXfXbw==}
-    dev: false
 
   /@types/node/16.10.2:
     resolution: {integrity: sha512-zCclL4/rx+W5SQTzFs9wyvvyCwoK9QtBpratqz2IYJ3O8Umrn0m3nsTv0wQBk9sRGpvUe9CwPDrQFB10f1FIjQ==}

--- a/src/index.js
+++ b/src/index.js
@@ -4,4 +4,5 @@ export * as v3 from './v3.js';
 export { get, set } from './lib/ops.js';
 export { slice } from './lib/util.js';
 export { registry } from './lib/codec-registry.js';
+export { is, is_numeric } from './lib/helpers.js';
 export { ExplicitGroup, Group, ImplicitGroup, ZarrArray } from './lib/hierarchy.js';

--- a/src/lib/custom-arrays.js
+++ b/src/lib/custom-arrays.js
@@ -1,0 +1,38 @@
+// @ts-check
+
+export class BoolArray {
+  /** @param {number | ArrayBuffer} x */
+  constructor(x) {
+    this._bytes = new Uint8Array(/** @type {any} */ (x));
+  }
+
+  get buffer() {
+    return this._bytes.buffer;
+  }
+
+  get length() {
+    return this._bytes.length;
+  }
+
+  /** @param {number} idx */
+  get(idx) {
+    return this._bytes[idx] === 1;
+  }
+
+  /**
+   * @param {number} idx
+   * @param {boolean} value
+   */
+  set(idx, value) {
+    this._bytes[idx] = value ? 1 : 0;
+  }
+
+  /** @param {boolean} value */
+  fill(value) {
+    this._bytes.fill(value ? 1 : 0);
+  }
+
+  array() {
+    return Array.from(this._bytes).map((b) => b === 1);
+  }
+}

--- a/src/lib/custom-arrays.js
+++ b/src/lib/custom-arrays.js
@@ -85,7 +85,7 @@ export class StringArray {
       this.bytes * this.chars * idx,
       this.bytes * this.chars,
     );
-    return new TextDecoder().decode(view).replaceAll(/\x00/g, '');
+    return new TextDecoder().decode(view).replace(/\x00/g, '');
   }
 
   /**

--- a/src/lib/custom-arrays.js
+++ b/src/lib/custom-arrays.js
@@ -36,3 +36,61 @@ export class BoolArray {
     return Array.from(this._bytes).map((b) => b === 1);
   }
 }
+
+export class ByteStringArray {
+  bytes = 1;
+
+  /**
+   * @param {number | ArrayBuffer} x
+   * @param {number} chars
+   */
+  constructor(x, chars) {
+    this.chars = chars;
+    if (typeof x === 'number') {
+      this.buffer = new ArrayBuffer(this.bytes * x * chars);
+    } else {
+      this.buffer = x;
+    }
+  }
+
+  get length() {
+    return this.buffer.byteLength / (this.bytes * this.chars);
+  }
+
+  /** @param {number} idx */
+  get(idx) {
+    const view = new DataView(
+      this.buffer,
+      this.bytes * this.chars * idx,
+      this.bytes * this.chars,
+    );
+    return new TextDecoder().decode(view).replaceAll(/\x00/g, '');
+  }
+
+  /**
+   * @param {number} idx
+   * @param {string} value
+   */
+  set(idx, value) {
+    const encoded = new TextEncoder().encode(value);
+    if (encoded.length > this.bytes * this.chars) {
+      throw new Error(`UTF-8 encoded string too large: ${value}`);
+    }
+    const view = new DataView(
+      this.buffer,
+      this.bytes * this.chars * idx,
+      this.bytes * this.chars,
+    );
+    for (let i = 0; i < this.bytes * this.chars; i++) {
+      view.setUint8(i, encoded[i] ?? 0);
+    }
+  }
+
+  array() {
+    return Array.from({ length: this.length }).map((_, idx) => this.get(idx));
+  }
+}
+
+export class UnicodeStringArray extends ByteStringArray {
+  bytes = 4;
+}

--- a/src/lib/get.js
+++ b/src/lib/get.js
@@ -33,11 +33,11 @@ export function register(setter) {
  * @template {DataType} Dtype
  * @param {import('../types').TypedArray<Dtype>} arr
  * @param {number} idx
- * @returns {import('../types').Scalar<Dtype>} 
+ * @returns {import('../types').Scalar<Dtype>}
  */
 const get_value = (arr, idx) => {
-	return '_bytes' in arr ? arr.get(idx) : arr[idx];
-}
+  return '_bytes' in arr ? arr.get(idx) : arr[idx];
+};
 
 /**
  * @template {DataType} Dtype

--- a/src/lib/get.js
+++ b/src/lib/get.js
@@ -31,6 +31,16 @@ export function register(setter) {
 
 /**
  * @template {DataType} Dtype
+ * @param {import('../types').TypedArray<Dtype>} arr
+ * @param {number} idx
+ * @returns {import('../types').Scalar<Dtype>} 
+ */
+const get_value = (arr, idx) => {
+	return '_bytes' in arr ? arr.get(idx) : arr[idx];
+}
+
+/**
+ * @template {DataType} Dtype
  * @template {import('../types').NdArrayLike<Dtype>} NdArray
  * @template {ArraySelection} Sel
  *
@@ -74,5 +84,5 @@ async function get(setter, arr, selection, opts) {
   await queue.onIdle();
 
   // If the final out shape is empty, we just return a scalar.
-  return indexer.shape.length === 0 ? out.data[0] : out;
+  return indexer.shape.length === 0 ? get_value(out.data, 0) : out;
 }

--- a/src/lib/get.js
+++ b/src/lib/get.js
@@ -36,7 +36,7 @@ export function register(setter) {
  * @returns {import('../types').Scalar<Dtype>}
  */
 const get_value = (arr, idx) => {
-  return '_bytes' in arr ? arr.get(idx) : arr[idx];
+  return 'get' in arr ? arr.get(idx) : arr[idx];
 };
 
 /**

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -4,7 +4,7 @@
 /** @typedef {import('../types').Store} Store */
 
 /**
- * @template {DataType | keyof DataTypeMapping} Str
+ * @template {DataType | keyof DataTypeMapping | `U${number}` | `S${number}`} Str
  * @template {DataType} D
  * @template {Store} S
  *

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -1,0 +1,28 @@
+// @ts-check
+/** @typedef {import('../types').DataType} DataType */
+/** @typedef {import('../types').DataTypeMapping} DataTypeMapping */
+/** @typedef {import('../types').Store} Store */
+
+/**
+ * @template {DataType | keyof DataTypeMapping} Str
+ * @template {DataType} D
+ * @template {Store} S
+ *
+ * @param {import('./hierarchy').ZarrArray<D, S>} arr
+ * @param {Str} str
+ * @returns {arr is import('./hierarchy').ZarrArray<Extract<Str | `${'<' | '>' | '|'}${Str}`, D>, S>}
+ */
+export const is = (arr, str) => {
+  // Caution! this is very sensitive to the data-type strings!
+  return arr.dtype === /** @type {DataType} */ (str) || arr.dtype.slice(1) === str;
+};
+
+/**
+ * @template {DataType} Dtype
+ * @template {Store} S
+ * @param {import('./hierarchy').ZarrArray<Dtype, S>} arr
+ * @returns {arr is import('./hierarchy').ZarrArray<Exclude<Dtype, '|b1'>, S>}
+ */
+export const is_numeric = (arr) => {
+  return arr.dtype !== '|b1';
+};

--- a/src/lib/helpers.js
+++ b/src/lib/helpers.js
@@ -21,8 +21,8 @@ export const is = (arr, str) => {
  * @template {DataType} Dtype
  * @template {Store} S
  * @param {import('./hierarchy').ZarrArray<Dtype, S>} arr
- * @returns {arr is import('./hierarchy').ZarrArray<Exclude<Dtype, '|b1'>, S>}
+ * @returns {arr is import('./hierarchy').ZarrArray<Exclude<Dtype, import('../types').StringDataType | '|b1'>, S>}
  */
 export const is_numeric = (arr) => {
-  return arr.dtype !== '|b1';
+  return (arr.dtype !== '|b1' && !arr.dtype.includes('U') && !arr.dtype.includes('S'));
 };

--- a/src/lib/hierarchy.js
+++ b/src/lib/hierarchy.js
@@ -6,7 +6,9 @@ import { byte_swap_inplace, parse_dtype, should_byte_swap } from './util.js';
 export class Node {
   /** @param {{ store: Store, path: string }} props */
   constructor({ store, path }) {
+    /** @readonly */
     this.store = store;
+    /** @readonly */
     this.path = path;
   }
 
@@ -24,6 +26,7 @@ export class Group extends Node {
   /** @param {{ store: Store, path: string, owner: Hierarchy }} props */
   constructor(props) {
     super(props);
+    /** @readonly */
     this.owner = props.owner;
   }
 
@@ -145,11 +148,17 @@ export class ZarrArray extends Node {
   /** @param {import('../types').ArrayAttributes<Dtype, Store>} props */
   constructor(props) {
     super(props);
+    /** @readonly */
     this.shape = props.shape;
+    /** @readonly */
     this.dtype = props.dtype;
+    /** @readonly */
     this.chunk_shape = props.chunk_shape;
+    /** @readonly */
     this.compressor = props.compressor;
+    /** @readonly */
     this.fill_value = props.fill_value;
+    /** @readonly */
     this.chunk_key = props.chunk_key;
     this._attrs = props.attrs;
   }

--- a/src/lib/ops.js
+++ b/src/lib/ops.js
@@ -5,7 +5,9 @@ import { register as registerSet } from './set.js';
 import { BoolArray } from './custom-arrays.js';
 
 /** @typedef {import('../types').Indices} Indices */
-/** @typedef {import('../types').DataType} DataType*/
+/** @typedef {import('../types').DataType} DataType */
+/** @typedef {import('../types').StringDataType} StringDataType */
+
 /**
  * @template {DataType} Dtype
  * @typedef {{ stride: number[] } & import('../types').NdArrayLike<Dtype>} NdArray
@@ -47,7 +49,7 @@ const cast_scalar = (arr, value) => {
 };
 
 /**
- * @template {DataType} Dtype
+ * @template {Exclude<DataType, StringDataType>} Dtype
  * @type {import('../types').Setter<Dtype, NdArray<Dtype> | Omit<NdArray<Dtype>, 'stride'>>}
  */
 const setter = {
@@ -102,7 +104,7 @@ function indices_len(start, stop, step) {
 }
 
 /**
- * @template {Exclude<DataType, '|b1'>} Dtype
+ * @template {Exclude<DataType, '|b1' | StringDataType>} Dtype
  * @param {Pick<NdArray<Dtype>, 'data' | 'stride'>} out
  * @param {(number | Indices)[]} out_selection
  * @param {import('../types').Scalar<Dtype>} value
@@ -146,7 +148,7 @@ function set_scalar(out, out_selection, value) {
 }
 
 /**
- * @template {Exclude<DataType, '|b1'>} Dtype
+ * @template {Exclude<DataType, '|b1' | StringDataType>} Dtype
  * @param {Pick<NdArray<Dtype>, 'data' | 'stride'>} out
  * @param {(number | Indices)[]} out_selection
  * @param {Pick<NdArray<Dtype>, 'data' | 'stride'>} chunk

--- a/src/lib/ops.js
+++ b/src/lib/ops.js
@@ -2,6 +2,8 @@
 import { register as registerGet } from './get.js';
 import { register as registerSet } from './set.js';
 
+import { BoolArray } from './custom-arrays.js';
+
 /** @typedef {import('../types').Indices} Indices */
 /** @typedef {import('../types').DataType} DataType*/
 /**
@@ -12,6 +14,37 @@ import { register as registerSet } from './set.js';
  * @template {DataType} Dtype
  * @typedef {import('../types').TypedArray<Dtype>} TypedArray
  */
+/**
+ * @template {DataType} Dtype
+ * @typedef {import('../types').Scalar<Dtype>} Scalar
+ */
+
+/**
+ * Extracts underyling TypedArray to make filling setter functions compatible with
+ * higher-level arrays (e.g. BoolArray).
+ *
+ * @template {DataType} Dtype
+ * @param {NdArray<Dtype> | Omit<NdArray<Dtype>, 'stride'>} arr
+ * @returns {any}
+ */
+const compat = (arr) => {
+  // ensure strides are computed
+  return {
+    data: arr.data instanceof BoolArray ? arr.data._bytes : arr.data,
+    stride: 'stride' in arr ? arr.stride : get_strides(arr.shape),
+  };
+};
+
+/**
+ * @template {DataType} Dtype
+ * @param {{ data: TypedArray<Dtype> }} arr
+ * @param {Scalar<Dtype>} value
+ * @returns {any}
+ */
+const cast_scalar = (arr, value) => {
+  if (arr.data instanceof BoolArray) return value ? 1 : 0;
+  return value;
+};
 
 /**
  * @template {DataType} Dtype
@@ -21,16 +54,16 @@ const setter = {
   prepare: (data, shape) => ({ data, shape, stride: get_strides(shape) }),
   set_scalar(out, out_selection, value) {
     return set_scalar(
-      'stride' in out ? out : { data: out.data, stride: get_strides(out.shape) },
+      compat(out),
       out_selection,
-      value,
+      cast_scalar(out, value),
     );
   },
   set_from_chunk(out, out_selection, chunk, chunk_selection) {
     return set_from_chunk(
-      'stride' in out ? out : { data: out.data, stride: get_strides(out.shape) },
+      compat(out),
       out_selection,
-      'stride' in chunk ? chunk : { data: chunk.data, stride: get_strides(chunk.shape) },
+      compat(chunk),
       chunk_selection,
     );
   },
@@ -69,7 +102,7 @@ function indices_len(start, stop, step) {
 }
 
 /**
- * @template {DataType} Dtype
+ * @template {Exclude<DataType, '|b1'>} Dtype
  * @param {Pick<NdArray<Dtype>, 'data' | 'stride'>} out
  * @param {(number | Indices)[]} out_selection
  * @param {import('../types').Scalar<Dtype>} value
@@ -113,7 +146,7 @@ function set_scalar(out, out_selection, value) {
 }
 
 /**
- * @template {DataType} Dtype
+ * @template {Exclude<DataType, '|b1'>} Dtype
  * @param {Pick<NdArray<Dtype>, 'data' | 'stride'>} out
  * @param {(number | Indices)[]} out_selection
  * @param {Pick<NdArray<Dtype>, 'data' | 'stride'>} chunk

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,3 +1,5 @@
+import { BoolArray } from './custom-arrays.js';
+
 // @ts-check
 const encoder = new TextEncoder();
 /** @param {Record<string, any>} o */
@@ -26,6 +28,7 @@ export const should_byte_swap = (endianness) => LITTLE_ENDIAN_OS && endianness =
 
 /** @param {import('../types').TypedArray<import('../types').DataType>} src */
 export function byte_swap_inplace(src) {
+  if (!('BYTES_PER_ELEMENT' in src)) return;
   const b = src.BYTES_PER_ELEMENT;
   const flipper = new Uint8Array(src.buffer, src.byteOffset, src.length * b);
   const numFlips = b / 2;
@@ -51,6 +54,7 @@ export function ensure_array(maybe_arr) {
 
 /** @type {Set<import('../types').DataType>} */
 const DTYPE_STRS = new Set([
+  '|b1',
   '|i1',
   '|u1',
   '<i2',
@@ -91,6 +95,7 @@ export function normalize_path(path) {
 
 /** @typedef {typeof DTYPES} DataTypeMapping */
 const DTYPES = {
+  b1: BoolArray,
   u1: Uint8Array,
   i1: Int8Array,
   u2: Uint16Array,

--- a/src/storage/fetch.js
+++ b/src/storage/fetch.js
@@ -1,0 +1,64 @@
+// @ts-check
+/** @typedef {import('../types').AsyncStore} Store */
+
+/**
+ * @template {string} Url
+ * @implements {Store}
+ */
+class FetchStore {
+  /** @param {Url} url */
+  constructor(url) {
+    this.url = url.endsWith('/') ? url.slice(0, -1) : url;
+  }
+
+  /** @param {string} key */
+  _path(key) {
+    return `${this.url}/${key.startsWith('/') ? key.slice(1) : key}`;
+  }
+
+  /**
+   * @param {string} key
+   * @returns {Promise<Uint8Array | undefined>}
+   */
+  async get(key) {
+    const path = this._path(key);
+    const res = await fetch(path);
+    if (res.status === 404 || res.status === 403) {
+      return undefined;
+    }
+    const value = await res.arrayBuffer();
+    return new Uint8Array(value);
+  }
+
+  /** @param {string} key */
+  has(key) {
+    return this.get(key).then((res) => res !== undefined);
+  }
+
+  /**
+   * @param {string} _key
+   * @param {Uint8Array} _value
+   * @return {never}
+   */
+  set(_key, _value) {
+    throw new Error('HTTPStore is read-only.');
+  }
+
+  /**
+   * @param {string} _key
+   * @returns {never}
+   */
+  delete(_key) {
+    throw new Error('HTTPStore is read-only.');
+  }
+
+  list_prefix() {
+    return Promise.resolve([]);
+  }
+
+  list_dir() {
+    return Promise.resolve({ contents: [], prefixes: [] });
+  }
+}
+
+export default FetchStore;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -17,17 +17,24 @@ export type DataType =
   | '<f4'
   | '<f8'
   | '>f4'
-  | '>f8';
+  | '>f8'
+  | StringDataType;
 
-export type Numeric = Exclude<DataType, '|b1'>;
+export type StringDataType =
+  | `<U${number}`
+  | `>U${number}`
+  | `|S${number}`;
+
+export type NumericDataType = Exclude<DataType, '|b1' | StringDataType>;
 
 type DataTypeMapping = import('./lib/util').DataTypeMapping;
 
 export type Endianness<Dtype extends DataType> = Dtype extends `${infer E}${infer _}` ? E
   : never;
 
-export type DataTypeMappingKey<Dtype extends DataType> = Dtype extends `${infer _}${infer Key}`
-  ? Key
+export type DataTypeMappingKey<Dtype extends DataType> = Dtype extends
+  `${infer _}${infer T}${infer _}`
+  ? T extends 'U' | 'S' ? T : Dtype extends `${infer _}${infer Key}` ? Key : never
   : never;
 
 export type TypedArrayConstructor<Dtype extends DataType> =
@@ -165,3 +172,4 @@ export type Options = {
 
 export type GetOptions = Options;
 export type SetOptions = Options;
+

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,5 @@
 export type DataType =
+  | '|b1'
   | '|i1'
   | '<i2'
   | '>i2'
@@ -18,19 +19,27 @@ export type DataType =
   | '>f4'
   | '>f8';
 
+export type Numeric = Exclude<DataType, '|b1'>;
+
 type DataTypeMapping = import('./lib/util').DataTypeMapping;
+
 export type Endianness<Dtype extends DataType> = Dtype extends `${infer E}${infer _}` ? E
   : never;
+
 export type DataTypeMappingKey<Dtype extends DataType> = Dtype extends `${infer _}${infer Key}`
   ? Key
   : never;
 
 export type TypedArrayConstructor<Dtype extends DataType> =
   DataTypeMapping[DataTypeMappingKey<Dtype>];
+
 export type TypedArray<Dtype extends DataType> = InstanceType<
   TypedArrayConstructor<Dtype>
 >;
-export type Scalar<Dtype extends DataType> = TypedArray<Dtype>[0];
+
+// Hack to get scalar type since is not defined on any typed arrays.
+export type Scalar<Dtype extends DataType> = Parameters<TypedArray<Dtype>['fill']>[0];
+
 export type NdArrayLike<Dtype extends DataType> = {
   data: TypedArray<Dtype>;
   shape: number[];

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -172,4 +172,3 @@ export type Options = {
 
 export type GetOptions = Options;
 export type SetOptions = Options;
-


### PR DESCRIPTION
Adds `BoolArray`, `UinicodeStringArray` and `ByteStringArray` data classes. These interfaces  adhere to the `generic` array datatype supported by `ndarray`, and also provide a helper method for reading the data as a simple javascript `Array`.

```typescript
interface GenericArray<T> {
  get(i: number): T;
  set(i: number, value: T): void;
  length: number;
}

interface ZarritaArray<T> extends GenericArray<T> {
  buffer: ArrayBuffer;
  fill(value: T): void;
  array(): Array<T> // collect underlying data into a JavaScript array
}

type BoolArray = ZarritaArray<boolean>;
type StringArray = ZarritaArray<string>; // UnicodeStringArray & ByteStringArray implement this differently.
```

Each class is backed by `DataView` of a linear `ArraryBuffer`; a much more efficient representation of the chunk-level data. I think ideally we could implement an interface that supports `Array.from`, like for TypedArrays, but `.array()` should suffice for now. E.g.

```typescript
z = await h.get_array('/path'); // ZarrArray<'|b1', FSStore>
const arr = await z.get_chunk([0,0]); // { data: BoolArray,  shape: number[] }
const data = Array.from(arr.data); // boolean[]
```