### PR TITLE
fix(storage): Rename type `Writeable` to `Writable`

### DIFF
--- a/.changeset/serious-comics-lick.md
+++ b/.changeset/serious-comics-lick.md
@@ -2,4 +2,4 @@
 "@zarrita/storage": minor
 ---
 
-fix(storage): rename storage type Writeable to Writable
+fix(storage): Rename storage type `Writeable` to `Writable`

--- a/.changeset/serious-comics-lick.md
+++ b/.changeset/serious-comics-lick.md
@@ -1,0 +1,5 @@
+---
+"@zarrita/storage": minor
+---
+
+fix(storage): rename storage type Writeable to Writable

--- a/README.md
+++ b/README.md
@@ -85,14 +85,14 @@ classDiagram
 
     class core {
         - open(store: Readable)
-        - create(store: Writeable)
+        - create(store: Writable)
         - zarr.Array and zarr.Group
         - access and decode individual chunks
     }
 
     class storage {
         - Readable
-        - Writeable
+        - Writable
         - Map()
         - FetchStore()
         - FileSystemStore()

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -58,7 +58,7 @@ const arr = await zarr.open.v2(store, { kind: "array" });
 
 ## Create an Array <Badge type="tip" text="v3" />
 
-Requires the `store` to implement `Writeable`.
+Requires the `store` to implement `Writable`.
 
 ```js
 import * as zarr from "zarrita";
@@ -75,7 +75,7 @@ arr; // zarr.Array<"int32", FileSystemStore>
 
 ## Create a Group <Badge type="tip" text="v3" />
 
-Requires the `store` to implement `Writeable`.
+Requires the `store` to implement `Writable`.
 
 ```js
 import * as zarr from "zarrita";

--- a/docs/packages/storage.md
+++ b/docs/packages/storage.md
@@ -25,19 +25,19 @@ interface AsyncReadable<Options> {
 }
 ```
 
-and may optionally implement `Writeable` or `AsyncWriteable`:
+and may optionally implement `Writable` or `AsyncWritable`:
 
 ```typescript
-interface Writeable {
+interface Writable {
 	set(key: string, value: Uint8Array): void;
 }
 
-interface AsyncWriteable {
+interface AsyncWritable {
 	set(key: string, value: Uint8Array): Promise<void>;
 }
 ```
 
-That's it! `Readable`/`Writeable` are enough to allow an
+That's it! `Readable`/`Writable` are enough to allow an
 [ES6 Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map)
 to serve as the most basic backend, while also facilitating developers in
 creating their custom stores as needed.
@@ -69,7 +69,7 @@ const store = new FetchStore("http://localhost:8080/data.zarr", {
 });
 ```
 
-### FileSystemStore <Badge type="tip" text="Readable" /> <Badge type="tip" text="Writeable" />
+### FileSystemStore <Badge type="tip" text="Readable" /> <Badge type="tip" text="Writable" />
 
 Designed for JavaScript runtimes with file system access, the The
 **FileSystemStore** is designed for JavaScript runtimes with file system access

--- a/docs/what-is-zarrita.md
+++ b/docs/what-is-zarrita.md
@@ -32,7 +32,7 @@ Zarr.
 ### [@zarrita/storage](/packages/storage)
 
 - A collection of useful of storage backends for Zarr.
-- Implement your own `Readable` and (optionally `Writeable`) stores.
+- Implement your own `Readable` and (optionally `Writable`) stores.
 
 ### [@zarrita/core](/packages/core)
 

--- a/packages/storage/src/types.ts
+++ b/packages/storage/src/types.ts
@@ -33,20 +33,20 @@ export interface SyncReadable<Options = unknown> {
 	): Uint8Array | undefined;
 }
 
-export type Writeable = AsyncWriteable | SyncWriteable;
-export interface AsyncWriteable {
+export type Writable = AsyncWritable | SyncWritable;
+export interface AsyncWritable {
 	set(key: AbsolutePath, value: Uint8Array): Promise<void>;
 }
-export interface SyncWriteable {
+export interface SyncWritable {
 	set(key: AbsolutePath, value: Uint8Array): void;
 }
 
 export type AsyncMutable<GetOptions = unknown> =
 	& AsyncReadable<GetOptions>
-	& AsyncWriteable;
+	& AsyncWritable;
 export type SyncMutable<GetOptions = unknown> =
 	& SyncReadable<GetOptions>
-	& SyncWriteable;
+	& SyncWritable;
 export type Mutable<GetOptions = unknown> =
 	| AsyncMutable<GetOptions>
 	| SyncMutable<GetOptions>;


### PR DESCRIPTION
Uses the preferred and more common spelling for Writable interface.
