### PR TITLE
Support TypeScript 5.6 and 5.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"@svitejs/changesets-changelog-github-compact": "^1.2.0",
 		"@types/node": "^22.10.1",
 		"publint": "^0.2.12",
-		"typescript": "5.6.3",
+		"typescript": "5.7.2",
 		"vitest": "^2.1.8"
 	},
 	"packageManager": "pnpm@9.7.0"

--- a/packages/core/src/codecs/vlen-utf8.ts
+++ b/packages/core/src/codecs/vlen-utf8.ts
@@ -26,7 +26,9 @@ export class VLenUTF8 {
 		for (let i = 0; i < data.length; i++) {
 			let item_length = view.getUint32(pos, true);
 			pos += 4;
-			data[i] = decoder.decode(bytes.buffer.slice(pos, pos + item_length));
+			// @ts-expect-error - we know this is an ArrayBuffer, TS just isn't smart enough to know it's not a SharedArrayBuffer
+			let buffer: ArrayBuffer = bytes.buffer;
+			data[i] = decoder.decode(buffer.slice(pos, pos + item_length));
 			pos += item_length;
 		}
 		return { data, shape: this.#shape, stride: this.#strides };

--- a/packages/indexing/__tests__/setter.test.ts
+++ b/packages/indexing/__tests__/setter.test.ts
@@ -36,6 +36,7 @@ function to_c<D extends DataType>({ data, shape, stride }: Chunk<D>): Chunk<D> {
 	let size = shape.reduce((a, b) => a * b, 1);
 	// @ts-expect-error - We know constructor exists on TypedArray
 	let out = ndarray(new data.constructor(size), shape);
+	// @ts-expect-error - ndarray types are a mismatch with ours but this operation is safe
 	assign(out, ndarray(data, shape, stride));
 	return out;
 }
@@ -59,7 +60,7 @@ describe("setter", () => {
 			1, 1, 1, 1,
 			1, 1, 1, 1,
 			1, 1, 1, 1,
-			
+
 			1, 1, 1, 1,
 			1, 1, 1, 1,
 			1, 1, 1, 1,
@@ -79,7 +80,7 @@ describe("setter", () => {
 			1, 0, 0, 0,
 			0, 0, 0, 0,
 			0, 0, 0, 0,
-			
+
 			0, 0, 0, 0,
 			0, 0, 0, 0,
 			0, 0, 0, 0,
@@ -91,7 +92,7 @@ describe("setter", () => {
 			1, 0, 0, 0,
 			0, 0, 0, 0,
 			0, 0, 0, 0,
-			
+
 			0, 0, 0, 0,
 			0, 2, 0, 0,
 			0, 0, 0, 0,
@@ -103,7 +104,7 @@ describe("setter", () => {
 			1, 0, 0, 0,
 			0, 0, 0, 0,
 			0, 0, 0, 0,
-			
+
 			0, 0, 0, 0,
 			0, 2, 0, 0,
 			0, 0, 0, 3,
@@ -115,7 +116,7 @@ describe("setter", () => {
 			1, 0, 0, 0,
 			0, 0, 0, 0,
 			0, 0, 0, 0,
-			
+
 			0, 0, 0, 0,
 			0, 2, 0, 0,
 			0, 0, 4, 3,
@@ -136,7 +137,7 @@ describe("setter", () => {
 			1, 0, 0, 0,
 			1, 0, 0, 0,
 			0, 0, 0, 0,
-			
+
 			1, 0, 0, 0,
 			1, 0, 0, 0,
 			0, 0, 0, 0,
@@ -150,7 +151,7 @@ describe("setter", () => {
 			2, 2, 2, 2,
 			2, 2, 2, 2,
 			2, 2, 2, 2,
-			
+
 			1, 0, 0, 0,
 			1, 0, 0, 0,
 			0, 0, 0, 0,
@@ -190,7 +191,7 @@ describe("setter", () => {
 			2, 2, 2, 2,
 			2, 2, 2, 2,
 			2, 2, 2, 2,
-			
+
 			1, 0, 0, 0,
 			1, 0, 0, 0,
 			0, 0, 0, 0,
@@ -222,7 +223,7 @@ describe("setter", () => {
 			1, 1, 0, 0,
 			1, 1, 0, 0,
 			0, 0, 0, 0,
-			
+
 			1, 1, 0, 0,
 			1, 1, 0, 0,
 			0, 0, 0, 0,
@@ -254,7 +255,7 @@ describe("setter", () => {
 			2, 0, 2, 0,
 			0, 0, 0, 0,
 			2, 0, 2, 0,
-			
+
 			2, 0, 2, 0,
 			0, 0, 0, 0,
 			2, 0, 2, 0,
@@ -274,7 +275,7 @@ describe("setter", () => {
 				2, 0, 2, 0,
 				0, 0, 0, 0,
 				2, 0, 2, 0,
-				
+
 				2, 0, 2, 0,
 				0, 0, 0, 0,
 				2, 0, 2, 0,
@@ -318,7 +319,7 @@ describe("setter", () => {
 			0, 2, 0, 0,
 			0, 0, 0, 0,
 			0, 2, 0, 0,
-			
+
 			0, 0, 0, 0,
 			0, 0, 0, 0,
 			0, 0, 0, 0,
@@ -334,7 +335,7 @@ describe("setter", () => {
 				0, 2, 0, 0,
 				0, 0, 0, 0,
 				0, 2, 0, 0,
-				
+
 				0, 0, 0, 0,
 				0, 0, 0, 0,
 				0, 0, 0, 0,
@@ -378,7 +379,7 @@ describe("setter", () => {
 			1, 1, 0, 0,
 			1, 1, 0, 0,
 			0, 0, 0, 0,
-			
+
 			1, 1, 0, 0,
 			1, 1, 0, 0,
 			0, 0, 0, 0,
@@ -439,14 +440,14 @@ describe("setter", () => {
 		setter.set_from_chunk(dest, src, mapping);
 		// biome-ignore format: the array should not be formatted
 		expect(to_c(dest).data).toStrictEqual(new Float32Array([
-				0, 2, 0, 0,
-				0, 0, 0, 0,
-				0, 2, 0, 0,
+			0, 2, 0, 0,
+			0, 0, 0, 0,
+			0, 2, 0, 0,
 
-				0, 0, 0, 0,
-				0, 0, 0, 0,
-				0, 0, 0, 0,
-			]));
+			0, 0, 0, 0,
+			0, 0, 0, 0,
+			0, 0, 0, 0,
+		]));
 	});
 
 	it("set_from_chunk - dest=C order, src=F order", async () => {

--- a/packages/ndarray/package.json
+++ b/packages/ndarray/package.json
@@ -11,7 +11,6 @@
 		}
 	},
 	"dependencies": {
-		"@types/ndarray": "^1.0.11",
 		"@types/ndarray-ops": "^1.2.4",
 		"@zarrita/core": "workspace:^",
 		"@zarrita/indexing": "workspace:^",

--- a/packages/ndarray/src/missing-types.d.ts
+++ b/packages/ndarray/src/missing-types.d.ts
@@ -1,0 +1,89 @@
+declare module "ndarray" {
+	declare function ndarray<D extends ndarray.Data = ndarray.Data<number>>(
+		data: D,
+		shape?: number[],
+		stride?: number[],
+		offset?: number,
+	): ndarray.NdArray<D>;
+
+	declare namespace ndarray {
+		interface NdArray<D extends Data = Data<number>> {
+			data: D;
+			shape: number[];
+			stride: number[];
+			offset: number;
+			dtype: DataType<D>;
+			size: number;
+			order: number[];
+			dimension: number;
+			get(...args: number[]): Value<D>;
+			set(...args: number[]): Value<D>;
+			index(...args: number[]): Value<D>;
+			lo(...args: number[]): NdArray<D>;
+			hi(...args: number[]): NdArray<D>;
+			step(...args: number[]): NdArray<D>;
+			transpose(...args: number[]): NdArray<D>;
+			pick(...args: Array<number | null>): NdArray<D>;
+			T: NdArray<D>;
+		}
+
+		interface GenericArray<T> {
+			get(idx: number): T;
+			set(idx: number, value: T): void;
+			length: number;
+		}
+
+		// biome-ignore lint/suspicious/noExplicitAny: not our library
+		type Data<T = any> = T extends number
+			? GenericArray<T> | T[] | TypedArray
+			: T extends bigint
+				? GenericArray<T> | T[] | BigInt64Array | BigUint64Array
+				: GenericArray<T> | T[];
+
+		type TypedArray =
+			| Int8Array
+			| Int16Array
+			| Int32Array
+			| Uint8Array
+			| Uint8ClampedArray
+			| Uint16Array
+			| Uint32Array
+			| Float32Array
+			| Float64Array;
+
+		type Value<D extends Data> = D extends
+			| GenericArray<infer T>
+			// biome-ignore lint/suspicious/noRedeclare: not our library
+			| Record<number, infer T>
+			? T
+			: never;
+
+		type DataType<D extends Data = Data> = D extends Int8Array
+			? "int8"
+			: D extends Int16Array
+				? "int16"
+				: D extends Int32Array
+					? "int32"
+					: D extends Uint8Array
+						? "uint8"
+						: D extends Uint8ClampedArray
+							? "uint8_clamped"
+							: D extends Uint16Array
+								? "uint16"
+								: D extends Uint32Array
+									? "uint32"
+									: D extends Float32Array
+										? "float32"
+										: D extends Float64Array
+											? "float64"
+											: D extends BigInt64Array
+												? "bigint64"
+												: D extends BigUint64Array
+													? "biguint64"
+													: D extends GenericArray<unknown>
+														? "generic"
+														: "array";
+	}
+
+	export = ndarray;
+}

--- a/packages/typedarray/__tests__/index.test.ts
+++ b/packages/typedarray/__tests__/index.test.ts
@@ -188,7 +188,9 @@ describe("ByteStringArray", () => {
 		let data = new TextEncoder().encode(
 			"Hello\x00world!\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00",
 		);
-		let arr = new ByteStringArray(2, data.buffer, 3, 4);
+		// @ts-expect-error - we know this is an ArrayBuffer, TS just isn't smart enough to know it's not a SharedArrayBuffer
+		let buffer: ArrayBuffer = data.buffer;
+		let arr = new ByteStringArray(2, buffer, 3, 4);
 		expect({
 			length: arr.length,
 			BYTES_PER_ELEMENT: arr.BYTES_PER_ELEMENT,

--- a/packages/typedarray/src/index.ts
+++ b/packages/typedarray/src/index.ts
@@ -31,6 +31,7 @@ export class BoolArray {
 	}
 
 	get buffer(): ArrayBuffer {
+		// @ts-expect-error - we know this is an ArrayBuffer (and not SharedArrayBuffer)
 		return this.#bytes.buffer;
 	}
 
@@ -106,6 +107,7 @@ export class ByteStringArray {
 	}
 
 	get buffer(): ArrayBuffer {
+		// @ts-expect-error - we know this is an ArrayBuffer (and not SharedArrayBuffer)
 		return this._data.buffer;
 	}
 
@@ -198,6 +200,7 @@ export class UnicodeStringArray {
 	}
 
 	get buffer(): ArrayBuffer {
+		// @ts-expect-error - we know this is an ArrayBuffer (and not SharedArrayBuffer)
 		return this.#data.buffer;
 	}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^0.2.12
         version: 0.2.12
       typescript:
-        specifier: 5.6.3
-        version: 5.6.3
+        specifier: 5.7.2
+        version: 5.7.2
       vitest:
         specifier: ^2.1.8
         version: 2.1.8(@types/node@22.10.1)
@@ -81,9 +81,6 @@ importers:
 
   packages/ndarray:
     dependencies:
-      '@types/ndarray':
-        specifier: ^1.0.11
-        version: 1.0.14
       '@types/ndarray-ops':
         specifier: ^1.2.4
         version: 1.2.7
@@ -1387,11 +1384,6 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
-  typescript@5.6.3:
-    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
-    engines: {node: '>=14.17'}
-    hasBin: true
 
   typescript@5.7.2:
     resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
@@ -2793,10 +2785,7 @@ snapshots:
 
   tr46@0.0.3: {}
 
-  typescript@5.6.3: {}
-
-  typescript@5.7.2:
-    optional: true
+  typescript@5.7.2: {}
 
   undici-types@6.20.0: {}
 


### PR DESCRIPTION
TypeScript 5.7 made TypeArray objects generic over an `ArrayBufferLike`
source. We only use `ArrayBuffer` internally, so isdeally we would be
explicit about the generic parameter in our return types. However, older
versions of TS will fail with an explicit generic parameter (i.e.,
`Uint8Array<ArrayBuffer>`).

The biggest issue is a mismatch between `ndarray` types and our own.
This change vendors the types for `ndarray`, to align them with our own.
