### PR TITLE
Consolidate `@zarrita/typedarray` into `@zarrita/core`

### DIFF
--- a/.changeset/four-bats-knock.md
+++ b/.changeset/four-bats-knock.md
@@ -1,0 +1,9 @@
+---
+"@zarrita/typedarray": patch
+"@zarrita/indexing": patch
+"@zarrita/ndarray": patch
+"zarrita": patch
+"@zarrita/core": patch
+---
+
+Remove \`@zarrita/typedarray\` package (now included in zarrita)

--- a/.changeset/nervous-boxes-exist.md
+++ b/.changeset/nervous-boxes-exist.md
@@ -1,0 +1,5 @@
+---
+"zarrita": patch
+---
+
+Export `BoolArray`, `UnicodeStringArray`, and `ByteStringArrary`

--- a/.changeset/quiet-queens-chew.md
+++ b/.changeset/quiet-queens-chew.md
@@ -1,0 +1,5 @@
+---
+"@zarrita/typedarray": patch
+---
+
+Deprecate package and move into zarrita

--- a/packages/core/__tests__/open.test.ts
+++ b/packages/core/__tests__/open.test.ts
@@ -1,11 +1,6 @@
 import * as path from "node:path";
 import * as url from "node:url";
 import { type AbsolutePath, FileSystemStore } from "@zarrita/storage";
-import {
-	BoolArray,
-	ByteStringArray,
-	UnicodeStringArray,
-} from "@zarrita/typedarray";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { NodeNotFoundError } from "../src/errors.js";
@@ -16,6 +11,11 @@ import type {
 	GroupMetadata,
 	GroupMetadataV2,
 } from "../src/metadata.js";
+import {
+	BoolArray,
+	ByteStringArray,
+	UnicodeStringArray,
+} from "../src/typedarray.js";
 import { open } from "../src/open.js";
 
 function range(n: number) {

--- a/packages/core/__tests__/typedarray.test.ts
+++ b/packages/core/__tests__/typedarray.test.ts
@@ -4,7 +4,7 @@ import {
 	BoolArray,
 	ByteStringArray,
 	UnicodeStringArray,
-} from "../src/index.js";
+} from "../src/typedarray.js";
 
 describe("BoolArray.constructor", () => {
 	test("new (size: number) -> BoolArray", () => {

--- a/packages/core/__tests__/util.test.ts
+++ b/packages/core/__tests__/util.test.ts
@@ -11,7 +11,7 @@ import {
 	BoolArray,
 	ByteStringArray,
 	UnicodeStringArray,
-} from "@zarrita/typedarray";
+} from "../src/typedarray.js";
 
 describe("get_ctr", () => {
 	test.each<[DataType, unknown]>([

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,6 @@
 	},
 	"dependencies": {
 		"@zarrita/storage": "workspace:^",
-		"@zarrita/typedarray": "workspace:^",
 		"numcodecs": "^0.3.2"
 	},
 	"publishConfig": {

--- a/packages/core/src/codecs/transpose.ts
+++ b/packages/core/src/codecs/transpose.ts
@@ -2,7 +2,7 @@ import {
 	BoolArray,
 	ByteStringArray,
 	UnicodeStringArray,
-} from "@zarrita/typedarray";
+} from "../typedarray.js";
 import type {
 	Chunk,
 	DataType,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,10 @@
 export { KeyError, NodeNotFoundError } from "./errors.js";
 export {
+	BoolArray,
+	ByteStringArray,
+	UnicodeStringArray,
+} from "./typedarray.js";
+export {
 	Array,
 	get_context as _internal_get_array_context,
 	Group,

--- a/packages/core/src/metadata.ts
+++ b/packages/core/src/metadata.ts
@@ -2,7 +2,7 @@ import type {
 	BoolArray,
 	ByteStringArray,
 	UnicodeStringArray,
-} from "@zarrita/typedarray";
+} from "./typedarray.js";
 
 /** @category Number */
 export type Int8 = "int8";

--- a/packages/core/src/typedarray.ts
+++ b/packages/core/src/typedarray.ts
@@ -1,3 +1,14 @@
+/**
+ * Custom array-like views (i.e., TypedArrays) for Zarr binary data buffers.
+ *
+ * @module
+ */
+
+/**
+ * An array-like view of a fixed-length boolean buffer.
+ *
+ * Encoded as 1 byte per value.
+ */
 export class BoolArray {
 	#bytes: Uint8Array;
 
@@ -58,6 +69,11 @@ export class BoolArray {
 	}
 }
 
+/**
+ * An array-like view of a fixed-length byte buffer.
+ *
+ * Encodes a raw byte sequences without enforced encoding.
+ */
 export class ByteStringArray {
 	_data: Uint8Array;
 	chars: number;
@@ -147,6 +163,11 @@ export class ByteStringArray {
 	}
 }
 
+/**
+ * An array-like view of a fixed-length Unicode string buffer.
+ *
+ * Encoded as UTF-32 code points.
+ */
 export class UnicodeStringArray {
 	#data: Int32Array;
 	chars: number;

--- a/packages/core/src/util.ts
+++ b/packages/core/src/util.ts
@@ -2,7 +2,7 @@ import {
 	BoolArray,
 	ByteStringArray,
 	UnicodeStringArray,
-} from "@zarrita/typedarray";
+} from "./typedarray.js";
 
 import type {
 	ArrayMetadata,

--- a/packages/indexing/__tests__/get.test.ts
+++ b/packages/indexing/__tests__/get.test.ts
@@ -2,11 +2,6 @@ import * as path from "node:path";
 import * as url from "node:url";
 import * as zarr from "@zarrita/core";
 import FSStore from "@zarrita/storage/fs";
-import {
-	BoolArray,
-	ByteStringArray,
-	UnicodeStringArray,
-} from "@zarrita/typedarray";
 import { describe, expect, it } from "vitest";
 
 import { get } from "../src/ops.js";
@@ -218,49 +213,29 @@ describe("get v2", () => {
 
 	it("1d.contiguous.U13.le", async () => {
 		let res = await get_v2("/1d.contiguous.U13.le");
-		expect(res.data).toBeInstanceOf(UnicodeStringArray);
-		expect(Array.from(res.data as UnicodeStringArray)).toStrictEqual([
-			"a",
-			"b",
-			"cc",
-			"d",
-		]);
+		expect(res.data).toBeInstanceOf(zarr.UnicodeStringArray);
+		expect(Array.from(res.data)).toStrictEqual(["a", "b", "cc", "d"]);
 		expect(res.shape).toStrictEqual([4]);
 	});
 
 	it("1d.contiguous.U13.be", async () => {
 		let res = await get_v2("/1d.contiguous.U13.be");
-		expect(res.data).toBeInstanceOf(UnicodeStringArray);
-		expect(Array.from(res.data as UnicodeStringArray)).toStrictEqual([
-			"a",
-			"b",
-			"cc",
-			"d",
-		]);
+		expect(res.data).toBeInstanceOf(zarr.UnicodeStringArray);
+		expect(Array.from(res.data)).toStrictEqual(["a", "b", "cc", "d"]);
 		expect(res.shape).toStrictEqual([4]);
 	});
 
 	it("1d.contiguous.U7", async () => {
 		let res = await get_v2("/1d.contiguous.U7");
-		expect(res.data).toBeInstanceOf(UnicodeStringArray);
-		expect(Array.from(res.data as UnicodeStringArray)).toStrictEqual([
-			"a",
-			"b",
-			"cc",
-			"d",
-		]);
+		expect(res.data).toBeInstanceOf(zarr.UnicodeStringArray);
+		expect(Array.from(res.data)).toStrictEqual(["a", "b", "cc", "d"]);
 		expect(res.shape).toStrictEqual([4]);
 	});
 
 	it("1d.contiguous.S7", async () => {
 		let res = await get_v2("/1d.contiguous.S7");
-		expect(res.data).toBeInstanceOf(ByteStringArray);
-		expect(Array.from(res.data as UnicodeStringArray)).toStrictEqual([
-			"a",
-			"b",
-			"cc",
-			"d",
-		]);
+		expect(res.data).toBeInstanceOf(zarr.ByteStringArray);
+		expect(Array.from(res.data)).toStrictEqual(["a", "b", "cc", "d"]);
 		expect(res.shape).toStrictEqual([4]);
 	});
 
@@ -277,12 +252,7 @@ describe("get v2", () => {
 			  ],
 			}
 		`);
-		expect(Array.from(res.data as BoolArray)).toStrictEqual([
-			true,
-			false,
-			true,
-			false,
-		]);
+		expect(Array.from(res.data)).toStrictEqual([true, false, true, false]);
 	});
 
 	it("2d.contiguous.i2", async () => {
@@ -414,12 +384,7 @@ describe("get v2", () => {
 
 	it("2d.chunked.U7", async () => {
 		let res = await get_v2("/2d.chunked.U7");
-		expect(Array.from(res.data as UnicodeStringArray)).toStrictEqual([
-			"a",
-			"b",
-			"cc",
-			"d",
-		]);
+		expect(Array.from(res.data)).toStrictEqual(["a", "b", "cc", "d"]);
 		expect(res.shape).toStrictEqual([2, 2]);
 	});
 
@@ -545,9 +510,9 @@ describe("get v2", () => {
 		let res = await get_v2("/3d.chunked.mixed.i2.F");
 		// biome-ignore format: the array should not be formatted
 		expect(res.data).toStrictEqual(new Int16Array([
-			0,  9, 18,  3, 12, 21,  6, 15, 24,
-			1, 10, 19,  4, 13, 22,  7, 16, 25,
-			2, 11, 20,  5, 14, 23,  8, 17, 26, 
+			0, 9, 18, 3, 12, 21, 6, 15, 24,
+			1, 10, 19, 4, 13, 22, 7, 16, 25,
+			2, 11, 20, 5, 14, 23, 8, 17, 26,
 		]));
 		expect(res.shape).toStrictEqual([3, 3, 3]);
 		expect(res.stride).toStrictEqual([1, 3, 9]);
@@ -632,8 +597,8 @@ describe("get v3", () => {
 
 	it("1d.contiguous.b1", async () => {
 		let res = await get_v3("/1d.contiguous.b1");
-		expect(res.data).toBeInstanceOf(BoolArray);
-		expect(Array.from(res.data as BoolArray)).toStrictEqual([
+		expect(res.data).toBeInstanceOf(zarr.BoolArray);
+		expect(Array.from(res.data as zarr.BoolArray)).toStrictEqual([
 			true,
 			false,
 			true,
@@ -695,9 +660,9 @@ describe("get v3", () => {
 		let res = await get_v3("/3d.chunked.mixed.i2.F");
 		// biome-ignore format: the array should not be formatted
 		expect(res.data).toStrictEqual(new Int16Array([
-			0,  9, 18,  3, 12, 21,  6, 15, 24,
-			1, 10, 19,  4, 13, 22,  7, 16, 25,
-			2, 11, 20,  5, 14, 23,  8, 17, 26, 
+			0, 9, 18, 3, 12, 21, 6, 15, 24,
+			1, 10, 19, 4, 13, 22, 7, 16, 25,
+			2, 11, 20, 5, 14, 23, 8, 17, 26,
 		]));
 		expect(res.shape).toStrictEqual([3, 3, 3]);
 		expect(res.stride).toStrictEqual([1, 3, 9]);

--- a/packages/ndarray/__tests__/index.test.ts
+++ b/packages/ndarray/__tests__/index.test.ts
@@ -6,11 +6,6 @@ import { get } from "../src/index.js";
 
 import * as zarr from "@zarrita/core";
 import { FileSystemStore } from "@zarrita/storage";
-import {
-	BoolArray,
-	ByteStringArray,
-	UnicodeStringArray,
-} from "@zarrita/typedarray";
 
 let __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
@@ -124,7 +119,7 @@ describe("ndarray", () => {
 			kind: "array",
 		});
 		let res = await get(arr);
-		expect(res.data).toBeInstanceOf(UnicodeStringArray);
+		expect(res.data).toBeInstanceOf(zarr.UnicodeStringArray);
 		expect(Array.from(res.data)).toStrictEqual(["a", "b", "cc", "d"]);
 		expect(res.shape).toStrictEqual([4]);
 	});
@@ -134,13 +129,8 @@ describe("ndarray", () => {
 			kind: "array",
 		});
 		let res = await get(arr);
-		expect(res.data).toBeInstanceOf(UnicodeStringArray);
-		expect(Array.from(res.data as UnicodeStringArray)).toStrictEqual([
-			"a",
-			"b",
-			"cc",
-			"d",
-		]);
+		expect(res.data).toBeInstanceOf(zarr.UnicodeStringArray);
+		expect(Array.from(res.data)).toStrictEqual(["a", "b", "cc", "d"]);
 		expect(res.shape).toStrictEqual([4]);
 	});
 
@@ -149,13 +139,8 @@ describe("ndarray", () => {
 			kind: "array",
 		});
 		let res = await get(arr);
-		expect(res.data).toBeInstanceOf(UnicodeStringArray);
-		expect(Array.from(res.data as UnicodeStringArray)).toStrictEqual([
-			"a",
-			"b",
-			"cc",
-			"d",
-		]);
+		expect(res.data).toBeInstanceOf(zarr.UnicodeStringArray);
+		expect(Array.from(res.data)).toStrictEqual(["a", "b", "cc", "d"]);
 		expect(res.shape).toStrictEqual([4]);
 	});
 
@@ -164,13 +149,8 @@ describe("ndarray", () => {
 			kind: "array",
 		});
 		let res = await get(arr);
-		expect(res.data).toBeInstanceOf(ByteStringArray);
-		expect(Array.from(res.data as ByteStringArray)).toStrictEqual([
-			"a",
-			"b",
-			"cc",
-			"d",
-		]);
+		expect(res.data).toBeInstanceOf(zarr.ByteStringArray);
+		expect(Array.from(res.data)).toStrictEqual(["a", "b", "cc", "d"]);
 		expect(res.shape).toStrictEqual([4]);
 	});
 
@@ -179,13 +159,8 @@ describe("ndarray", () => {
 			kind: "array",
 		});
 		let res = await get(arr);
-		expect(res.data).toBeInstanceOf(BoolArray);
-		expect(Array.from(res.data as BoolArray)).toStrictEqual([
-			true,
-			false,
-			true,
-			false,
-		]);
+		expect(res.data).toBeInstanceOf(zarr.BoolArray);
+		expect(Array.from(res.data)).toStrictEqual([true, false, true, false]);
 		expect(res.shape).toStrictEqual([4]);
 	});
 
@@ -290,9 +265,9 @@ describe("ndarray", () => {
 		let res = await get(arr);
 		// biome-ignore format: the array should not be formatted
 		expect(res.data).toStrictEqual(new Int16Array([
-			0,  9, 18,  3, 12, 21,  6, 15, 24,
-			1, 10, 19,  4, 13, 22,  7, 16, 25,
-			2, 11, 20,  5, 14, 23,  8, 17, 26, 
+			0, 9, 18, 3, 12, 21, 6, 15, 24,
+			1, 10, 19, 4, 13, 22, 7, 16, 25,
+			2, 11, 20, 5, 14, 23, 8, 17, 26,
 		]));
 		expect(res.shape).toStrictEqual([3, 3, 3]);
 		expect(res.stride).toStrictEqual([1, 3, 9]);

--- a/packages/typedarray/README.md
+++ b/packages/typedarray/README.md
@@ -1,4 +1,4 @@
-# @zarrita/typedarray
+# ⚠️ @zarrita/typedarray
 
 [![NPM](https://img.shields.io/npm/v/@zarrita/typedarray/next.svg?color=black)](https://www.npmjs.com/package/zarrita)
 [![License](https://img.shields.io/npm/l/zarrita.svg?color=black)](https://github.com/manzt/zarrita.js/raw/main/LICENSE)
@@ -6,28 +6,30 @@
 > ArrayBuffer-backed containers for
 > **[zarrita.js](https://manzt.github.io/zarrita.js)**.
 
-## Installation
+This package has been deprecated and its functionality is now part of `zarrita`.
 
-```sh
-npm install @zarrita/typedarray@next
-```
+## Migration
 
-## Usage
+If you were using `@zarrita/typedarray`, switch to `zarrita`:
 
-```javascript
+**Before**
+
+```ts
 import {
 	BoolArray,
 	ByteStringArray,
 	UnicodeStringArray,
 } from "@zarrita/typedarray";
+```
 
-let arrs = [
-	new BoolArray([true, false, true]),
-	new UnicodeStringArray(5, ["hello", "world"]),
-	new ByteStringArray(5, ["hello", "world"]),
-];
+**After**
 
-let bytes = arrs.map((a) => new Uint8Array(arr.buffer));
+```ts
+import {
+	BoolArray,
+	ByteStringArray,
+	UnicodeStringArray,
+} from "zarrita";
 ```
 
 Read the [documentation](https://manzt.github.io/zarrita.js/) to learn more.

--- a/packages/typedarray/index.ts
+++ b/packages/typedarray/index.ts
@@ -1,0 +1,1 @@
+export { BoolArray, ByteStringArray, UnicodeStringArray } from "zarrita";

--- a/packages/typedarray/package.json
+++ b/packages/typedarray/package.json
@@ -6,20 +6,11 @@
 	"sideEffects": false,
 	"exports": {
 		".": {
-			"types": "./src/index.ts",
-			"import": "./src/index.ts"
+			"types": "./dist/index.d.ts",
+			"import": "./dist/index.js"
 		}
 	},
-	"files": [
-		"dist"
-	],
-	"publishConfig": {
-		"main": "dist/src/index.js",
-		"exports": {
-			".": {
-				"types": "./dist/src/index.d.ts",
-				"import": "./dist/src/index.js"
-			}
-		}
+	"dependencies": {
+		"zarrita": "workspace:^"
 	}
 }

--- a/packages/zarrita/index.test.ts
+++ b/packages/zarrita/index.test.ts
@@ -6,11 +6,14 @@ it("exports all the things", () => {
 	expect(mod).toMatchInlineSnapshot(`
 		{
 		  "Array": [Function],
+		  "BoolArray": [Function],
+		  "ByteStringArray": [Function],
 		  "FetchStore": [Function],
 		  "Group": [Function],
 		  "KeyError": [Function],
 		  "Location": [Function],
 		  "NodeNotFoundError": [Function],
+		  "UnicodeStringArray": [Function],
 		  "_internal_get_array_context": [Function],
 		  "create": [Function],
 		  "get": [Function],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,9 +47,6 @@ importers:
       '@zarrita/storage':
         specifier: workspace:^
         version: link:../storage
-      '@zarrita/typedarray':
-        specifier: workspace:^
-        version: link:../typedarray
       numcodecs:
         specifier: ^0.3.2
         version: 0.3.2
@@ -113,7 +110,11 @@ importers:
         specifier: ^1.4.3
         version: 1.4.3
 
-  packages/typedarray: {}
+  packages/typedarray:
+    dependencies:
+      zarrita:
+        specifier: workspace:^
+        version: link:../zarrita
 
   packages/zarrita:
     dependencies:


### PR DESCRIPTION
This also starts the deprecation of `@zarrita/typedarray`. It's a small
module and it makes sense to keep it in the core to simplify project
structure.
