### PR TITLE
Configure changesets to sync JSR manifests on version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           title: Create Release
           publish: pnpm changeset publish
+          version: pnpm version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
 		"lint": "biome ci .",
 		"fix": "biome check --write .",
 		"publint": "pnpm --recursive --filter=\"./packages/**\" exec publint",
-		"update-fixtures": "uv run scripts/generate-v2.py && uv run scripts/generate-v3.py && bash scripts/zip-fixtures.sh"
+		"update-fixtures": "uv run scripts/generate-v2.py && uv run scripts/generate-v3.py && bash scripts/zip-fixtures.sh",
+		"version": "changeset version && node scripts/sync-jsr.mjs"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "2.1.1",


### PR DESCRIPTION
Add `version` script to package.json that runs `scripts/sync-jsr.mjs` after versioning. Should allow our changesets to automatically trigger JSR releases as well, without needing to "sync" in a separate commit/PR.
