### PR TITLE
Emit and publish sourcemaps

### DIFF
--- a/.changeset/thick-owls-swim.md
+++ b/.changeset/thick-owls-swim.md
@@ -1,0 +1,7 @@
+---
+"@zarrita/ndarray": patch
+"@zarrita/storage": patch
+"zarrita": patch
+---
+
+Emit and publish [sourcemap files](http://web.dev/articles/source-maps)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
 		"verbatimModuleSyntax": true,
 		"isolatedModules": true,
 		"declaration": true,
+		"sourceMap": true,
 		/* Linting */
 		"strict": true,
 		"noUnusedLocals": true,


### PR DESCRIPTION
Enables the generation of [sourcemap files](https://web.dev/articles/source-maps), which allow debuggers and other tools to display the original TypeScript source code when actually working with the emitted JavaScript files. 

This should provide better introspection of zarrita code.

<img src="https://github.com/user-attachments/assets/ba0dbf9e-bdc1-4904-b699-36759ffa513a" />
