### PR TITLE
Use `pnpm run version` instead of `pnpm version`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           title: Create Release
           publish: pnpm changeset publish
-          version: pnpm version
+          version: pnpm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
`pnpm version` runs the built-in command (prints version info), while `pnpm run version` runs the script that applies changesets.