### PR TITLE
Use conditional types to allow readonly store implementations

### DIFF
--- a/src/lib/hierarchy.ts
+++ b/src/lib/hierarchy.ts
@@ -6,6 +6,7 @@ import type {
 	Attrs,
 	DataType,
 	Hierarchy,
+	ReadableStore,
 	Scalar,
 	Store,
 	TypedArray,
@@ -13,7 +14,7 @@ import type {
 } from "../types";
 import type { Codec } from "numcodecs";
 
-export class Node<S extends Store, Path extends AbsolutePath> {
+export class Node<S extends Store | ReadableStore, Path extends AbsolutePath> {
 	constructor(public readonly store: S, public readonly path: Path) {}
 
 	get name() {
@@ -22,7 +23,7 @@ export class Node<S extends Store, Path extends AbsolutePath> {
 }
 
 export class Group<
-	S extends Store,
+	S extends Store | ReadableStore,
 	H extends Hierarchy<S>,
 	P extends AbsolutePath = AbsolutePath,
 > extends Node<S, P> {
@@ -85,7 +86,7 @@ export class Group<
 
 interface ExplicitGroupProps<
 	P extends AbsolutePath,
-	S extends Store,
+	S extends Store | ReadableStore,
 	H extends Hierarchy<S>,
 > {
 	store: S;
@@ -95,7 +96,7 @@ interface ExplicitGroupProps<
 }
 
 export class ExplicitGroup<
-	S extends Store,
+	S extends Store | ReadableStore,
 	H extends Hierarchy<S>,
 	P extends AbsolutePath = AbsolutePath,
 > extends Group<S, H, P> {
@@ -118,7 +119,7 @@ export class ExplicitGroup<
 }
 
 export class ImplicitGroup<
-	S extends Store,
+	S extends Store | ReadableStore,
 	H extends Hierarchy<S>,
 	P extends AbsolutePath = AbsolutePath,
 > extends Group<S, H, P> {}
@@ -126,7 +127,7 @@ export class ImplicitGroup<
 export interface ZarrArrayProps<
 	P extends AbsolutePath,
 	D extends DataType,
-	S extends Store,
+	S extends ReadableStore,
 > {
 	store: S;
 	shape: number[];
@@ -141,7 +142,7 @@ export interface ZarrArrayProps<
 
 export class ZarrArray<
 	D extends DataType,
-	S extends Store,
+	S extends ReadableStore,
 	P extends AbsolutePath = AbsolutePath,
 > extends Node<S, P> {
 	readonly shape: number[];

--- a/src/storage/fetch.ts
+++ b/src/storage/fetch.ts
@@ -1,4 +1,4 @@
-import type { AbsolutePath, ReadableAsyncStore } from "../types";
+import type { AbsolutePath, Async, Readable } from "../types";
 
 function resolve(root: string | URL, path: AbsolutePath): URL {
 	const base = typeof root === "string" ? new URL(root) : root;
@@ -12,7 +12,7 @@ function resolve(root: string | URL, path: AbsolutePath): URL {
 	return resolved;
 }
 
-class FetchStore implements ReadableAsyncStore<RequestInit> {
+class FetchStore implements Async<Readable<RequestInit>> {
 	constructor(public url: string | URL) {}
 
 	async get(key: AbsolutePath, opts: RequestInit = {}): Promise<Uint8Array | undefined> {

--- a/src/storage/fetch.ts
+++ b/src/storage/fetch.ts
@@ -1,5 +1,4 @@
-import ReadOnlyStore from "./readonly";
-import type { AbsolutePath } from "../types";
+import type { AbsolutePath, ReadableAsyncStore } from "../types";
 
 function resolve(root: string | URL, path: AbsolutePath): URL {
 	const base = typeof root === "string" ? new URL(root) : root;
@@ -13,10 +12,8 @@ function resolve(root: string | URL, path: AbsolutePath): URL {
 	return resolved;
 }
 
-class FetchStore extends ReadOnlyStore<RequestInit> {
-	constructor(public url: string | URL) {
-		super();
-	}
+class FetchStore implements ReadableAsyncStore<RequestInit> {
+	constructor(public url: string | URL) {}
 
 	async get(key: AbsolutePath, opts: RequestInit = {}): Promise<Uint8Array | undefined> {
 		const { href } = resolve(this.url, key);

--- a/src/storage/fs.ts
+++ b/src/storage/fs.ts
@@ -1,9 +1,17 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-import type { AbsolutePath, AsyncStore, PrefixPath, RootPath } from "../types";
+import type {
+	AbsolutePath,
+	Async,
+	ExtendedReadable,
+	PrefixPath,
+	Readable,
+	RootPath,
+	Writeable,
+} from "../types";
 
-class FileSystemStore implements AsyncStore {
+class FileSystemStore implements Async<Readable & Writeable & ExtendedReadable> {
 	constructor(public root: string) {}
 
 	get(key: AbsolutePath): Promise<Uint8Array | undefined> {

--- a/src/storage/mem.ts
+++ b/src/storage/mem.ts
@@ -1,6 +1,13 @@
-import type { PrefixPath, RootPath, SyncStore } from "../types";
+import type {
+	ExtendedReadable,
+	PrefixPath,
+	Readable,
+	RootPath,
+	Writeable,
+} from "../types";
 
-class MemoryStore extends Map<string, Uint8Array> implements SyncStore {
+class MemoryStore extends Map<string, Uint8Array>
+	implements Readable, Writeable, ExtendedReadable {
 	list_prefix(prefix: RootPath | PrefixPath) {
 		const items = [];
 		for (const path of super.keys()) {

--- a/src/v3.ts
+++ b/src/v3.ts
@@ -6,14 +6,15 @@ import { json_decode_object, json_encode_object } from "./lib/util";
 
 import type {
 	AbsolutePath,
+	Async,
 	Attrs,
 	CreateArrayProps,
 	DataType,
+	ExtendedReadable,
 	Hierarchy as _Hierarchy,
-	ReadableStore,
+	Readable,
 	Scalar,
-	Store,
-	WriteableStore,
+	Writeable,
 } from "./types";
 import type { Codec } from "numcodecs";
 
@@ -96,8 +97,8 @@ function meta_key<Path extends string, Suffix extends string>(
 }
 
 async function create_group<
-	S extends Store,
-	H extends Hierarchy<S>,
+	Store extends (Readable & Writeable) | Async<Readable & Writeable>,
+	H extends Hierarchy<Store>,
 	Path extends AbsolutePath,
 >(owner: H, path: Path, attrs: Attrs = {}) {
 	const meta: GroupMetadata = { extensions: [], attributes: attrs };
@@ -110,21 +111,21 @@ async function create_group<
 }
 
 async function create_array<
-	S extends Store,
-	H extends Hierarchy<S>,
+	Store extends (Readable & Writeable) | Async<Readable & Writeable>,
+	H extends Hierarchy<Store>,
 	Path extends AbsolutePath,
-	D extends DataType,
+	Dtype extends DataType,
 >(
 	owner: H,
 	path: Path,
-	props: Omit<CreateArrayProps<D>, "filters">,
-): Promise<ZarrArray<D, S, Path>> {
+	props: Omit<CreateArrayProps<Dtype>, "filters">,
+): Promise<ZarrArray<Dtype, Store, Path>> {
 	const shape = props.shape;
 	const dtype = props.dtype;
 	const chunk_shape = props.chunk_shape;
 	const compressor = props.compressor;
 
-	const meta: ArrayMetadata<D> = {
+	const meta: ArrayMetadata<Dtype> = {
 		shape,
 		data_type: dtype,
 		chunk_grid: {
@@ -166,9 +167,11 @@ const chunk_key = (path: string, chunk_separator: "." | "/") =>
 		return `/data/root${path}/${chunk_identifier}`;
 	};
 
-export async function create_hierarchy<S extends Store>(
-	store: S,
-): Promise<Hierarchy<S>> {
+export async function create_hierarchy<
+	Store extends (Readable & Writeable) | Async<Readable & Writeable>,
+>(
+	store: Store,
+): Promise<Hierarchy<Store>> {
 	// create entry point metadata document
 	const meta_key_suffix = ".json";
 
@@ -188,9 +191,9 @@ export async function create_hierarchy<S extends Store>(
 	return new Hierarchy({ store, meta_key_suffix });
 }
 
-export async function get_hierarchy<S extends Store | ReadableStore>(
-	store: S,
-): Promise<Hierarchy<S>> {
+export async function get_hierarchy<Store extends Readable | Async<Readable>>(
+	store: Store,
+): Promise<Hierarchy<Store>> {
 	// retrieve and parse entry point metadata document
 	const meta_key = "/zarr.json";
 	const meta_doc = await store.get(meta_key);
@@ -241,11 +244,12 @@ export async function get_hierarchy<S extends Store | ReadableStore>(
 	return new Hierarchy({ store, meta_key_suffix });
 }
 
-export class Hierarchy<S extends Store | ReadableStore> implements _Hierarchy<S> {
-	store: S;
+export class Hierarchy<Store extends Readable | Async<Readable>>
+	implements _Hierarchy<Store> {
+	store: Store;
 	meta_key_suffix: string;
 
-	constructor({ store, meta_key_suffix }: { store: S; meta_key_suffix: string }) {
+	constructor({ store, meta_key_suffix }: { store: Store; meta_key_suffix: string }) {
 		this.store = store;
 		this.meta_key_suffix = meta_key_suffix;
 	}
@@ -265,22 +269,25 @@ export class Hierarchy<S extends Store | ReadableStore> implements _Hierarchy<S>
 	create_group<Path extends AbsolutePath>(
 		path: Path,
 		props: { attrs?: Attrs } = {},
-	): S extends WriteableStore ? Promise<ExplicitGroup<S, Hierarchy<S>, Path>> : never {
+	): Store extends (Writeable | Async<Writeable>)
+		? Promise<ExplicitGroup<Store, Hierarchy<Store>, Path>>
+		: never {
 		assert("set" in this.store, "Not a writable store");
-		return create_group(this as Hierarchy<Store>, path, props.attrs) as any;
+		return create_group(this as Hierarchy<any>, path, props.attrs) as any;
 	}
 
-	create_array<Path extends AbsolutePath, D extends DataType>(
+	create_array<Path extends AbsolutePath, Dtype extends DataType>(
 		path: Path,
-		props: Omit<CreateArrayProps<D>, "filters">,
-	): S extends WriteableStore ? Promise<ZarrArray<D, S, Path>> : never {
+		props: Omit<CreateArrayProps<Dtype>, "filters">,
+	): Store extends (Writeable | Async<Writeable>) ? Promise<ZarrArray<Dtype, Store, Path>>
+		: never {
 		assert("set" in this.store, "Not a writable store");
-		return create_array(this as Hierarchy<Store>, path, props) as any;
+		return create_array(this as Hierarchy<any>, path, props) as any;
 	}
 
 	async get_array<Path extends AbsolutePath>(
 		path: Path,
-	): Promise<ZarrArray<DataType, S, Path>> {
+	): Promise<ZarrArray<DataType, Store, Path>> {
 		const key = meta_key(path, this.meta_key_suffix, "array");
 		const meta_doc = await this.store.get(key);
 
@@ -338,7 +345,7 @@ export class Hierarchy<S extends Store | ReadableStore> implements _Hierarchy<S>
 
 	async get_group<Path extends AbsolutePath>(
 		path: Path,
-	): Promise<ExplicitGroup<S, Hierarchy<S>, Path>> {
+	): Promise<ExplicitGroup<Store, Hierarchy<Store>, Path>> {
 		// retrieve and parse group metadata document
 		const key = meta_key(path, this.meta_key_suffix, "group");
 		const meta_doc = await this.store.get(key);
@@ -358,33 +365,36 @@ export class Hierarchy<S extends Store | ReadableStore> implements _Hierarchy<S>
 		});
 	}
 
-	async get_implicit_group<Path extends AbsolutePath>(
+	get_implicit_group<Path extends AbsolutePath>(
 		path: Path,
-	): Promise<ImplicitGroup<S, Hierarchy<S>, Path>> {
-		let contents: string[] = [];
-		let prefixes: string[] = [];
-		if ("list_dir" in this.store) {
+	): Store extends ExtendedReadable | Async<ExtendedReadable>
+		? Promise<ImplicitGroup<Store, Hierarchy<Store>, Path>>
+		: never {
+		assert(
+			"list_dir" in this.store,
+			"Not ExtendedReadable, store must implement list_dir",
+		);
+		return (async () => {
 			// attempt to list directory
 			const key_prefix = (path as any) === "/"
 				? "/meta/root/"
 				: `/meta/root${path}/` as const;
 
-			const result = await this.store.list_dir(key_prefix);
-			contents = result.contents;
-			prefixes = result.prefixes;
-		}
+			const res = await (this.store as ExtendedReadable | Async<ExtendedReadable>)
+				.list_dir(key_prefix);
 
-		if (contents.length === 0 && prefixes.length === 0) {
-			throw new NodeNotFoundError(path);
-		}
+			if (res.contents.length === 0 && res.prefixes.length === 0) {
+				throw new NodeNotFoundError(path);
+			}
 
-		return new ImplicitGroup({ store: this.store, path, owner: this });
+			return new ImplicitGroup({ store: this.store, path, owner: this });
+		})() as any;
 	}
 
 	async get<Path extends AbsolutePath>(path: Path): Promise<
-		| ZarrArray<DataType, S, Path>
-		| ExplicitGroup<S, Hierarchy<S>, Path>
-		| ImplicitGroup<S, Hierarchy<S>, Path>
+		| ZarrArray<DataType, Store, Path>
+		| ExplicitGroup<Store, Hierarchy<Store>, Path>
+		| ImplicitGroup<Store, Hierarchy<Store>, Path>
 	> {
 		try {
 			return await this.get_array(path);
@@ -425,71 +435,87 @@ export class Hierarchy<S extends Store | ReadableStore> implements _Hierarchy<S>
 		}
 	}
 
-	async get_nodes(): Promise<Map<string, string>> {
-		const nodes: Map<string, string> = new Map();
-		if (!("list_prefix" in this.store)) {
-			return nodes;
-		}
-		const result = await this.store.list_prefix("/meta/");
+	get_nodes(): Store extends ExtendedReadable | Async<ExtendedReadable>
+		? Promise<Map<string, string>>
+		: never {
+		assert(
+			"list_prefix" in this.store,
+			"Not ExtendedReadable, store must implement list_prefix",
+		);
+		return (async () => {
+			const nodes: Map<string, string> = new Map();
+			const result = await (this.store as ExtendedReadable | Async<ExtendedReadable>)
+				.list_prefix("/meta/");
+			const lookup = (key: string) => {
+				if (key.endsWith(this.array_suffix)) {
+					return { suffix: this.array_suffix, type: "array" };
+				} else if (key.endsWith(this.group_suffix)) {
+					return { suffix: this.group_suffix, type: "explicit_group" };
+				}
+			};
 
-		const lookup = (key: string) => {
-			if (key.endsWith(this.array_suffix)) {
-				return { suffix: this.array_suffix, type: "array" };
-			} else if (key.endsWith(this.group_suffix)) {
-				return { suffix: this.group_suffix, type: "explicit_group" };
-			}
-		};
-
-		for (const key of result) {
-			if (key === "root.array" + this.meta_key_suffix) {
-				nodes.set("/", "array");
-			} else if (key == "root.group") {
-				nodes.set("/", "explicit_group");
-			} else if (key.startsWith("root/")) {
-				const m = lookup(key);
-				if (m) {
-					const path = key.slice("root".length, -m.suffix.length);
-					nodes.set(path, m.type);
-					const segments = path.split("/");
-					segments.pop();
-					while (segments.length > 1) {
-						const parent = segments.join("/");
-						nodes.set(
-							parent,
-							nodes.get(parent) || "implicit_group",
-						);
+			for (const key of result) {
+				if (key === "root.array" + this.meta_key_suffix) {
+					nodes.set("/", "array");
+				} else if (key == "root.group") {
+					nodes.set("/", "explicit_group");
+				} else if (key.startsWith("root/")) {
+					const m = lookup(key);
+					if (m) {
+						const path = key.slice("root".length, -m.suffix.length);
+						nodes.set(path, m.type);
+						const segments = path.split("/");
 						segments.pop();
+						while (segments.length > 1) {
+							const parent = segments.join("/");
+							nodes.set(
+								parent,
+								nodes.get(parent) || "implicit_group",
+							);
+							segments.pop();
+						}
+						nodes.set("/", nodes.get("/") || "implicit_group");
 					}
-					nodes.set("/", nodes.get("/") || "implicit_group");
 				}
 			}
-		}
-		return nodes;
+			return nodes;
+		})() as any;
 	}
 
-	async get_children(path: AbsolutePath = "/"): Promise<Map<string, string>> {
-		const children: Map<string, string> = new Map();
+	get_children(
+		path: AbsolutePath = "/",
+	): Store extends ExtendedReadable | Async<ExtendedReadable>
+		? Promise<Map<string, string>>
+		: never {
+		assert(
+			"list_dir" in this.store,
+			"Not ExtendedReadable, store must implement list_dir",
+		);
+		return (async () => {
+			const children: Map<string, string> = new Map();
 
-		// attempt to list directory
-		const key_prefix = path === "/" ? "/meta/root/" : `/meta/root${path}/` as const;
-		const result = await this.store.list_dir(key_prefix);
+			// attempt to list directory
+			const key_prefix = path === "/" ? "/meta/root/" : `/meta/root${path}/` as const;
+			const result = await (this.store as ExtendedReadable | Async<ExtendedReadable>)
+				.list_dir(key_prefix);
 
-		// find explicit children
-		for (const n of result.contents) {
-			if (n.endsWith(this.array_suffix)) {
-				const name = n.slice(0, -this.array_suffix.length);
-				children.set(name, "array");
-			} else if (n.endsWith(this.group_suffix)) {
-				const name = n.slice(0, -this.group_suffix.length);
-				children.set(name, "explicit_group");
+			// find explicit children
+			for (const n of result.contents) {
+				if (n.endsWith(this.array_suffix)) {
+					const name = n.slice(0, -this.array_suffix.length);
+					children.set(name, "array");
+				} else if (n.endsWith(this.group_suffix)) {
+					const name = n.slice(0, -this.group_suffix.length);
+					children.set(name, "explicit_group");
+				}
 			}
-		}
 
-		// find implicit children
-		for (const name of result.prefixes) {
-			children.set(name, children.get(name) || "implicit_group");
-		}
+			// find implicit children
+			for (const name of result.prefixes) {
+				children.set(name, children.get(name) || "implicit_group");
+			}
 
-		return children;
+			return children;
+		})() as any;
 	}
 }

--- a/test/common.js
+++ b/test/common.js
@@ -1,12 +1,11 @@
 // @ts-check
-
 import { test } from "zora";
 
 import { ExplicitGroup, ImplicitGroup, registry, slice, v3, ZarrArray } from "zarrita";
 import { get, set } from "zarrita/ndarray";
 import ndarray from "ndarray";
-import GZip from "numcodecs/gzip";
 
+import GZip from "numcodecs/gzip";
 // add dynamic codec to registry
 // @ts-ignore
 registry.set("gzip", () => GZip);
@@ -17,7 +16,7 @@ function json(bytes) {
 	return JSON.parse(str);
 }
 
-/** @param {{ name: string, setup: () => Promise<any> }} props */
+/** @param {{ name: string, setup: () => Promise<import('../src/types').Store> }} props */
 export function run_test_suite({ name, setup }) {
 	test(`Zarrita test suite: ${name}.`, async (t) => {
 		const store = await setup();


### PR DESCRIPTION

Return type is `never` for store that only implement `Readable`:

![image](https://user-images.githubusercontent.com/24403730/145724736-46cfda84-63e4-4399-aa71-bd6cd0a6fd24.png)

![image](https://user-images.githubusercontent.com/24403730/145724751-18c8fdee-d80f-4e7e-92c2-1039d05f31b0.png)

