### PR TITLE
feat(core): Add `tryWithConsolidated` helper

### DIFF
--- a/.changeset/green-pandas-argue.md
+++ b/.changeset/green-pandas-argue.md
@@ -1,0 +1,23 @@
+---
+"@zarrita/core": minor
+---
+
+feat: Add `tryWithConsolidated` store helper
+
+Provides a convenient way to open a store that may or may not have consolidated
+metadata. Ideal for usage senarios with known access paths, since store with
+consolidated metadata do not incur additional network requests when accessing
+underlying groups and arrays.
+
+```js
+import * as zarr from "zarrita";
+
+let store = await zarr.tryWithConsolidated(
+  new zarr.FetchStore("https://localhost:8080/data.zarr");
+);
+
+// The following do not read from the store
+// (make network requests) if it is consolidated.
+let grp = await zarr.open(store, { kind: "group" });
+let foo = await zarr.open(grp.resolve("foo"), { kind: "array" });
+```

--- a/packages/core/__tests__/consolidated.test.ts
+++ b/packages/core/__tests__/consolidated.test.ts
@@ -100,15 +100,15 @@ describe("tryWithConsolidated", () => {
 	it("creates Listable from consolidated store", async () => {
 		let root = path.join(__dirname, "../../../fixtures/v2/data.zarr");
 		let store = await tryWithConsolidated(new FileSystemStore(root));
-		expect("contents" in store).toBe(true);
+		expect(store).toHaveProperty("contents");
 	});
 
 	it("falls back to original store if missing consolidated metadata", async () => {
 		let root = path.join(
 			__dirname,
-			"../../../fixtures/v2/data.zarr/3d.chunked.mixed.i2.C",
+			"../../../fixtures/v2/data.zarr/3d.contiguous.i2",
 		);
 		let store = await tryWithConsolidated(new FileSystemStore(root));
-		expect("contents" in store).toBe(false);
+		expect(store).toBeInstanceOf(FileSystemStore);
 	});
 });

--- a/packages/core/__tests__/consolidated.test.ts
+++ b/packages/core/__tests__/consolidated.test.ts
@@ -94,6 +94,16 @@ describe("withConsolidated", () => {
 		let arr = await open(grp.resolve("1d.chunked.i2"), { kind: "array" });
 		expect(arr.kind).toBe("array");
 	});
+
+	it("throws if consolidated metadata is missing", async () => {
+		let root = path.join(
+			__dirname,
+			"../../../fixtures/v2/data.zarr/3d.contiguous.i2",
+		);
+		await expect(() => withConsolidated(new FileSystemStore(root)))
+			.rejects
+			.toThrowErrorMatchingInlineSnapshot('"Node not found: v2 consolidated metadata"');
+	});
 });
 
 describe("tryWithConsolidated", () => {

--- a/packages/core/__tests__/consolidated.test.ts
+++ b/packages/core/__tests__/consolidated.test.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import * as url from "node:url";
 
 import { FileSystemStore } from "@zarrita/storage";
-import { withConsolidated } from "../src/consolidated.js";
+import { tryWithConsolidated, withConsolidated } from "../src/consolidated.js";
 import { open } from "../src/open.js";
 import { Array as ZarrArray } from "../src/hierarchy.js";
 
@@ -93,5 +93,22 @@ describe("withConsolidated", () => {
 		expect(grp.kind).toBe("group");
 		let arr = await open(grp.resolve("1d.chunked.i2"), { kind: "array" });
 		expect(arr.kind).toBe("array");
+	});
+});
+
+describe("tryWithConsolidated", () => {
+	it("creates Listable from consolidated store", async () => {
+		let root = path.join(__dirname, "../../../fixtures/v2/data.zarr");
+		let store = await tryWithConsolidated(new FileSystemStore(root));
+		expect("contents" in store).toBe(true);
+	});
+
+	it("falls back to original store if missing consolidated metadata", async () => {
+		let root = path.join(
+			__dirname,
+			"../../../fixtures/v2/data.zarr/3d.chunked.mixed.i2.C",
+		);
+		let store = await tryWithConsolidated(new FileSystemStore(root));
+		expect("contents" in store).toBe(false);
 	});
 });

--- a/packages/core/__tests__/consolidated.test.ts
+++ b/packages/core/__tests__/consolidated.test.ts
@@ -6,6 +6,7 @@ import { FileSystemStore } from "@zarrita/storage";
 import { tryWithConsolidated, withConsolidated } from "../src/consolidated.js";
 import { open } from "../src/open.js";
 import { Array as ZarrArray } from "../src/hierarchy.js";
+import { NodeNotFoundError } from "../src/errors.js";
 
 let __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
@@ -100,9 +101,11 @@ describe("withConsolidated", () => {
 			__dirname,
 			"../../../fixtures/v2/data.zarr/3d.contiguous.i2",
 		);
-		await expect(() => withConsolidated(new FileSystemStore(root)))
-			.rejects
-			.toThrowErrorMatchingInlineSnapshot('"Node not found: v2 consolidated metadata"');
+		let try_open = () => withConsolidated(new FileSystemStore(root));
+		await expect(try_open).rejects.toThrowError(NodeNotFoundError);
+		await expect(try_open).rejects.toThrowErrorMatchingInlineSnapshot(
+			'"Node not found: v2 consolidated metadata"',
+		);
 	});
 });
 

--- a/packages/core/__tests__/open.test.ts
+++ b/packages/core/__tests__/open.test.ts
@@ -463,9 +463,12 @@ describe("v2", () => {
 	});
 
 	it("throws when group is not found", async () => {
-		let try_open = () => open.v2(store.resolve("/not/a/group"), { kind: "group" });
+		let try_open = () =>
+			open.v2(store.resolve("/not/a/group"), { kind: "group" });
 		await expect(try_open).rejects.toThrowError(NodeNotFoundError);
-		await expect(try_open).rejects.toThrowErrorMatchingInlineSnapshot('"Node not found: v2 group"');
+		await expect(try_open).rejects.toThrowErrorMatchingInlineSnapshot(
+			'"Node not found: v2 group"',
+		);
 	});
 
 	describe("opens array from group", async () => {

--- a/packages/core/__tests__/open.test.ts
+++ b/packages/core/__tests__/open.test.ts
@@ -463,9 +463,9 @@ describe("v2", () => {
 	});
 
 	it("throws when group is not found", async () => {
-		await expect(open.v2(store.resolve("/not/a/group"), { kind: "group" }))
-			.rejects
-			.toThrow(NodeNotFoundError);
+		let try_open = () => open.v2(store.resolve("/not/a/group"), { kind: "group" });
+		await expect(try_open).rejects.toThrowError(NodeNotFoundError);
+		await expect(try_open).rejects.toThrowErrorMatchingInlineSnapshot('"Node not found: v2 group"');
 	});
 
 	describe("opens array from group", async () => {
@@ -717,9 +717,12 @@ describe("v3", () => {
 	});
 
 	it("throws when group not found", async () => {
-		await expect(open.v3(store.resolve("/not/a/group"), { kind: "group" }))
-			.rejects
-			.toThrow(NodeNotFoundError);
+		const try_open = () =>
+			open.v3(store.resolve("/not/a/group"), { kind: "group" });
+		await expect(try_open).rejects.toThrowError(NodeNotFoundError);
+		await expect(try_open).rejects.toThrowErrorMatchingInlineSnapshot(
+			'"Node not found: v3 array or group"',
+		);
 	});
 
 	describe("opens array from group", async () => {

--- a/packages/core/src/consolidated.ts
+++ b/packages/core/src/consolidated.ts
@@ -77,17 +77,11 @@ function is_v3(meta: Metadata): meta is ArrayMetadata | GroupMetadata {
 export async function withConsolidated<Store extends Readable>(
 	store: Store,
 ): Promise<Listable<Store>> {
-	let known_meta: Record<AbsolutePath, Metadata> =
-		await get_consolidated_metadata(store)
-			.then((meta) => {
-				let new_meta: Record<AbsolutePath, Metadata> = {};
-				for (let [key, value] of Object.entries(meta.metadata)) {
-					new_meta[`/${key}`] = value;
-				}
-				return new_meta;
-			})
-			.catch(() => ({}));
-
+	let v2_meta = await get_consolidated_metadata(store);
+	let known_meta: Record<AbsolutePath, Metadata> = {};
+	for (let [key, value] of Object.entries(v2_meta.metadata)) {
+		known_meta[`/${key}`] = value;
+	}
 	return {
 		async get(
 			...args: Parameters<Store["get"]>

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,4 +9,5 @@ export {
 export { open } from "./open.js";
 export { create } from "./create.js";
 export { registry } from "./codecs.js";
+export { tryWithConsolidated, withConsolidated } from "./consolidated.js";
 export type * from "./metadata.js";

--- a/packages/zarrita/index.test.ts
+++ b/packages/zarrita/index.test.ts
@@ -29,6 +29,8 @@ it("exports all the things", () => {
 		  "root": [Function],
 		  "set": [Function],
 		  "slice": [Function],
+		  "tryWithConsolidated": [Function],
+		  "withConsolidated": [Function],
 		}
 	`);
 });


### PR DESCRIPTION
Adds `tryWithConsolidated` helper to provide a consistent interface for reading from a store that may or may not be consolidated. Consolidated stores will not incur additional network requests when reading underlying groups and arrays.
