### PR TITLE
add default exports to all packages

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,7 +10,8 @@
 	"exports": {
 		".": {
 			"types": "./src/index.ts",
-			"import": "./src/index.ts"
+			"import": "./src/index.ts",
+			"default": "./src/index.ts"
 		}
 	},
 	"dependencies": {

--- a/packages/indexing/package.json
+++ b/packages/indexing/package.json
@@ -7,7 +7,8 @@
 	"exports": {
 		".": {
 			"types": "./src/index.ts",
-			"import": "./src/index.ts"
+			"import": "./src/index.ts",
+			"default": "./src/index.ts"
 		}
 	},
 	"files": [

--- a/packages/ndarray/package.json
+++ b/packages/ndarray/package.json
@@ -7,7 +7,8 @@
 	"exports": {
 		".": {
 			"types": "./src/index.ts",
-			"import": "./src/index.ts"
+			"import": "./src/index.ts",
+			"default": "./src/index.ts"
 		}
 	},
 	"dependencies": {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -10,23 +10,28 @@
 	"exports": {
 		".": {
 			"types": "./src/index.ts",
-			"import": "./src/index.ts"
+			"import": "./src/index.ts",
+			"default": "./src/index.ts"
 		},
 		"./fetch": {
 			"types": "./src/fetch.ts",
-			"import": "./src/fetch.ts"
+			"import": "./src/fetch.ts",
+			"default": "./src/fetch.ts"
 		},
 		"./fs": {
 			"types": "./src/fs.ts",
-			"import": "./src/fs.ts"
+			"import": "./src/fs.ts",
+			"default": "./src/fs/ts"
 		},
 		"./ref": {
 			"types": "./src/ref.ts",
-			"import": "./src/ref.ts"
+			"import": "./src/ref.ts",
+			"default": "./src/ref.ts"
 		},
 		"./zip": {
 			"types": "./src/zip.ts",
-			"import": "./src/zip.ts"
+			"import": "./src/zip.ts",
+			"default": "./src/zip.ts"
 		}
 	},
 	"dependencies": {

--- a/packages/typedarray/package.json
+++ b/packages/typedarray/package.json
@@ -7,7 +7,8 @@
 	"exports": {
 		".": {
 			"types": "./src/index.ts",
-			"import": "./src/index.ts"
+			"import": "./src/index.ts",
+			"default": "./src/index.ts"
 		}
 	},
 	"files": ["dist"],

--- a/packages/zarrita/package.json
+++ b/packages/zarrita/package.json
@@ -12,7 +12,8 @@
 	"exports": {
 		".": {
 			"types": "./index.ts",
-			"import": "./index.ts"
+			"import": "./index.ts",
+			"default": "./index.ts"
 		}
 	},
 	"dependencies": {


### PR DESCRIPTION
We are using Jest to do unit tests on a project that is newly integrating with some code that imports zarrita.
Jest simply can not resolve zarrita imports and we determined that it's because jest can't understand the "export" construct in the package.jsons of the zarrita packages.

We found that just adding a "default" entry suddenly made everything work.
We are unsure if this would break anything else but it seems harmless and allows the module resolution to happen correctly at least in Jest.