### PR TITLE
Include TypeScript source files to npm packages

### DIFF
--- a/packages/@zarrita-ndarray/package.json
+++ b/packages/@zarrita-ndarray/package.json
@@ -11,7 +11,8 @@
 		}
 	},
 	"files": [
-		"dist"
+		"dist",
+		"src"
 	],
 	"publishConfig": {
 		"main": "dist/src/index.js",

--- a/packages/@zarrita-storage/package.json
+++ b/packages/@zarrita-storage/package.json
@@ -5,7 +5,8 @@
 	"type": "module",
 	"sideEffects": false,
 	"files": [
-		"dist"
+		"dist",
+		"src"
 	],
 	"exports": {
 		".": {

--- a/packages/zarrita/package.json
+++ b/packages/zarrita/package.json
@@ -5,7 +5,8 @@
 	"type": "module",
 	"sideEffects": false,
 	"files": [
-		"dist/"
+		"dist/",
+		"src/"
 	],
 	"exports": {
 		".": {


### PR DESCRIPTION
Fixes #293

Add `src/` directories to the files array in `package.json` for all
three packages (`zarrita`, `@zarrita/storage`, `@zarrita/ndarray`).
