### PR TITLE
Remove `Chars` generic for str datatypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@types/node": "^16.10.2",
     "mkdist": "^0.3.5",
     "tsm": "^2.2.1",
-    "typescript": "^4.5.2",
+    "typescript": "^4.6.2",
     "uvu": "^0.5.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ specifiers:
   numcodecs: ^0.2.2
   reference-spec-reader: ^0.1.3
   tsm: ^2.2.1
-  typescript: ^4.5.2
+  typescript: ^4.6.2
   unzipit: ^1.3.6
   uvu: ^0.5.3
 
@@ -23,9 +23,9 @@ dependencies:
 
 devDependencies:
   '@types/node': 16.10.2
-  mkdist: 0.3.5_typescript@4.5.2
+  mkdist: 0.3.5_typescript@4.6.2
   tsm: 2.2.1
-  typescript: 4.5.2
+  typescript: 4.6.2
   uvu: 0.5.3
 
 packages:
@@ -544,7 +544,7 @@ packages:
       picomatch: 2.3.0
     dev: true
 
-  /mkdist/0.3.5_typescript@4.5.2:
+  /mkdist/0.3.5_typescript@4.6.2:
     resolution: {integrity: sha512-3ai1qPfTufa/YMdsjYoA372YVogn1yLkHTG7H7tG66xJpYdoK3vnelROhM41dGhHh/4RhObCkDwAQCpIx81A3g==}
     hasBin: true
     peerDependencies:
@@ -560,7 +560,7 @@ packages:
       jiti: 1.12.9
       mri: 1.2.0
       pathe: 0.2.0
-      typescript: 4.5.2
+      typescript: 4.6.2
     dev: true
 
   /mri/1.2.0:
@@ -646,8 +646,8 @@ packages:
       esbuild: 0.14.11
     dev: true
 
-  /typescript/4.5.2:
-    resolution: {integrity: sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==}
+  /typescript/4.6.2:
+    resolution: {integrity: sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true

--- a/src/dtypes.ts
+++ b/src/dtypes.ts
@@ -49,8 +49,6 @@ export type DataType =
 	| StringDataType
 	| Bool;
 
-export type WithoutEndianness = DataType extends `${infer _}${infer Rest}` ? Rest : never;
-
 export type TypedArray<D extends DataType> = D extends Int8 ? Int8Array
 	: D extends Int16 ? Int16Array
 	: D extends Int32 ? Int32Array
@@ -62,9 +60,9 @@ export type TypedArray<D extends DataType> = D extends Int8 ? Int8Array
 	: D extends Float32 ? Float32Array
 	: D extends Float64 ? Float64Array
 	: D extends Bool ? BoolArray
-	: D extends `|S${infer B}` ? ByteStringArray<ParseNumber<B>>
-	: D extends `>U${infer B}` ? UnicodeStringArray<ParseNumber<B>>
-	: D extends `<U${infer B}` ? UnicodeStringArray<ParseNumber<B>>
+	: D extends `|S${infer _}` ? ByteStringArray
+	: D extends `>U${infer _}` ? UnicodeStringArray
+	: D extends `<U${infer _}` ? UnicodeStringArray
 	: never;
 
 export type TypedArrayConstructor<D extends DataType> = {
@@ -80,34 +78,6 @@ export type Scalar<D extends DataType> = D extends "|b1" ? boolean
 	: D extends `${infer _}${"U" | "S"}${infer _}` ? string
 	: D extends `${"<" | ">"}${"u" | "i"}8` ? bigint
 	: number;
-
-// Hack to statically infer sizing of string
-// TODO: use this implemention when tail recursion is better.
-// type Range<
-// 	N extends number,
-// 	Result extends Array<unknown> = [],
-// > = (Result["length"] extends N ? Result
-// 	: Range<N, [...Result, Result["length"]]>);
-//
-// type MAX_SIZE = 256;
-// type NumRange = Range<MAX_SIZE>;
-
-//deno-fmt-ignore
-type NumRange = [
-	  0,   1,   2,   3,   4,   5,   6,   7,   8,   9,  10,  11,  12,  13,  14,  15,  16,  17,  18,  19,  20,  21,  22,  23,  24,
-	 25,  26,  27,  28,  29,  30,  31,  32,  33,  34,  35,  36,  37,  38,  39,  40,  41,  42,  43,  44,  45,  46,  47,  48,  49,
-	 50,  51,  52,  53,  54,  55,  56,  57,  58,  59,  60,  61,  62,  63,  64,  65,  66,  67,  68,  69,  70,  71,  72,  73,  74,
-	 75,  76,  77,  78,  79,  80,  81,  82,  83,  84,  85,  86,  87,  88,  89,  90,  91,  92,  93,  94,  95,  96,  97,  98,  99,
-	100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124,
-	125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149,
-	150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174,
-	175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199,
-	200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224,
-	225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249,
-	250, 251, 252, 253, 254, 255, 256,
-];
-// fallback to number if not in range.
-type ParseNumber<T extends string> = T extends keyof NumRange ? NumRange[T] : number;
 
 // TODO: Using this for sanity check, but really should move to formal compilation tests.
 type Parts<D extends DataType> = {

--- a/src/dtypes.ts
+++ b/src/dtypes.ts
@@ -60,9 +60,8 @@ export type TypedArray<D extends DataType> = D extends Int8 ? Int8Array
 	: D extends Float32 ? Float32Array
 	: D extends Float64 ? Float64Array
 	: D extends Bool ? BoolArray
-	: D extends `|S${infer _}` ? ByteStringArray
-	: D extends `>U${infer _}` ? UnicodeStringArray
-	: D extends `<U${infer _}` ? UnicodeStringArray
+	: D extends ByteStr ? ByteStringArray
+	: D extends UnicodeStr ? UnicodeStringArray
 	: never;
 
 export type TypedArrayConstructor<D extends DataType> = {

--- a/src/lib/custom-arrays.ts
+++ b/src/lib/custom-arrays.ts
@@ -34,12 +34,12 @@ export class BoolArray {
 	}
 }
 
-export class ByteStringArray<Chars extends number> {
+export class ByteStringArray {
 	private _bytes: Uint8Array;
 
-	constructor(size: number, chars: Chars);
-	constructor(buffer: ArrayBuffer, chars: Chars);
-	constructor(x: number | ArrayBuffer, public chars: Chars) {
+	constructor(size: number, chars: number);
+	constructor(buffer: ArrayBuffer, chars: number);
+	constructor(x: number | ArrayBuffer, public chars: number) {
 		if (typeof x === "number") {
 			this._bytes = new Uint8Array(x * chars);
 		} else {
@@ -92,14 +92,14 @@ export class ByteStringArray<Chars extends number> {
 	}
 }
 
-export class UnicodeStringArray<Chars extends number> {
+export class UnicodeStringArray {
 	private _data: Int32Array;
 	BYTES_PER_ELEMENT = 4;
 	byteOffset = 0;
 
-	constructor(size: number, chars: Chars);
-	constructor(buffer: ArrayBuffer, chars: Chars);
-	constructor(x: number | ArrayBuffer, public chars: Chars) {
+	constructor(size: number, chars: number);
+	constructor(buffer: ArrayBuffer, chars: number);
+	constructor(x: number | ArrayBuffer, public chars: number) {
 		if (typeof x === "number") {
 			this._data = new Int32Array(x * chars);
 		} else {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -78,7 +78,7 @@ export function get_ctr<D extends DataType>(dtype: D): TypedArrayConstructor<D> 
 	// dynamically create typed array, use named class so logging is nice
 	if (second === "U") {
 		const size = parseInt(dtype.slice(2));
-		class UnicodeStringArray extends _UnicodeStringArray<typeof size> {
+		class UnicodeStringArray extends _UnicodeStringArray {
 			constructor(x: ArrayBuffer | number) {
 				super(x as any, size);
 			}
@@ -89,7 +89,7 @@ export function get_ctr<D extends DataType>(dtype: D): TypedArrayConstructor<D> 
 	// dynamically create typed array, use named class so logging is nice
 	if (second === "S") {
 		const size = parseInt(dtype.slice(2));
-		class ByteStringArray extends _ByteStringArray<typeof size> {
+		class ByteStringArray extends _ByteStringArray {
 			constructor(x: ArrayBuffer | number) {
 				super(x as any, size);
 			}

--- a/tests/get-v2.ts
+++ b/tests/get-v2.ts
@@ -91,7 +91,7 @@ contiguous("1d.contiguous.U13.le", async () => {
 	let arr = await get_array(store, "/1d.contiguous.U13.le");
 	let chunk = await arr.get_chunk([0]);
 	assert.instance(chunk.data, UnicodeStringArray);
-	assert.equal(Array.from(chunk.data as UnicodeStringArray<13>), ["a", "b", "cc", "d"]);
+	assert.equal(Array.from(chunk.data as UnicodeStringArray), ["a", "b", "cc", "d"]);
 	assert.equal(chunk.shape, [4]);
 });
 
@@ -99,7 +99,7 @@ contiguous("1d.contiguous.U13.be", async () => {
 	let arr = await get_array(store, "/1d.contiguous.U13.be");
 	let chunk = await arr.get_chunk([0]);
 	assert.instance(chunk.data, UnicodeStringArray);
-	assert.equal(Array.from(chunk.data as UnicodeStringArray<14>), ["a", "b", "cc", "d"]);
+	assert.equal(Array.from(chunk.data as UnicodeStringArray), ["a", "b", "cc", "d"]);
 	assert.equal(chunk.shape, [4]);
 });
 
@@ -107,7 +107,7 @@ contiguous("1d.contiguous.U7", async () => {
 	let arr = await get_array(store, "/1d.contiguous.U7");
 	let chunk = await arr.get_chunk([0]);
 	assert.instance(chunk.data, UnicodeStringArray);
-	assert.equal(Array.from(chunk.data as UnicodeStringArray<7>), ["a", "b", "cc", "d"]);
+	assert.equal(Array.from(chunk.data as UnicodeStringArray), ["a", "b", "cc", "d"]);
 	assert.equal(chunk.shape, [4]);
 });
 
@@ -115,7 +115,7 @@ contiguous("1d.contiguous.S7", async () => {
 	let arr = await get_array(store, "/1d.contiguous.S7");
 	let chunk = await arr.get_chunk([0]);
 	assert.instance(chunk.data, ByteStringArray);
-	assert.equal(Array.from(chunk.data as ByteStringArray<7>), ["a", "b", "cc", "d"]);
+	assert.equal(Array.from(chunk.data as ByteStringArray), ["a", "b", "cc", "d"]);
 	assert.equal(chunk.shape, [4]);
 });
 
@@ -198,13 +198,13 @@ chunked("2d.chunked.U7", async () => {
 		arr.get_chunk([1, 0]),
 		arr.get_chunk([1, 1]),
 	]);
-	assert.equal(Array.from(c1.data as UnicodeStringArray<7>), ["a"]);
+	assert.equal(Array.from(c1.data as UnicodeStringArray), ["a"]);
 	assert.equal(c1.shape, [1, 1]);
-	assert.equal(Array.from(c2.data as UnicodeStringArray<7>), ["b"]);
+	assert.equal(Array.from(c2.data as UnicodeStringArray), ["b"]);
 	assert.equal(c2.shape, [1, 1]);
-	assert.equal(Array.from(c3.data as UnicodeStringArray<7>), ["cc"]);
+	assert.equal(Array.from(c3.data as UnicodeStringArray), ["cc"]);
 	assert.equal(c3.shape, [1, 1]);
-	assert.equal(Array.from(c4.data as UnicodeStringArray<7>), ["d"]);
+	assert.equal(Array.from(c4.data as UnicodeStringArray), ["d"]);
 	assert.equal(c4.shape, [1, 1]);
 });
 


### PR DESCRIPTION
Type inference for the number of chars in a str datatype is possible, but it currently breaks type narrowing with a custom type guard.  This PR removes all the fancy inference, so that useful custom type guards are possible:

```typescript
import type * as zarr from "zarrita/v2";
import type { DataType, Readable, Async, AbsolutePath } from "zarrita/types";

function is<
	D extends DataType,
	Store extends Readable | Async<Readable>,
	Path extends AbsolutePath,
>(
	arr: zarr.Array<DataType, Store, Path>,
	dtype: D,
): arr is zarr.Array<D, Store, Path> {
	return arr.dtype === dtype;
}

declare const arr: zarr.Array<DataType, Map<string, Uint8Array>, "/">;
declare const d: "|S43" | ">i2";

if (is(arr, d)) {
	arr // zarr.Array<">i2" | "S43", Map<string, Uint8Array>, "/">
} 
```