### PR TITLE
chore: replace deno fmt with dprint

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,10 +1,10 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
-  "changelog": [
-    "@svitejs/changesets-changelog-github-compact",
-    { "repo": "manzt/zarrita.js" }
-  ],
-  "commit": false,
-  "access": "public",
-  "baseBranch": "main"
+	"$schema": "https://unpkg.com/@changesets/config@2.3.0/schema.json",
+	"changelog": [
+		"@svitejs/changesets-changelog-github-compact",
+		{ "repo": "manzt/zarrita.js" }
+	],
+	"commit": false,
+	"access": "public",
+	"baseBranch": "main"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,6 @@ jobs:
       - uses: pnpm/action-setup@v2
         with:
           version: 8
-      - run: pnpm lint
+      - run: |
+          pnpm install
+          pnpm lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ concurrency:
 jobs:
   Test:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
       - uses: pnpm/action-setup@v2
@@ -23,14 +22,11 @@ jobs:
           pnpm install
           pnpm build
           pnpm test
+
   Lint:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
-      - uses: denoland/setup-deno@v1
-        with:
-          deno-version: v1.x
       - uses: pnpm/action-setup@v2
         with:
           version: 8

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ const region = await get(arr, [null, slice(6)]);
 
 zarrita's API is almost entirely tree-shakeable, meaning users are able to pick
 and choose only the features of Zarr which are necessary for an applications. At
-its core, the `zarr.Array` class allows accessing and decoding individual array chunks.
-"Fancy-indexing" and "slicing" are accomplished via (optional) functions which
-operate on `zarr.Array` objects.
+its core, the `zarr.Array` class allows accessing and decoding individual array
+chunks. "Fancy-indexing" and "slicing" are accomplished via (optional) functions
+which operate on `zarr.Array` objects.
 
 Thus, you only pay for these features if used (when bundling for the web). This
 design choice differs from existing implemenations of Zarr in JavaScript, and

--- a/dprint.json
+++ b/dprint.json
@@ -1,0 +1,23 @@
+{
+	"typescript": {
+		"deno": true,
+		"useTabs": true
+	},
+	"json": {
+		"deno": true,
+		"useTabs": true
+	},
+	"markdown": {
+		"deno": true
+	},
+	"excludes": [
+		"**/node_modules",
+		"**/*-lock.json",
+		"fixtures/**/*"
+	],
+	"plugins": [
+		"https://plugins.dprint.dev/typescript-0.86.2.wasm",
+		"https://plugins.dprint.dev/json-0.17.4.wasm",
+		"https://plugins.dprint.dev/markdown-0.15.3.wasm"
+	]
+}

--- a/package.json
+++ b/package.json
@@ -3,13 +3,14 @@
 	"scripts": {
 		"build": "tsc --build",
 		"test": "vitest --api",
-		"fmt": "deno fmt --use-tabs packages docs",
-		"lint": "deno fmt --use-tabs packages docs --check"
+		"fmt": "dprint fmt",
+		"lint": "dprint check"
 	},
 	"devDependencies": {
 		"@changesets/cli": "^2.26.2",
 		"@svitejs/changesets-changelog-github-compact": "^1.1.0",
 		"@types/node": "^20.4.9",
+		"dprint": "^0.40.2",
 		"typescript": "^5.1.6",
 		"vitest": "^0.33.0"
 	}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@types/node':
         specifier: ^20.4.9
         version: 20.4.9
+      dprint:
+        specifier: ^0.40.2
+        version: 0.40.2
       typescript:
         specifier: ^5.1.6
         version: 5.1.6
@@ -524,6 +527,54 @@ packages:
       - '@algolia/client-search'
       - search-insights
     dev: true
+
+  /@dprint/darwin-arm64@0.40.2:
+    resolution: {integrity: sha512-qharMFhxpNq9brgvHLbqzzAgVgPWSHLfzNLwWWhKcGOUUDUIilfAo3SlvOz6w4nQiIifLpYZOvZqK7Lpf9mSSw==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@dprint/darwin-x64@0.40.2:
+    resolution: {integrity: sha512-FPDdOTVr1JfqtLBTCvqlihWslTy3LBUoi3H1gaqIazCKMj2dB9voFWkBiMT+REMHDrlVsoSpFAfsliNr/y7HPA==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@dprint/linux-arm64-glibc@0.40.2:
+    resolution: {integrity: sha512-GmUWfKwEwXA+onvewX9hEJSMcd9V184+uRbEhI5tG28tBP9+IjQhrY7jCjxPvaZA+EvzNPnAy5D1wbJdlNLBNA==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@dprint/linux-x64-glibc@0.40.2:
+    resolution: {integrity: sha512-vMHAHdsOY+2thieSWbIrIioDfPgvipwUgd0MZUWOqycTrXU6kLyi2B+5J/2Jc+QO3CiLIbumQd2FH/0vB1eWqA==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@dprint/linux-x64-musl@0.40.2:
+    resolution: {integrity: sha512-nFSbDWd9ORyOhJ7a+RmE39WbuPoQ3OQutIgfAmfikiu/wENzEwxxv4QJ7aFnBaoZb0wuVEEpXShr8vY4p0exkg==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@dprint/win32-x64@0.40.2:
+    resolution: {integrity: sha512-qF4VCQzFTZYD61lbQqXLU/IwUTbLK22CancO+uVtXmZRoKU9GaVjcBhMUB7URxsa8rvxWHhHT6ldillI/aOWCg==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /@esbuild/android-arm64@0.18.16:
     resolution: {integrity: sha512-wsCqSPqLz+6Ov+OM4EthU43DyYVVyfn15S4j1bJzylDpc1r1jZFFfJQNfDuT8SlgwuqpmpJXK4uPlHGw6ve7eA==}
@@ -1410,6 +1461,19 @@ packages:
   /dotenv@16.3.1:
     resolution: {integrity: sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==}
     engines: {node: '>=12'}
+    dev: true
+
+  /dprint@0.40.2:
+    resolution: {integrity: sha512-3LdyUV0itEW59UPtsRA2StOWOu8FyOW+BgvJpH/tACRHKi0z5gaQnvSxdS3mbG7dgtEhdRnGg6JoiQyGib6NTg==}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@dprint/darwin-arm64': 0.40.2
+      '@dprint/darwin-x64': 0.40.2
+      '@dprint/linux-arm64-glibc': 0.40.2
+      '@dprint/linux-x64-glibc': 0.40.2
+      '@dprint/linux-x64-musl': 0.40.2
+      '@dprint/win32-x64': 0.40.2
     dev: true
 
   /emoji-regex@8.0.0:


### PR DESCRIPTION
`deno fmt` uses `dprint` under the hood. This PR configures `dprint` in "deno" mode, but using Node.js to run the package.
