### PR TITLE
Remove order from `GetOptions`

### DIFF
--- a/.changeset/all-apples-beam.md
+++ b/.changeset/all-apples-beam.md
@@ -1,0 +1,6 @@
+---
+"zarrita": minor
+"@zarrita/ndarray": minor
+---
+
+Remove explicit `order` from `GetOptions`.

--- a/packages/@zarrita-ndarray/__tests__/index.test.ts
+++ b/packages/@zarrita-ndarray/__tests__/index.test.ts
@@ -272,14 +272,4 @@ describe("ndarray", () => {
 		expect(res.shape).toStrictEqual([3, 3, 3]);
 		expect(res.stride).toStrictEqual([1, 3, 9]);
 	});
-
-	it("3d.chunked.mixed.i2.F -- force C", async () => {
-		let arr = await zarr.open.v2(store.resolve("/3d.chunked.mixed.i2.F"), {
-			kind: "array",
-		});
-		let res = await get(arr, null, { order: "C" });
-		expect(res.data).toStrictEqual(new Int16Array(range(27)));
-		expect(res.shape).toStrictEqual([3, 3, 3]);
-		expect(res.stride).toStrictEqual([9, 3, 1]);
-	});
 });

--- a/packages/zarrita/__tests__/indexing/get.test.ts
+++ b/packages/zarrita/__tests__/indexing/get.test.ts
@@ -518,13 +518,6 @@ describe("get v2", () => {
 		expect(res.stride).toStrictEqual([1, 3, 9]);
 	});
 
-	it("3d.chunked.mixed.i2.F -- force C", async () => {
-		let res = await get_v2("/3d.chunked.mixed.i2.F", null, { order: "C" });
-		expect(res.data).toStrictEqual(new Int16Array(range(27)));
-		expect(res.shape).toStrictEqual([3, 3, 3]);
-		expect(res.stride).toStrictEqual([9, 3, 1]);
-	});
-
 	it("3d.chunked.O", async () => {
 		let arr = await get_v2("/3d.chunked.O");
 		expect(arr).toStrictEqual({
@@ -666,14 +659,5 @@ describe("get v3", () => {
 		]));
 		expect(res.shape).toStrictEqual([3, 3, 3]);
 		expect(res.stride).toStrictEqual([1, 3, 9]);
-	});
-
-	it("3d.chunked.mixed.i2.F -- force C", async () => {
-		let res = await get_v3("/3d.chunked.mixed.i2.F", null, {
-			order: "C",
-		});
-		expect(res.data).toStrictEqual(new Int16Array(range(27)));
-		expect(res.shape).toStrictEqual([3, 3, 3]);
-		expect(res.stride).toStrictEqual([9, 3, 1]);
 	});
 });

--- a/packages/zarrita/src/hierarchy.ts
+++ b/packages/zarrita/src/hierarchy.ts
@@ -99,8 +99,8 @@ function create_context<Store extends Readable, D extends DataType>(
 				shape: configuration.chunk_shape,
 				codecs: configuration.codecs,
 			}),
-			get_strides(shape: number[], order?: "C" | "F") {
-				return get_strides(shape, order ?? native_order);
+			get_strides(shape: number[]) {
+				return get_strides(shape, native_order);
 			},
 			get_chunk_bytes: create_sharded_chunk_getter(
 				location,
@@ -121,8 +121,8 @@ function create_context<Store extends Readable, D extends DataType>(
 			shape: metadata.chunk_grid.configuration.chunk_shape,
 			codecs: metadata.codecs,
 		}),
-		get_strides(shape: number[], order?: "C" | "F") {
-			return get_strides(shape, order ?? native_order);
+		get_strides(shape: number[]) {
+			return get_strides(shape, native_order);
 		},
 		async get_chunk_bytes(chunk_coords, options) {
 			let chunk_key = shared_context.encode_chunk_key(chunk_coords);
@@ -142,7 +142,7 @@ interface ArrayContext<Store extends Readable, D extends DataType> {
 	/** The TypedArray constructor for this array chunks. */
 	TypedArray: TypedArrayConstructor<D>;
 	/** A function to get the strides for a given shape, using the array order */
-	get_strides(shape: number[], order?: "C" | "F"): number[];
+	get_strides(shape: number[]): number[];
 	/** The fill value for this array. */
 	fill_value: Scalar<D> | null;
 	/** A function to get the bytes for a given chunk. */

--- a/packages/zarrita/src/indexing/get.ts
+++ b/packages/zarrita/src/indexing/get.ts
@@ -42,10 +42,11 @@ export async function get<
 		shape: arr.shape,
 		chunk_shape: arr.chunks,
 	});
+
 	let out = setter.prepare(
 		new context.TypedArray(indexer.shape.reduce((a, b) => a * b, 1)),
 		indexer.shape,
-		context.get_strides(indexer.shape, opts.order),
+		context.get_strides(indexer.shape),
 	);
 
 	let queue = opts.create_queue?.() ?? create_queue();

--- a/packages/zarrita/src/indexing/types.ts
+++ b/packages/zarrita/src/indexing/types.ts
@@ -44,7 +44,7 @@ export type Options = {
 	create_queue?: () => ChunkQueue;
 };
 
-export type GetOptions<O> = Options & { opts?: O; order?: "C" | "F" };
+export type GetOptions<O> = Options & { opts?: O };
 
 export type SetOptions = Options;
 


### PR DESCRIPTION
I want to make a stable release of `zarrita` and this feature is not stable. We can focus on a PR after to support along with deciding on a new API if necessary.
