### PR TITLE
feat!(zarrita): Replace `gzip`/`zlib` codecs with decode-only `DecompressionStream` implementation

### DIFF
--- a/.changeset/tired-doodles-attack.md
+++ b/.changeset/tired-doodles-attack.md
@@ -4,9 +4,9 @@
 
 Replace default `gzip`/`zlib` codecs with dependency-less decode-only versions
 
-This is a **breaking change**. Since usage of **zarrita** is primarily read-only, this change replaces the default `numcodecs/gzip` and `numcodecs/zlib` codecs with custom decode-only codecs based on the builtin `DecompressionStream` API.
+This is a **breaking change** since by default **zarrita** no longer supports _encoding_ with these codecs. The new implementation is based on the [`DecompressionStream`](https://developer.mozilla.org/en-US/docs/Web/API/DecompressionStream) API, preferring a built-in (i.e., dependency-free) solution for the majority use case (read-only) with zarrita.
 
-These changes reduce dynamic imports and remove additional dependencies for the majority use case. Users who require encoding must explicitly register their own codecs from `numcodecs`.
+Encoding remains supported but must be explicitly enabled with a custom codec from `numcodecs`:
 
 ```ts
 import * as zarr from "zarrita";

--- a/.changeset/tired-doodles-attack.md
+++ b/.changeset/tired-doodles-attack.md
@@ -1,0 +1,21 @@
+---
+"zarrita": minor
+---
+
+Replace default `gzip`/`zlib` codecs with dependency-less decode-only versions
+
+This is a **breaking change**. Since usage of **zarrita** is primarily read-only, this change replaces the default `numcodecs/gzip` and `numcodecs/zlib` codecs with custom decode-only codecs based on the builtin `DecompressionStream` API.
+
+These changes reduce dynamic imports and remove additional dependencies for the majority use case. Users who require encoding must explicitly register their own codecs from `numcodecs`.
+
+```ts
+import * as zarr from "zarrita";
+
+import GZip from "numcodecs/gzip";
+import Zlib from "numcodecs/zlib";
+
+
+zarr.registry.set("gzip", () => GZip);
+zarr.registry.set("zlib", () => Zlib);
+```
+

--- a/packages/zarrita/src/codecs.ts
+++ b/packages/zarrita/src/codecs.ts
@@ -4,9 +4,11 @@ import type { Chunk, CodecMetadata, DataType } from "./metadata.js";
 import { BitroundCodec } from "./codecs/bitround.js";
 import { BytesCodec } from "./codecs/bytes.js";
 import { Crc32cCodec } from "./codecs/crc32c.js";
+import { GzipCodec } from "./codecs/gzip.js";
 import { JsonCodec } from "./codecs/json2.js";
 import { TransposeCodec } from "./codecs/transpose.js";
 import { VLenUTF8 } from "./codecs/vlen-utf8.js";
+import { ZlibCodec } from "./codecs/zlib.js";
 import { assert } from "./util.js";
 
 type ChunkMetadata<D extends DataType> = {
@@ -25,10 +27,10 @@ type Codec = _Codec & { kind: CodecEntry["kind"] };
 function create_default_registry(): Map<string, () => Promise<CodecEntry>> {
 	return new Map()
 		.set("blosc", () => import("numcodecs/blosc").then((m) => m.default))
-		.set("gzip", () => import("numcodecs/gzip").then((m) => m.default))
 		.set("lz4", () => import("numcodecs/lz4").then((m) => m.default))
-		.set("zlib", () => import("numcodecs/zlib").then((m) => m.default))
 		.set("zstd", () => import("numcodecs/zstd").then((m) => m.default))
+		.set("gzip", () => GzipCodec)
+		.set("zlib", () => ZlibCodec)
 		.set("transpose", () => TransposeCodec)
 		.set("bytes", () => BytesCodec)
 		.set("crc32c", () => Crc32cCodec)

--- a/packages/zarrita/src/codecs/gzip.ts
+++ b/packages/zarrita/src/codecs/gzip.ts
@@ -1,0 +1,24 @@
+import { decompress } from "../util.js";
+
+interface GzipCodecConfig {
+	level: number;
+}
+
+export class GzipCodec {
+	kind = "bytes_to_bytes";
+
+	static fromConfig(_: GzipCodecConfig) {
+		return new GzipCodec();
+	}
+
+	encode(_bytes: Uint8Array): never {
+		throw new Error(
+			"Gzip encoding is not enabled by default. Please register a custom codec with `numcodecs/gzip`.",
+		);
+	}
+
+	async decode(bytes: Uint8Array): Promise<Uint8Array> {
+		const buffer = await decompress(bytes, { format: "gzip" });
+		return new Uint8Array(buffer);
+	}
+}

--- a/packages/zarrita/src/codecs/zlib.ts
+++ b/packages/zarrita/src/codecs/zlib.ts
@@ -1,0 +1,24 @@
+import { decompress } from "../util.js";
+
+interface ZlibCodecConfig {
+	level: number;
+}
+
+export class ZlibCodec {
+	kind = "bytes_to_bytes";
+
+	static fromConfig(_: ZlibCodecConfig) {
+		return new ZlibCodec();
+	}
+
+	encode(_bytes: Uint8Array): never {
+		throw new Error(
+			"Zlib encoding is not enabled by default. Please register a codec with `numcodecs/zlib`.",
+		);
+	}
+
+	async decode(bytes: Uint8Array): Promise<Uint8Array> {
+		const buffer = await decompress(bytes, { format: "deflate" });
+		return new Uint8Array(buffer);
+	}
+}

--- a/packages/zarrita/src/util.ts
+++ b/packages/zarrita/src/util.ts
@@ -346,3 +346,29 @@ export function assert(
 		throw new Error(msg);
 	}
 }
+
+/**
+ * @param {ArrayBuffer |ArrayBufferView | Response} data
+ * @param {Object} options
+ * @param {CompressionFormat} options.format
+ * @param {AbortSignal} [options.signal]
+ *
+ * @returns {Promise<ArrayBuffer>}
+ */
+export async function decompress(
+	data: ArrayBuffer | ArrayBufferView | Response,
+	{ format, signal }: { format: CompressionFormat; signal?: AbortSignal },
+): Promise<ArrayBuffer> {
+	const response = data instanceof Response ? data : new Response(data);
+	assert(response.body, "Response does not contain body.");
+	try {
+		const decompressedResponse = new Response(
+			response.body.pipeThrough(new DecompressionStream(format), { signal }),
+		);
+		const buffer = await decompressedResponse.arrayBuffer();
+		return buffer;
+	} catch {
+		signal?.throwIfAborted();
+		throw new Error(`Failed to decode ${format}`);
+	}
+}


### PR DESCRIPTION
This is a **breaking change**. Since usage of **zarrita** is primarily read-only, this change replaces the default `numcodecs/gzip` and `numcodecs/zlib` codecs with custom decode-only codecs based on the builtin `DecompressionStream` API.

These changes reduce dynamic imports and remove additional dependencies for the majority use case. Users who require encoding must explicitly register their own codecs from `numcodecs`.

```ts
import * as zarr from "zarrita";

import GZip from "numcodecs/gzip";
import Zlib from "numcodecs/zlib";

zarr.registry.set("gzip", () => GZip);
zarr.registry.set("zlib", () => Zlib);
```