### PR TITLE
Fix TypedArray types for TypeScript < 5.7

### DIFF
--- a/.changeset/breezy-windows-notice.md
+++ b/.changeset/breezy-windows-notice.md
@@ -1,0 +1,12 @@
+---
+"@zarrita/core": patch
+"@zarrita/indexing": patch
+"@zarrita/ndarray": patch
+"@zarrita/storage": patch
+"@zarrita/typedarray": patch
+"zarrita": patch
+---
+
+Fix TypedArray types for TypeScript < 5.7
+
+TypeScript changed the typing behavior of all `TypedArray` objects to now be generic over the underlying `ArrayBufferLike` type. In order to have our types be consistent with these changes, we needed to specify the `ArrayBuffer` explicitly, but that breaks for older versions of TypeScript. This PR fixes the version of TypeScript to 5.6. We will need to bump again when we want to support 5.7.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"@svitejs/changesets-changelog-github-compact": "^1.2.0",
 		"@types/node": "^22.10.1",
 		"publint": "^0.2.12",
-		"typescript": "5.7.2",
+		"typescript": "5.6.3",
 		"vitest": "^2.1.8"
 	},
 	"packageManager": "pnpm@9.7.0"

--- a/packages/core/src/codecs/vlen-utf8.ts
+++ b/packages/core/src/codecs/vlen-utf8.ts
@@ -18,7 +18,7 @@ export class VLenUTF8 {
 		throw new Error("Method not implemented.");
 	}
 
-	decode(bytes: Uint8Array<ArrayBuffer>): Chunk<ObjectType> {
+	decode(bytes: Uint8Array): Chunk<ObjectType> {
 		let decoder = new TextDecoder();
 		let view = new DataView(bytes.buffer);
 		let data = Array(view.getUint32(0, true));

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -131,16 +131,16 @@ export type GroupMetadataV2 = {
 };
 
 // biome-ignore format: easier to read this way
-export type TypedArray<D extends DataType> = D extends Int8 ? Int8Array<ArrayBuffer>
-	: D extends Int16 ? Int16Array<ArrayBuffer>
-	: D extends Int32 ? Int32Array<ArrayBuffer>
-	: D extends Int64 ? BigInt64Array<ArrayBuffer>
-	: D extends Uint8 ? Uint8Array<ArrayBuffer>
-	: D extends Uint16 ? Uint16Array<ArrayBuffer>
-	: D extends Uint32 ? Uint32Array<ArrayBuffer>
-	: D extends Uint64 ? BigUint64Array<ArrayBuffer>
-	: D extends Float32 ? Float32Array<ArrayBuffer>
-	: D extends Float64 ? Float64Array<ArrayBuffer>
+export type TypedArray<D extends DataType> = D extends Int8 ? Int8Array
+	: D extends Int16 ? Int16Array
+	: D extends Int32 ? Int32Array
+	: D extends Int64 ? BigInt64Array
+	: D extends Uint8 ? Uint8Array
+	: D extends Uint16 ? Uint16Array
+	: D extends Uint32 ? Uint32Array
+	: D extends Uint64 ? BigUint64Array
+	: D extends Float32 ? Float32Array
+	: D extends Float64 ? Float64Array
 	: D extends Bool ? BoolArray
 	: D extends UnicodeStr ? UnicodeStringArray
 	: D extends ByteStr ? ByteStringArray

--- a/packages/typedarray/__tests__/index.test.ts
+++ b/packages/typedarray/__tests__/index.test.ts
@@ -188,9 +188,7 @@ describe("ByteStringArray", () => {
 		let data = new TextEncoder().encode(
 			"Hello\x00world!\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
 		);
-		// @ts-expect-error - We know this is an ArrayBuffer but `encode` returns Uint8Array<ArrayBufferLike>
-		let buffer: ArrayBuffer = data.buffer;
-		let arr = new ByteStringArray(2, buffer, 3, 4);
+		let arr = new ByteStringArray(2, data.buffer, 3, 4);
 		expect({
 			length: arr.length,
 			BYTES_PER_ELEMENT: arr.BYTES_PER_ELEMENT,

--- a/packages/typedarray/src/index.ts
+++ b/packages/typedarray/src/index.ts
@@ -1,5 +1,5 @@
 export class BoolArray {
-	#bytes: Uint8Array<ArrayBuffer>;
+	#bytes: Uint8Array;
 
 	constructor(size: number);
 	constructor(arr: Iterable<boolean>);
@@ -59,7 +59,7 @@ export class BoolArray {
 }
 
 export class ByteStringArray {
-	_data: Uint8Array<ArrayBuffer>;
+	_data: Uint8Array;
 	chars: number;
 	#encoder: TextEncoder;
 
@@ -148,7 +148,7 @@ export class ByteStringArray {
 }
 
 export class UnicodeStringArray {
-	#data: Int32Array<ArrayBuffer>;
+	#data: Int32Array;
 	chars: number;
 
 	constructor(chars: number, size: number);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^0.2.12
         version: 0.2.12
       typescript:
-        specifier: 5.7.2
-        version: 5.7.2
+        specifier: 5.6.3
+        version: 5.6.3
       vitest:
         specifier: ^2.1.8
         version: 2.1.8(@types/node@22.10.1)
@@ -1387,6 +1387,11 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  typescript@5.6.3:
+    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   typescript@5.7.2:
     resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
@@ -2788,7 +2793,10 @@ snapshots:
 
   tr46@0.0.3: {}
 
-  typescript@5.7.2: {}
+  typescript@5.6.3: {}
+
+  typescript@5.7.2:
+    optional: true
 
   undici-types@6.20.0: {}
 


### PR DESCRIPTION
TypeScript changed the typing behavior of all `TypedArray` objects to
now be generic over the underlying `ArrayBufferLike` type. In order to
have our types be consistent with these changes, we needed to specify
the `ArrayBuffer` explicitly, but that breaks for older versions of
TypeScript. This PR fixes the version of TypeScript to 5.6. We will need
to bump again when we want to support 5.7.
