### PR TITLE
Enable npm provenance for package publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
@@ -29,4 +33,3 @@ jobs:
           version: pnpm run version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ node_modules/
 dist/
 *.tgz
 
+.claude/
+
 .venv
 docs/.vitepress/cache
 .DS_Store


### PR DESCRIPTION
npm deprecated classic tokens in December 2025, shifting to session-based auth and OIDC trusted publishing. This updates the release workflow to use OIDC-based authentication by adding the `id-token: write` permission, which enables npm provenance.