### PR TITLE
Add `rethrow_unless` util for try/catch blocks

### DIFF
--- a/packages/core/src/consolidated.ts
+++ b/packages/core/src/consolidated.ts
@@ -7,7 +7,11 @@ import type {
 	GroupMetadata,
 	GroupMetadataV2,
 } from "./metadata.js";
-import { json_decode_object, json_encode_object } from "./util.js";
+import {
+	json_decode_object,
+	json_encode_object,
+	rethrow_unless,
+} from "./util.js";
 
 type ConsolidatedMetadata = {
 	metadata: Record<string, ArrayMetadataV2 | GroupMetadataV2>;
@@ -134,10 +138,8 @@ export async function withConsolidated<Store extends Readable>(
 export async function tryWithConsolidated<Store extends Readable>(
 	store: Store,
 ): Promise<Listable<Store> | Store> {
-	return withConsolidated(store).catch((e: unknown) => {
-		if (e instanceof NodeNotFoundError) {
-			return store;
-		}
-		throw e;
+	return withConsolidated(store).catch((error: unknown) => {
+		rethrow_unless(error, NodeNotFoundError);
+		return store;
 	});
 }

--- a/packages/core/src/open.ts
+++ b/packages/core/src/open.ts
@@ -10,6 +10,7 @@ import type {
 import {
 	ensure_correct_scalar,
 	json_decode_object,
+	rethrow_unless,
 	v2_to_v3_array_metadata,
 	v2_to_v3_group_metadata,
 } from "./util.js";
@@ -64,8 +65,8 @@ async function open_v2<Store extends Readable>(
 	if (options.kind === "array") return open_array_v2(loc, attrs);
 	if (options.kind === "group") return open_group_v2(loc, attrs);
 	return open_array_v2(loc, attrs).catch((err) => {
-		if (err instanceof NodeNotFoundError) return open_group_v2(loc, attrs);
-		throw err;
+		rethrow_unless(err, NodeNotFoundError);
+		return open_group_v2(loc, attrs);
 	});
 }
 
@@ -192,10 +193,8 @@ export async function open<Store extends Readable>(
 	let open_primary = version_max === "v2" ? open.v2 : open.v3;
 	let open_secondary = version_max === "v2" ? open.v3 : open.v2;
 	return open_primary(location, options).catch((err) => {
-		if (err instanceof NodeNotFoundError) {
-			return open_secondary(location, options);
-		}
-		throw err;
+		rethrow_unless(err, NodeNotFoundError);
+		return open_secondary(location, options);
 	});
 }
 


### PR DESCRIPTION
Add a custom type-safe util that ensures an error matches an expected
type, otherwise rethrows. Just cleans up some logic with fallback logic
and `NodeNotFoundError`.
