### PR TITLE
Update exports for `@zarrita/ndarray`

### DIFF
--- a/packages/ndarray/package.json
+++ b/packages/ndarray/package.json
@@ -6,8 +6,8 @@
 	"sideEffects": false,
 	"exports": {
 		".": {
-			"types": "./index.js",
-			"import": "./index.js"
+			"types": "./src/index.ts",
+			"import": "./src/index.ts"
 		}
 	},
 	"dependencies": {


### PR DESCRIPTION
👋 I've been (finally!) playing around with integrating `@carbonplan/maps` with `zarrita`. It's been a pretty smooth transition, except when I have a basic import from `@zarrita/ndarray`
```js
import { get } from '@zarrita/ndarray'
```
I see the following error
```
Module not found: Package path . is not exported from package
/Users/katamartin/carbonplan/maps/node_modules/@zarrita/ndarray (see exports field in 
/Users/katamartin/carbonplan/maps/node_modules/@zarrita/ndarray/package.json)
```
I think this should be resolved by updating the `exports` for`@zarrita/ndarray` to point to the correct index files (and match the [`@zarrita/storage` exports](https://github.com/manzt/zarrita.js/blob/ee6a672904714d43dcbc8d97d1b89220ada16a3f/packages/storage/package.json#L12-L13)!). I haven't actually tested this, so I very well may be missing something here!