### PR TITLE
fix(sharding): deduplicate concurrent shard index fetches

### DIFF
--- a/.changeset/fix-shard-index-race.md
+++ b/.changeset/fix-shard-index-race.md
@@ -1,0 +1,5 @@
+---
+"zarrita": patch
+---
+
+fix(sharding): deduplicate concurrent shard index fetches

--- a/packages/zarrita/__tests__/open.test.ts
+++ b/packages/zarrita/__tests__/open.test.ts
@@ -1227,6 +1227,69 @@ describe("v3", async () => {
 		});
 	});
 
+	it("deduplicates concurrent shard index fetches", async () => {
+		let fs_store = new FileSystemStore(
+			path.resolve(__dirname, "../../../fixtures/v3/data.zarr"),
+		);
+		let spy = vi.spyOn(fs_store, "getRange");
+		// 2d.chunked.compressed.sharded.i2: shape [4,4], shard [2,2], inner [1,1]
+		// chunks [0,0],[0,1],[1,0],[1,1] are all in shard c/0/0
+		let arr = await open.v3(
+			root(fs_store).resolve("2d.chunked.compressed.sharded.i2"),
+			{
+				kind: "array",
+			},
+		);
+		spy.mockClear();
+		// Read 4 chunks from the same shard concurrently
+		let results = await Promise.all([
+			arr.getChunk([0, 0]),
+			arr.getChunk([0, 1]),
+			arr.getChunk([1, 0]),
+			arr.getChunk([1, 1]),
+		]);
+		expect(results[0].data).toStrictEqual(new Int16Array([1]));
+		expect(results[1].data).toStrictEqual(new Int16Array([2]));
+		expect(results[2].data).toStrictEqual(new Int16Array([5]));
+		expect(results[3].data).toStrictEqual(new Int16Array([6]));
+		// Count suffix range requests (shard index fetches)
+		let suffix_calls = spy.mock.calls.filter(
+			(call) => call[1] && "suffixLength" in call[1],
+		);
+		expect(suffix_calls).toHaveLength(1);
+		spy.mockRestore();
+	});
+
+	it("evicts cached shard index on fetch failure and retries", async () => {
+		let fs_store = new FileSystemStore(
+			path.resolve(__dirname, "../../../fixtures/v3/data.zarr"),
+		);
+		if (!fs_store.getRange)
+			throw new Error("FileSystemStore must support getRange");
+		let original = fs_store.getRange.bind(fs_store);
+		let call_count = 0;
+		vi.spyOn(fs_store, "getRange").mockImplementation((key, range, options) => {
+			call_count++;
+			// Fail the first suffix range request (shard index), pass the rest
+			if (call_count === 1 && range && "suffixLength" in range) {
+				return Promise.reject(new Error("transient network error"));
+			}
+			return original(key, range, options);
+		});
+		let arr = await open.v3(
+			root(fs_store).resolve("2d.chunked.compressed.sharded.i2"),
+			{ kind: "array" },
+		);
+		call_count = 0;
+		// First read should fail
+		await expect(arr.getChunk([0, 0])).rejects.toThrow(
+			"transient network error",
+		);
+		// Retry should succeed (cache evicted the failed Promise)
+		let chunk = await arr.getChunk([0, 0]);
+		expect(chunk.data).toStrictEqual(new Int16Array([1]));
+	});
+
 	describe("sharded arrays from ZipFileStore (uncompressed)", async () => {
 		let uncompressed_zip_buffer = await fs.readFile(
 			path.resolve(

--- a/packages/zarrita/src/codecs/sharding.ts
+++ b/packages/zarrita/src/codecs/sharding.ts
@@ -23,7 +23,9 @@ export function create_sharded_chunk_getter<Store extends Readable>(
 		codecs: sharding_config.index_codecs,
 	});
 
-	let cache: Record<string, Chunk<"uint64"> | null> = {};
+	let checksum_size = 4;
+	let index_size = 16 * index_shape.reduce((a, b) => a * b, 1);
+	let cache: Record<string, Promise<Chunk<"uint64"> | null>> = {};
 	return async (
 		chunk_coord: number[],
 		options?: Parameters<Store["get"]>[1],
@@ -31,23 +33,22 @@ export function create_sharded_chunk_getter<Store extends Readable>(
 		let shard_coord = chunk_coord.map((d, i) => Math.floor(d / index_shape[i]));
 		let shard_path = location.resolve(encode_shard_key(shard_coord)).path;
 
-		let index: Chunk<"uint64"> | null;
-		if (shard_path in cache) {
-			index = cache[shard_path];
-		} else {
-			let checksum_size = 4;
-			let index_size = 16 * index_shape.reduce((a, b) => a * b, 1);
-			let bytes = await get_range(
-				shard_path,
-				{
-					suffixLength: index_size + checksum_size,
-				},
-				options,
-			);
-			index = cache[shard_path] = bytes
-				? await index_codec.decode(bytes)
-				: null;
+		if (!(shard_path in cache)) {
+			cache[shard_path] = (async () => {
+				let bytes = await get_range(
+					shard_path,
+					{
+						suffixLength: index_size + checksum_size,
+					},
+					options,
+				);
+				return bytes ? await index_codec.decode(bytes) : null;
+			})().catch((err) => {
+				delete cache[shard_path];
+				throw err;
+			});
 		}
+		let index = await cache[shard_path];
 
 		if (index === null) {
 			return undefined;


### PR DESCRIPTION
`create_sharded_chunk_getter` caches decoded shard indices in a plain object, but the cache is only populated after the async index fetch completes. When `get()` dispatches multiple chunks from the same shard concurrently (via `create_queue`), each sees a cache miss and fetches the index independently.

Fix: cache the `Promise<Chunk<"uint64"> | null>` instead of the resolved value. The Promise is stored synchronously before any `await`, so concurrent callers immediately see it and share the same in-flight fetch. Added `.catch()` eviction so transient network errors don't permanently poison the cache.

Behavioral note: the first concurrent caller's `options` (including `AbortSignal`) is used for the shared fetch. This matches the existing cache-hit behavior where resolved indices are reused regardless of the new caller's options. In practice, concurrent callers within a single `get()` call always share the same options.

Tests:
- 4 concurrent `getChunk` calls on chunks in the same shard: spy confirms 1 suffix request instead of 4
- Error eviction: mock `getRange` to reject once, verify retry succeeds (cache doesn't permanently poison)

Fixes #345.

*AI (Claude) supported my development of this PR.*