### PR TITLE
Fix BigInt fill_value for missing chunks in uint64/int64 arrays

### DIFF
--- a/.changeset/fix-bigint-fill-value.md
+++ b/.changeset/fix-bigint-fill-value.md
@@ -1,0 +1,5 @@
+---
+"zarrita": patch
+---
+
+Fix "Cannot convert 0 to a BigInt" error when reading missing chunks from uint64/int64 arrays

--- a/packages/zarrita/__tests__/hierarchy.test.ts
+++ b/packages/zarrita/__tests__/hierarchy.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, expectTypeOf, test } from "vitest";
+import { assert, describe, expect, expectTypeOf, test } from "vitest";
 import { Array, Group } from "../src/hierarchy.js";
 import type {
 	ArrayMetadata,
@@ -80,6 +80,34 @@ describe("Array", () => {
 		if (arr.is("int8")) {
 			expectTypeOf(arr.dtype).toMatchTypeOf<Int8>();
 		}
+	});
+
+	test("getChunk returns fill_value for missing uint64 chunk", async () => {
+		// Cast needed: fill_value is intentionally a number (not bigint) to
+		// simulate JSON-parsed metadata, which is how the bug manifests.
+		let arr = new Array(new Map(), "/", {
+			...array_metadata,
+			data_type: "uint64",
+			codecs: [{ name: "bytes", configuration: { endian: "little" } }],
+		} as ArrayMetadata);
+		let chunk = await arr.getChunk([0, 0]);
+		expect(chunk.data).toBeInstanceOf(BigUint64Array);
+		assert(chunk.data instanceof BigUint64Array);
+		expect(chunk.data[0]).toBe(0n);
+	});
+
+	test("getChunk returns fill_value for missing int64 chunk", async () => {
+		// Cast needed: fill_value is intentionally a number (not bigint) to
+		// simulate JSON-parsed metadata, which is how the bug manifests.
+		let arr = new Array(new Map(), "/", {
+			...array_metadata,
+			data_type: "int64",
+			codecs: [{ name: "bytes", configuration: { endian: "little" } }],
+		} as ArrayMetadata);
+		let chunk = await arr.getChunk([0, 0]);
+		expect(chunk.data).toBeInstanceOf(BigInt64Array);
+		assert(chunk.data instanceof BigInt64Array);
+		expect(chunk.data[0]).toBe(0n);
 	});
 });
 

--- a/packages/zarrita/src/hierarchy.ts
+++ b/packages/zarrita/src/hierarchy.ts
@@ -170,7 +170,7 @@ export class Array<
 			...metadata,
 			fill_value: ensure_correct_scalar(metadata),
 		};
-		this[CONTEXT_MARKER] = create_context(this, metadata);
+		this[CONTEXT_MARKER] = create_context(this, this.#metadata);
 	}
 
 	get attrs(): Attributes {


### PR DESCRIPTION
Closes #341

The `Array` constructor called `ensure_correct_scalar` to convert numeric fill values to `BigInt` for 64-bit integer types, but passed the original (unconverted) metadata to `create_context`. When a chunk was missing, `BigUint64Array.fill(0)` threw "Cannot convert 0 to a BigInt".

Pass the corrected metadata (with BigInt fill_value) to `create_context`.