### PR TITLE
feat(storage)!: Throw an error for 403 HTTP responses

### DIFF
--- a/.changeset/smooth-scissors-end.md
+++ b/.changeset/smooth-scissors-end.md
@@ -1,0 +1,5 @@
+---
+"@zarrita/storage": patch
+---
+
+`FetchStore` throws an error for 403 (forbidden) responses. This is a **breaking** change because previously `404` and `403` responses were treated the same way. Now, only `404` responses signify a "missing" key from the store.

--- a/packages/storage/src/fetch.ts
+++ b/packages/storage/src/fetch.ts
@@ -16,7 +16,7 @@ function resolve(root: string | URL, path: AbsolutePath): URL {
 async function handle_response(
 	response: Response,
 ): Promise<Uint8Array | undefined> {
-	if (response.status === 404 || response.status === 403) {
+	if (response.status === 404) {
 		return undefined;
 	}
 	if (response.status === 200 || response.status === 206) {


### PR DESCRIPTION
`FetchStore` now throws an error for 403 (forbidden) responses. This is a **breaking** change because previously `404` and `403` responses were treated the same way. Now, only `404` responses signify a "missing" key from the store.

I believe this carries the correct semantics around 404 and 403 responses. If you disagree, please let me know and we can discuss how to extend the `FetchStore` to be more flexible with handling responses.

see: https://github.com/hms-dbmi/vizarr/pull/214

