### PR TITLE
fix(core): Avoid importing types from top-level @zarrita/storage

### DIFF
--- a/packages/core/src/consolidated.ts
+++ b/packages/core/src/consolidated.ts
@@ -1,4 +1,4 @@
-import { type AbsolutePath, type Readable } from "@zarrita/storage";
+import type { AbsolutePath, Readable } from "@zarrita/storage";
 import { json_decode_object, json_encode_object } from "./util.js";
 import { KeyError, NodeNotFoundError } from "./errors.js";
 import type {


### PR DESCRIPTION
Changes

```ts
import { type ... } from "@zarrita/storage";
```

to

```ts
import type { ... } from "@zarrita/storage"
```

so the import is dropped by TypeScript in the build output. Prevents bundlers from typing to import from `@zarrita/storage`.
