### PR TITLE
Add options for ReferenceStore

### DIFF
--- a/.changeset/something.md
+++ b/.changeset/something.md
@@ -1,0 +1,5 @@
+---
+"@zarrita/storage": patch
+---
+
+Add support for passing fetch options to ReferenceStore.

--- a/packages/storage/src/fetch.ts
+++ b/packages/storage/src/fetch.ts
@@ -1,5 +1,5 @@
 import type { AbsolutePath, AsyncReadable, RangeQuery } from "./types.js";
-import { fetch_range } from "./util.js";
+import { fetch_range, merge_init } from "./util.js";
 
 function resolve(root: string | URL, path: AbsolutePath): URL {
 	const base = typeof root === "string" ? new URL(root) : root;
@@ -72,14 +72,7 @@ class FetchStore implements AsyncReadable<RequestInit> {
 	}
 
 	#merge_init(overrides: RequestInit) {
-		return {
-			...this.#overrides,
-			...overrides,
-			headers: {
-				...this.#overrides.headers,
-				...overrides.headers,
-			},
-		};
+		return merge_init(this.#overrides, overrides);
 	}
 
 	async get(

--- a/packages/storage/src/ref.ts
+++ b/packages/storage/src/ref.ts
@@ -36,7 +36,6 @@ type ReferenceEntry = string | [url: string | null] | [
 
 interface ReferenceStoreOptions {
 	target?: string | URL;
-	preferTarget?: boolean;
 	overrides?: RequestInit;
 }
 
@@ -72,12 +71,6 @@ class ReferenceStore implements AsyncReadable<RequestInit> {
 
 		let [urlOrNull, offset, size] = ref;
 		let url = urlOrNull ?? this.#opts.target;
-		if (this.#opts.target && this.#opts.preferTarget) {
-			// If preferTarget is true, then the target URL
-			// should take precedence regardless of whether
-			// a URL was present in the reference spec.
-			url = this.#opts.target;
-		}
 		if (!url) {
 			throw Error(`No url for key ${key}, and no target url provided.`);
 		}

--- a/packages/storage/src/ref.ts
+++ b/packages/storage/src/ref.ts
@@ -104,7 +104,7 @@ class ReferenceStore implements AsyncReadable<RequestInit> {
 	}
 
 	static async fromUrl(url: string | URL, opts?: ReferenceStoreOptions) {
-		let spec = await fetch(url).then((res) => res.json());
+		let spec = await fetch(url, opts?.overrides).then((res) => res.json());
 		return ReferenceStore.fromSpec(spec, opts);
 	}
 }

--- a/packages/storage/src/util.ts
+++ b/packages/storage/src/util.ts
@@ -40,3 +40,18 @@ export function fetch_range(
 	}
 	return fetch(url, opts);
 }
+
+export function merge_init(
+	storeOverrides: RequestInit,
+	requestOverrides: RequestInit,
+) {
+	// Request overrides take precedence over storeOverrides.
+	return {
+		...storeOverrides,
+		...requestOverrides,
+		headers: {
+			...storeOverrides.headers,
+			...requestOverrides.headers,
+		},
+	};
+}


### PR DESCRIPTION
This pull request adds two options for the ReferenceStore:
- `overrides` to specify fetch options like auth headers
  - ~Should these same overrides also be used in the fetch call within `ReferenceStore.fromUrl`?~
- ~`preferTarget` to denote that the `opts.target` URL should be used regardless of whether a URL is present in the reference JSON~
  - I would also be open to removing this change if it is unfavorable as it can alternatively be achieved in user-land by the user manually null-ing the URLs within the contents of the ReferenceEntrys before passing into `fromSpec`
  