### PR TITLE
Add optional chunk caching to `get()` function

### DIFF
--- a/packages/zarrita/src/indexing/get.ts
+++ b/packages/zarrita/src/indexing/get.ts
@@ -4,6 +4,7 @@ import { type Array, get_context } from "../hierarchy.js";
 import type { Chunk, DataType, Scalar, TypedArray } from "../metadata.js";
 import { BasicIndexer } from "./indexer.js";
 import type {
+	ChunkCache,
 	GetOptions,
 	Prepare,
 	SetFromChunk,
@@ -11,6 +12,11 @@ import type {
 	Slice,
 } from "./types.js";
 import { create_queue } from "./util.js";
+
+const NULL_CACHE: ChunkCache = {
+	get: () => undefined,
+	set: () => {},
+};
 
 // WeakMap to assign unique IDs to store instances
 const storeIdMap = new WeakMap<object, number>();
@@ -71,7 +77,7 @@ export async function get<
 	);
 
 	let queue = opts.create_queue?.() ?? create_queue();
-	let cache = opts.cache ?? { get: () => undefined, set: () => {} };
+	let cache = opts.cache ?? NULL_CACHE;
 	for (const { chunk_coords, mapping } of indexer) {
 		queue.add(async () => {
 			let cacheKey = createCacheKey(arr, chunk_coords);

--- a/packages/zarrita/src/indexing/types.ts
+++ b/packages/zarrita/src/indexing/types.ts
@@ -36,7 +36,7 @@ export type SetFromChunk<D extends DataType, NdArray extends Chunk<D>> = (
 
 export interface ChunkCache {
 	get(key: string): Chunk<DataType> | undefined;
-	set(key: string, value: Chunk<DataType>): any;
+	set(key: string, value: Chunk<DataType>): void;
 }
 
 export type Setter<D extends DataType, Arr extends Chunk<D>> = {

--- a/packages/zarrita/src/indexing/types.ts
+++ b/packages/zarrita/src/indexing/types.ts
@@ -34,6 +34,11 @@ export type SetFromChunk<D extends DataType, NdArray extends Chunk<D>> = (
 	proj: Projection[],
 ) => void;
 
+export interface ChunkCache {
+	get(key: string): Chunk<DataType> | undefined;
+	set(key: string, value: Chunk<DataType>): any;
+}
+
 export type Setter<D extends DataType, Arr extends Chunk<D>> = {
 	prepare: Prepare<D, Arr>;
 	set_from_chunk: SetFromChunk<D, Arr>;
@@ -42,6 +47,7 @@ export type Setter<D extends DataType, Arr extends Chunk<D>> = {
 
 export type Options = {
 	create_queue?: () => ChunkQueue;
+	cache?: ChunkCache;
 };
 
 export type GetOptions<O> = Options & { opts?: O };

--- a/packages/zarrita/src/indexing/util.ts
+++ b/packages/zarrita/src/indexing/util.ts
@@ -127,3 +127,4 @@ export function create_queue(): ChunkQueue {
 		onIdle: () => Promise.all(promises),
 	};
 }
+

--- a/packages/zarrita/src/indexing/util.ts
+++ b/packages/zarrita/src/indexing/util.ts
@@ -127,4 +127,3 @@ export function create_queue(): ChunkQueue {
 		onIdle: () => Promise.all(promises),
 	};
 }
-


### PR DESCRIPTION
## Summary

This adds optional chunk caching to the `get()` function to avoid repeated decompression of chunks when accessing overlapping selections or making multiple calls to the same data. I've noticed this can be a significant bottleneck when indexing data slice-by-slice, for example, where the chunks span many slices.

This may be a niche need, so no worries if this is out of scope for this library!

### New API

  - `cache?: ChunkCache` in `GetOptions`
  - `ChunkCache` interface with `get(key: string): Chunk<DataType> | undefined` and `set(key: string, value: Chunk<DataType>): any` (meant to be compatible with simple `Map`)

### Usage
```typescript
  // Use built-in Map as cache
  const cache = new Map();
  const result = await get(array, selection, { cache });

  // Custom LRU cache  
  const result = await get(array, selection, {
    cache: new LRUCache({ max: 100 })
  });

  // No cache (default - unchanged behavior)
  const result = await get(array, selection);
```

### Implementation

  - Cache keys use `store_N:${array.path}:${chunkKey}` format
  - Store isolation: `WeakMap` assigns unique IDs to store instances to prevent cache collisions when sharing caches across stores (perhaps not recommended)
  - Single cache can hold chunks from arrays with different data types