### PR TITLE
feat(indexing): generalize buffer-backed operations

### DIFF
--- a/.changeset/cold-dancers-chew.md
+++ b/.changeset/cold-dancers-chew.md
@@ -1,0 +1,7 @@
+---
+"@zarrita/indexing": patch
+---
+
+feat: generalize chunk-indexing/slicing operations
+
+Refactors the internals of `get`/`set` to operate on the raw 1D "bytes" for decompressed chunks.

--- a/packages/indexing/src/ops.ts
+++ b/packages/indexing/src/ops.ts
@@ -1,10 +1,5 @@
 import type { Mutable, Readable } from "@zarrita/storage";
 import type * as core from "@zarrita/core";
-import {
-	BoolArray,
-	ByteStringArray,
-	UnicodeStringArray,
-} from "@zarrita/typedarray";
 import { get as get_with_setter } from "./get.js";
 import { set as set_with_setter } from "./set.js";
 import type {
@@ -15,127 +10,82 @@ import type {
 	Slice,
 } from "./types.js";
 
-type CompatDataType<D extends core.DataType> = D extends core.Bool ? core.Uint8
-	: D;
-
-type TypedArrayProxy<D extends core.DataType> = {
-	[prop: number]: core.Scalar<D>;
-	subarray(from: number, to?: number): TypedArrayProxy<D>;
-	set(source: TypedArrayProxy<D>, offset: number): void;
-	fill(value: core.Scalar<D>, start: number, end: number): void;
-};
-
-type CompatChunk<D extends core.DataType> = {
-	data: TypedArrayProxy<CompatDataType<D>>;
-	stride: number[];
-};
-
-function object_array_proxy<T extends core.DataType>(
-	arr: T[],
-	offset = 0,
-	lengthArg?: number,
-): TypedArrayProxy<T> {
-	let length = lengthArg ?? arr.length - offset;
-	return new Proxy(arr, {
-		get(target, prop: string) {
-			let idx = +prop;
-			if (!Number.isNaN(idx)) {
-				return target[offset + idx];
-			}
-			if (prop === "subarray") {
-				return (from: number, to: number = length) => {
-					return object_array_proxy(target, offset + from, to - from);
-				};
-			}
-			if (prop === "set") {
-				return (source: typeof target, start: number) => {
-					for (let i = 0; i < source.length; i++) {
-						target[offset + start + i] = source[i];
-					}
-				};
-			}
-			return Reflect.get(target, prop);
-		},
-		set(target, idx: string, value: T) {
-			target[offset + Number(idx)] = value;
-			return true;
-		},
-	}) as any;
-}
-
-function string_array_proxy<D extends core.ByteStr | core.UnicodeStr>(
-	arr: core.TypedArray<D>,
-): TypedArrayProxy<D> {
-	const StringArrayConstructor = arr.constructor.bind(null, arr.chars);
-	return new Proxy(arr, {
-		get(target, prop: string) {
-			let idx = +prop;
-			if (!Number.isNaN(idx)) {
-				return target.get(idx);
-			}
-			if (prop === "subarray") {
-				return (from: number, to: number = arr.length) => {
-					return string_array_proxy(
-						new StringArrayConstructor(
-							target.buffer,
-							target.byteOffset + arr.BYTES_PER_ELEMENT * from,
-							to - from,
-						),
-					);
-				};
-			}
-			if (prop === "set") {
-				return (source: typeof target, offset: number) => {
-					for (let i = 0; i < source.length; i++) {
-						target.set(offset + i, source.get(i));
-					}
-				};
-			}
-			if (prop === "fill") {
-				return (value: string, start: number, end: number) => {
-					for (let i = start; i < end; i++) {
-						target.set(i, value);
-					}
-				};
-			}
-			return Reflect.get(target, prop);
-		},
-		set(target, idx: string, value: string) {
-			target.set(Number(idx), value);
-			return true;
-		},
-	}) as any;
-}
-
-function compat<D extends core.DataType>(arr: core.Chunk<D>): CompatChunk<D> {
-	let data: any = arr.data;
-
-	if (arr.data instanceof BoolArray) {
-		data = new Uint8Array(arr.data.buffer);
-	} else if (
-		arr.data instanceof ByteStringArray ||
-		arr.data instanceof UnicodeStringArray
-	) {
-		data = string_array_proxy(arr.data);
-	} else if (arr.data instanceof globalThis.Array) {
-		data = object_array_proxy(arr.data);
-	}
+/** A 1D "view" of an array that can be used to set values in the array. */
+function object_array_view<T>(arr: T[], offset = 0, size?: number) {
+	let length = size ?? arr.length - offset;
 	return {
-		data,
-		stride: arr.stride,
+		length,
+		subarray(from: number, to: number = length) {
+			return object_array_view(arr, offset + from, to - from);
+		},
+		set(data: { get(idx: number): T; length: number }, start: number = 0) {
+			for (let i = 0; i < data.length; i++) {
+				arr[offset + start + i] = data.get(i);
+			}
+		},
+		get(index: number) {
+			return arr[offset + index];
+		},
 	};
 }
 
-type CompatScalar<D extends core.DataType> = core.Scalar<CompatDataType<D>>;
+/**
+ * Convert a chunk to a Uint8Array that can be used with the binary
+ * set functions. This is necessary because the binary set functions
+ * require a contiguous block of memory, and allows us to support more than
+ * just the browser's TypedArray objects.
+ *
+ * WARNING: This function is not meant to be used directly and is NOT type-safe.
+ * In the case of `Array` instances, it will return a `object_array_view` of
+ * the underlying, which is supported by our binary set functions.
+ */
+function compat_chunk<D extends core.DataType>(arr: core.Chunk<D>): {
+	data: Uint8Array;
+	stride: number[];
+	bytes_per_element: number;
+} {
+	if (arr.data instanceof globalThis.Array) {
+		return {
+			// @ts-expect-error
+			data: object_array_view(arr.data),
+			stride: arr.stride,
+			bytes_per_element: 1,
+		};
+	}
+	return {
+		data: new Uint8Array(
+			arr.data.buffer,
+			arr.data.byteOffset,
+			arr.data.byteLength,
+		),
+		stride: arr.stride,
+		bytes_per_element: arr.data.BYTES_PER_ELEMENT,
+	};
+}
 
-function cast_scalar<D extends core.DataType>(
+/**
+ * Convert a scalar to a Uint8Array that can be used with the binary
+ * set functions. This is necessary because the binary set functions
+ * require a contiguous block of memory, and allows us to support more
+ * than just the browser's TypedArray objects.
+ *
+ * WARNING: This function is not meant to be used directly and is NOT type-safe.
+ * In the case of `Array` instances, it will return a `object_array_view` of
+ * the scalar, which is supported by our binary set functions.
+ */
+function compat_scalar<D extends core.DataType>(
 	arr: core.Chunk<D>,
 	value: core.Scalar<D>,
-): CompatScalar<D> {
-	if (arr.data instanceof BoolArray) {
-		return (value ? 1 : 0) as any;
+): Uint8Array {
+	if (arr.data instanceof globalThis.Array) {
+		// @ts-expect-error
+		return object_array_view([value]);
 	}
-	return value as any;
+	let TypedArray = arr.data.constructor as core.TypedArrayConstructor<
+		Exclude<D, "v2:object">
+	>;
+	let data = new TypedArray([value]);
+	return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
 }
 
 export const setter = {
@@ -151,14 +101,26 @@ export const setter = {
 		sel: (number | Indices)[],
 		value: core.Scalar<D>,
 	) {
-		set_scalar(compat(dest), sel, cast_scalar(dest, value));
+		let view = compat_chunk(dest);
+		set_scalar_binary(
+			view,
+			sel,
+			compat_scalar(dest, value),
+			view.bytes_per_element,
+		);
 	},
 	set_from_chunk<D extends core.DataType>(
 		dest: core.Chunk<D>,
 		src: core.Chunk<D>,
-		mapping: Projection[],
+		projections: Projection[],
 	) {
-		set_from_chunk(compat(dest), compat(src), mapping);
+		let view = compat_chunk(dest);
+		set_from_chunk_binary(
+			view,
+			compat_chunk(src),
+			view.bytes_per_element,
+			projections,
+		);
 	},
 };
 
@@ -200,108 +162,126 @@ function indices_len(start: number, stop: number, step: number) {
 	return 0;
 }
 
-function set_scalar<D extends core.DataType>(
-	out: CompatChunk<D>,
+function set_scalar_binary(
+	out: { data: Uint8Array; stride: number[] },
 	out_selection: (Indices | number)[],
-	value: CompatScalar<D>,
+	value: Uint8Array,
+	bytes_per_element: number,
 ) {
 	if (out_selection.length === 0) {
-		out.data[0] = value;
+		out.data.set(value, 0);
 		return;
 	}
 	const [slice, ...slices] = out_selection;
 	const [curr_stride, ...stride] = out.stride;
-
 	if (typeof slice === "number") {
-		const data = out.data.subarray(curr_stride * slice);
-		set_scalar({ data, stride } as unknown as CompatChunk<D>, slices, value);
+		const data = out.data.subarray(curr_stride * slice * bytes_per_element);
+		set_scalar_binary({ data, stride }, slices, value, bytes_per_element);
 		return;
 	}
-
 	const [from, to, step] = slice;
 	const len = indices_len(from, to, step);
 	if (slices.length === 0) {
-		if (step === 1 && curr_stride === 1) {
-			out.data.fill(value, from, from + len);
-		} else {
-			for (let i = 0; i < len; i++) {
-				out.data[curr_stride * (from + step * i)] = value;
-			}
+		for (let i = 0; i < len; i++) {
+			out.data.set(value, curr_stride * (from + step * i) * bytes_per_element);
 		}
 		return;
 	}
 	for (let i = 0; i < len; i++) {
-		const data = out.data.subarray(curr_stride * (from + step * i));
-		set_scalar({ data, stride } as unknown as CompatChunk<D>, slices, value);
+		const data = out.data.subarray(
+			curr_stride * (from + step * i) * bytes_per_element,
+		);
+		set_scalar_binary({ data, stride }, slices, value, bytes_per_element);
 	}
 }
 
-function set_from_chunk<D extends core.DataType>(
-	dest: CompatChunk<D>,
-	src: CompatChunk<D>,
+function set_from_chunk_binary(
+	dest: { data: Uint8Array; stride: number[] },
+	src: { data: Uint8Array; stride: number[] },
+	bytes_per_element: number,
 	projections: Projection[],
 ) {
 	const [proj, ...projs] = projections;
 	const [dstride, ...dstrides] = dest.stride;
 	const [sstride, ...sstrides] = src.stride;
-
 	if (proj.from === null) {
 		if (projs.length === 0) {
-			dest.data[proj.to] = src.data[0];
+			dest.data.set(
+				src.data.subarray(0, bytes_per_element),
+				proj.to * bytes_per_element,
+			);
 			return;
 		}
-		set_from_chunk(
+		set_from_chunk_binary(
 			{
-				data: dest.data.subarray(dstride * proj.to),
+				data: dest.data.subarray(dstride * proj.to * bytes_per_element),
 				stride: dstrides,
 			},
 			src,
+			bytes_per_element,
 			projs,
 		);
 		return;
 	}
-
 	if (proj.to === null) {
 		if (projs.length === 0) {
-			dest.data[0] = src.data[proj.from];
+			let offset = proj.from * bytes_per_element;
+			dest.data.set(src.data.subarray(offset, offset + bytes_per_element), 0);
 			return;
 		}
-		let view = {
-			data: src.data.subarray(sstride * proj.from),
-			stride: sstrides,
-		};
-		set_from_chunk(dest, view, projs);
+		set_from_chunk_binary(
+			dest,
+			{
+				data: src.data.subarray(sstride * proj.from * bytes_per_element),
+				stride: sstrides,
+			},
+			bytes_per_element,
+			projs,
+		);
 		return;
 	}
-
 	const [from, to, step] = proj.to;
 	const [sfrom, _, sstep] = proj.from;
 	const len = indices_len(from, to, step);
-
 	if (projs.length === 0) {
+		// NB: we have a contiguous block of memory
+		// so we can just copy over all the data at once.
 		if (
 			step === 1 && sstep === 1 && dstride === 1 && sstride === 1
 		) {
-			dest.data.set(src.data.subarray(sfrom, sfrom + len), from);
-		} else {
-			for (let i = 0; i < len; i++) {
-				dest.data[dstride * (from + step * i)] =
-					src.data[sstride * (sfrom + sstep * i)];
-			}
+			let offset = sfrom * bytes_per_element;
+			let size = len * bytes_per_element;
+			dest.data.set(
+				src.data.subarray(offset, offset + size),
+				from * bytes_per_element,
+			);
+			return;
+		}
+		// Otherwise, we have to copy over each element individually.
+		for (let i = 0; i < len; i++) {
+			let offset = sstride * (sfrom + sstep * i) * bytes_per_element;
+			dest.data.set(
+				src.data.subarray(offset, offset + bytes_per_element),
+				dstride * (from + step * i) * bytes_per_element,
+			);
 		}
 		return;
 	}
-
 	for (let i = 0; i < len; i++) {
-		set_from_chunk(
+		set_from_chunk_binary(
 			{
-				data: dest.data.subarray(dstride * (from + i * step)),
+				data: dest.data.subarray(
+					dstride * (from + i * step) * bytes_per_element,
+				),
 				stride: dstrides,
 			},
 			{
-				data: src.data.subarray(sstride * (sfrom + i * sstep)),
+				data: src.data.subarray(
+					sstride * (sfrom + i * sstep) * bytes_per_element,
+				),
 				stride: sstrides,
 			},
+			bytes_per_element,
 			projs,
 		);
 	}


### PR DESCRIPTION
All the array containers (except for `Array`) are backed by `ArrayBuffer`, but we currently have special handling for our string array containers.

This PR generalizes the indexing algorithm to operate on the "raw" bytes directly for any data. This way we _only_ move contigous blocks of binary data between src and target and avoid needing to move data out of the buffers into JS objects.
