### PR TITLE
zarrv3 handle missing chunk_key_encoding.configuration

### DIFF
--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -94,7 +94,7 @@ export type ArrayMetadata<D extends DataType = DataType> = {
 	};
 	chunk_key_encoding: {
 		name: "v2" | "default";
-		configuration: {
+		configuration?: {
 			separator: "." | "/";
 		};
 	};

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -114,7 +114,7 @@ export function create_chunk_key_encoder({
 			["c", ...chunk_coords].join(configuration?.separator || "/");
 	}
 	if (name === "v2") {
-		return (chunk_coords) => chunk_coords.join(configuration.separator) || "0";
+		return (chunk_coords) => chunk_coords.join(configuration?.separator) || ".";
 	}
 	throw new Error(`Unknown chunk key encoding: ${name}`);
 }

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -111,7 +111,7 @@ export function create_chunk_key_encoder({
 }: ArrayMetadata["chunk_key_encoding"]): (chunk_coords: number[]) => string {
 	if (name === "default") {
 		return (chunk_coords) =>
-			["c", ...chunk_coords].join(configuration.separator);
+			["c", ...chunk_coords].join(configuration?.separator || "/");
 	}
 	if (name === "v2") {
 		return (chunk_coords) => chunk_coords.join(configuration.separator) || "0";


### PR DESCRIPTION
Fixes #186

I looked at tests to see if I could make a failing test that was fixed by this change...
Tried removing `configuration` from a sample (and corresponding types) but this didn't cause any tests to fail and was unsure if you'd want these changes?

```
diff --git a/packages/core/__tests__/open.test.ts b/packages/core/__tests__/open.test.ts
index fd1d0da..e427d59 100644
--- a/packages/core/__tests__/open.test.ts
+++ b/packages/core/__tests__/open.test.ts
@@ -73,10 +73,7 @@ describe("open (v2 vs v3 priority)", () => {
                                        },
                                        codecs: [],
                                        chunk_key_encoding: {
-                                               name: "default",
-                                               configuration: {
-                                                       separator: "/",
-                                               },
+                                               name: "default"
                                        },
                                        fill_value: null,
                                        attributes: {},
diff --git a/packages/core/src/metadata.ts b/packages/core/src/metadata.ts
index 8aa22db..b2fc641 100644
--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -94,7 +94,7 @@ export type ArrayMetadata<D extends DataType = DataType> = {
        };
        chunk_key_encoding: {
                name: "v2" | "default";
-               configuration: {
+               configuration?: {
                        separator: "." | "/";
                };
        };
diff --git a/packages/core/src/util.ts b/packages/core/src/util.ts

```
