### PR TITLE
Assign dimension names to meta_doc attributes

### DIFF
--- a/packages/zarrita/src/open.ts
+++ b/packages/zarrita/src/open.ts
@@ -118,7 +118,7 @@ async function _open_v3<Store extends Readable>(location: Location<Store>) {
 	}
 	let meta_doc: ArrayMetadata<DataType> | GroupMetadata =
 		json_decode_object(meta);
-	if (meta_doc.dimension_names){
+		if (meta_doc.node_type === "array" && meta_doc.dimension_names){
         meta_doc.attributes.dimension_names = meta_doc.dimension_names
     }
 	if (meta_doc.node_type === "array") {


### PR DESCRIPTION
In Zarr v3, the `dimension_names` attribute is usually not in the attributes subgroup. So there's no way to get the dimension information of a given variable with v3.

This very simple fix  just puts it in the attributes object so it's referenced with 
```ts 
get attrs() {
    return this.#metadata.attributes;
}
```
In the Array class. 