### PR TITLE
feat: add `withConsolidated` store helper

### DIFF
--- a/.changeset/popular-glasses-nail.md
+++ b/.changeset/popular-glasses-nail.md
@@ -1,0 +1,28 @@
+---
+"@zarrita/indexing": minor
+"zarrita": minor
+"@zarrita/core": minor
+---
+
+feat: Add `withConsolidated` store utility
+
+**BREAKING**: Replaces [`openConsolidated`](https://github.com/manzt/zarrita.js/pull/91)
+to provide a consistent interface for accessing consolidated and non-consolidated stores.
+
+```javascript
+import * as zarr from "zarrita";
+
+// non-consolidated
+let store = new zarr.FetchStore("https://localhost:8080/data.zarr");
+let grp = await zarr.open(store); // network request for .zgroup/.zattrs
+let foo = await zarr.open(grp.resolve("/foo"), { kind: array }); // network request for .zarray/.zattrs
+
+// consolidated
+let store = new zarr.FetchStore("https://localhost:8080/data.zarr");
+let consolidatedStore = await zarr.withConsolidated(store); // opens ./zmetadata
+let contents = consolidatedStore.contents(); // [ {path: "/", kind: "group" }, { path: "/foo", kind: "array" }, ...]
+let grp = await zarr.open(consolidatedStore); // no network request
+let foo = await zarr.open(grp.resolve(contents[1].path), {
+  kind: contents[1].kind,
+}); // no network request
+```

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
 		"test": "vitest --api",
 		"fmt": "dprint fmt",
 		"lint": "dprint check",
-		"publint": "pnpm --recursive --filter=\"./packages/**\" exec publint"
+		"publint": "pnpm --recursive --filter=\"./packages/**\" exec publint",
+		"errors": "vim -c \"copen\" -c \"cexpr system('npx build')\" -c \"wincmd p\""
 	},
 	"devDependencies": {
 		"@changesets/cli": "^2.27.1",

--- a/packages/core/__tests__/consolidated.test.ts
+++ b/packages/core/__tests__/consolidated.test.ts
@@ -9,7 +9,7 @@ import { Array as ZarrArray } from "../src/hierarchy.js";
 
 let __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
-describe("openConsolidated", () => {
+describe("withConsolidated", () => {
 	it("loads consolidated metadata", async () => {
 		let root = path.join(__dirname, "../../../fixtures/v2/data.zarr");
 		let store = await withConsolidated(new FileSystemStore(root));

--- a/packages/core/__tests__/consolidated.test.ts
+++ b/packages/core/__tests__/consolidated.test.ts
@@ -3,16 +3,18 @@ import * as path from "node:path";
 import * as url from "node:url";
 
 import { FileSystemStore } from "@zarrita/storage";
-import { openConsolidated } from "../src/consolidated.js";
+import { withConsolidated } from "../src/consolidated.js";
+import { open } from "../src/open.js";
+import { Array as ZarrArray } from "../src/hierarchy.js";
 
 let __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
 describe("openConsolidated", () => {
 	it("loads consolidated metadata", async () => {
 		let root = path.join(__dirname, "../../../fixtures/v2/data.zarr");
-		let h = await openConsolidated(new FileSystemStore(root));
+		let store = await withConsolidated(new FileSystemStore(root));
 		let map = new Map(
-			[...h.contents.values()].map((entry) => [entry.path, entry.kind]),
+			store.contents().map((x) => [x.path, x.kind]),
 		);
 		expect(map).toMatchInlineSnapshot(`
 			Map {
@@ -49,8 +51,12 @@ describe("openConsolidated", () => {
 
 	it("loads chunk data from underlying store", async () => {
 		let root = path.join(__dirname, "../../../fixtures/v2/data.zarr");
-		let h = await openConsolidated(new FileSystemStore(root));
-		let arr = h.open("/3d.chunked.mixed.i2.C", { kind: "array" });
+		let store = await withConsolidated(new FileSystemStore(root));
+		let entry = store.contents().find((x) => x.path === "/3d.chunked.mixed.i2.C")!;
+		let grp = await open(store, { kind: "group" });
+		let arr = await open(grp.resolve(entry.path), { kind: entry.kind });
+		expect(arr).toBeInstanceOf(ZarrArray);
+		// @ts-expect-error - we know this is an array
 		expect(await arr.getChunk([0, 0, 0])).toMatchInlineSnapshot(`
 			{
 			  "data": Int16Array [
@@ -80,10 +86,10 @@ describe("openConsolidated", () => {
 
 	it("loads and navigates from root", async () => {
 		let path_root = path.join(__dirname, "../../../fixtures/v2/data.zarr");
-		let h = await openConsolidated(new FileSystemStore(path_root));
-		let grp = h.root();
+		let store = await withConsolidated(new FileSystemStore(path_root));
+		let grp = await open(store, { kind: "group" });
 		expect(grp.kind).toBe("group");
-		let arr = h.open(grp.resolve("1d.chunked.i2"), { kind: "array" });
+		let arr = await open(grp.resolve("1d.chunked.i2"), { kind: "array" });
 		expect(arr.kind).toBe("array");
 	});
 });

--- a/packages/core/__tests__/consolidated.test.ts
+++ b/packages/core/__tests__/consolidated.test.ts
@@ -52,7 +52,9 @@ describe("withConsolidated", () => {
 	it("loads chunk data from underlying store", async () => {
 		let root = path.join(__dirname, "../../../fixtures/v2/data.zarr");
 		let store = await withConsolidated(new FileSystemStore(root));
-		let entry = store.contents().find((x) => x.path === "/3d.chunked.mixed.i2.C")!;
+		let entry = store.contents().find((x) =>
+			x.path === "/3d.chunked.mixed.i2.C"
+		)!;
 		let grp = await open(store, { kind: "group" });
 		let arr = await open(grp.resolve(entry.path), { kind: entry.kind });
 		expect(arr).toBeInstanceOf(ZarrArray);

--- a/packages/core/src/consolidated.ts
+++ b/packages/core/src/consolidated.ts
@@ -1,5 +1,6 @@
 import { type AbsolutePath, type Readable } from "@zarrita/storage";
 import { json_decode_object, json_encode_object } from "./util.js";
+import { KeyError, NodeNotFoundError } from "./errors.js";
 import type {
 	ArrayMetadata,
 	ArrayMetadataV2,
@@ -22,7 +23,11 @@ async function get_consolidated_metadata(
 	store: Readable,
 ): Promise<ConsolidatedMetadata> {
 	let bytes = await store.get("/.zmetadata");
-	if (!bytes) throw new Error("No consolidated metadata found.");
+	if (!bytes) {
+		throw new NodeNotFoundError("v2 consolidated metadata", {
+			cause: new KeyError("/.zmetadata"),
+		});
+	}
 	let meta: ConsolidatedMetadata = json_decode_object(bytes);
 	if (meta.zarr_consolidated_format !== 1) {
 		throw new Error("Unsupported consolidated format.");

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,6 +1,6 @@
 export class NodeNotFoundError extends Error {
 	constructor(context: string, options: { cause?: Error } = {}) {
-		super(`Node not found: ${context}`);
+		super(`Node not found: ${context}`, options);
 		this.name = "NodeNotFoundError";
 	}
 }

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,13 +1,13 @@
 export class NodeNotFoundError extends Error {
-	constructor(msg: string) {
-		super(msg);
+	constructor(context: string, options: { cause?: Error } = {}) {
+		super(`Node not found: ${context}`);
 		this.name = "NodeNotFoundError";
 	}
 }
 
 export class KeyError extends Error {
-	constructor(msg: string) {
-		super(msg);
+	constructor(path: string) {
+		super(`Missing key: ${path}`);
 		this.name = "KeyError";
 	}
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,5 +9,4 @@ export {
 export { open } from "./open.js";
 export { create } from "./create.js";
 export { registry } from "./codecs.js";
-export { openConsolidated } from "./consolidated.js";
 export type * from "./metadata.js";

--- a/packages/core/src/open.ts
+++ b/packages/core/src/open.ts
@@ -169,6 +169,11 @@ export function open<Store extends Readable>(
 	options: { kind: "array" },
 ): Promise<Array<DataType, Store>>;
 
+export async function open<Store extends Readable>(
+	location: Location<Store> | Store,
+	options: { kind?: "array" | "group" },
+): Promise<Array<DataType, Store> | Group<Store>>;
+
 export function open<Store extends Readable>(
 	location: Location<Store> | Store,
 ): Promise<Array<DataType, Store> | Group<Store>>;

--- a/packages/core/src/open.ts
+++ b/packages/core/src/open.ts
@@ -6,13 +6,14 @@ import type {
 	GroupMetadata,
 } from "./metadata.js";
 import { Array, Group, Location } from "./hierarchy.js";
-import { NodeNotFoundError } from "./errors.js";
+import { KeyError, NodeNotFoundError } from "./errors.js";
 import {
 	json_decode_object,
 	v2_to_v3_array_metadata,
 	v2_to_v3_group_metadata,
 } from "./util.js";
 
+let VERSION_COUNTER = create_version_counter();
 function create_version_counter() {
 	let version_counts = new WeakMap<Readable, { v2: number; v3: number }>();
 	function get_counts(store: Readable) {
@@ -30,7 +31,6 @@ function create_version_counter() {
 		},
 	};
 }
-let VERSION_COUNTER = create_version_counter();
 
 async function load_attrs(
 	location: Location<Readable>,
@@ -77,7 +77,9 @@ async function open_array_v2<Store extends Readable>(
 	let { path } = location.resolve(".zarray");
 	let meta = await location.store.get(path);
 	if (!meta) {
-		throw new NodeNotFoundError(path);
+		throw new NodeNotFoundError("v2 array", {
+			cause: new KeyError(path),
+		});
 	}
 	VERSION_COUNTER.increment(location.store, "v2");
 	return new Array(
@@ -94,7 +96,9 @@ async function open_group_v2<Store extends Readable>(
 	let { path } = location.resolve(".zgroup");
 	let meta = await location.store.get(path);
 	if (!meta) {
-		throw new NodeNotFoundError(path);
+		throw new NodeNotFoundError("v2 group", {
+			cause: new KeyError(path),
+		});
 	}
 	VERSION_COUNTER.increment(location.store, "v2");
 	return new Group(
@@ -110,7 +114,9 @@ async function _open_v3<Store extends Readable>(
 	let { store, path } = location.resolve("zarr.json");
 	let meta = await location.store.get(path);
 	if (!meta) {
-		throw new NodeNotFoundError(path);
+		throw new NodeNotFoundError("v3 array or group", {
+			cause: new KeyError(path),
+		});
 	}
 	let meta_doc: ArrayMetadata<DataType> | GroupMetadata = json_decode_object(
 		meta,
@@ -186,8 +192,8 @@ export async function open<Store extends Readable>(
 	location: Location<Store> | Store,
 	options: { kind?: "array" | "group" } = {},
 ): Promise<Array<DataType, Store> | Group<Store>> {
-	const store = "store" in location ? location.store : location;
-	const version_max = VERSION_COUNTER.version_max(store);
+	let store = "store" in location ? location.store : location;
+	let version_max = VERSION_COUNTER.version_max(store);
 	// Use the open function for the version with the most successful opens.
 	// Note that here we use the dot syntax to access the open functions
 	// because this enables us to use vi.spyOn during testing.

--- a/packages/indexing/src/set.ts
+++ b/packages/indexing/src/set.ts
@@ -1,4 +1,4 @@
-import { _internal_get_array_context, KeyError } from "@zarrita/core";
+import { _internal_get_array_context } from "@zarrita/core";
 import type { Mutable } from "@zarrita/storage";
 import type { Array, Chunk, DataType, Scalar, TypedArray } from "@zarrita/core";
 
@@ -78,15 +78,7 @@ export async function set<Dtype extends DataType, Arr extends Chunk<Dtype>>(
 				}
 			} else {
 				// partially replace the contents of this chunk
-				chunk_data = await arr.getChunk(chunk_coords)
-					.then(({ data }) => data)
-					.catch((err) => {
-						if (!(err instanceof KeyError)) throw err;
-						const empty = new context.TypedArray(chunk_size);
-						// @ts-expect-error
-						if (arr.fill_value) empty.fill(arr.fill_value);
-						return empty;
-					});
+				chunk_data = await arr.getChunk(chunk_coords).then(({ data }) => data);
 
 				const chunk = setter.prepare(
 					chunk_data,

--- a/packages/zarrita/index.test.ts
+++ b/packages/zarrita/index.test.ts
@@ -15,7 +15,6 @@ it("exports all the things", () => {
 		  "create": [Function],
 		  "get": [Function],
 		  "open": [Function],
-		  "openConsolidated": [Function],
 		  "registry": Map {
 		    "blosc" => [Function],
 		    "gzip" => [Function],


### PR DESCRIPTION
Towards #117

Introduces the `withConsolidated` store helper (?). Looks for v2 consolidated metadata,
and returns known `contents`. "Opening" paths from the store is essentially free for
consolidated data (and will not make a network request)

```ts
let store = await withConsolidated(new FetchStore("http://localhost:8080"));
let contents = store.contents() // [ {path: "/", kind: "group" }, { path: "/foo", kind: "array" }, ...]
let foo = await open(contents[1].path, { kind: "array" });
```
