### PR TITLE
Rename internal snake_case identifiers to camelCase

### DIFF
--- a/.changeset/camelcase-internals.md
+++ b/.changeset/camelcase-internals.md
@@ -2,14 +2,14 @@
 "zarrita": minor
 ---
 
-**BREAKING**: `zarr.create` options now use camelCase (`chunkShape`, `dataType`, `fillValue`, `chunkSeparator`, `dimensionNames`).
+**BREAKING**: `zarr.create` options now use camelCase (`chunkShape`, `fillValue`, `chunkSeparator`, `dimensionNames`).
 
 ```ts
-zarr.create(store, {
+await zarr.create(store, {
+  dtype: "float32",            // was data_type
   shape: [100, 100],
-  chunkShape: [10, 10],
-  dataType: "float32",
-  fillValue: 0,
-  dimensionNames: ["y", "x"],
-});
+  chunkShape: [10, 10],        // was chunk_shape
+  fillValue: 0,                // was fill_value
+  dimensionNames: ["y", "x"],  // was dimension_names
+})
 ```

--- a/.changeset/camelcase-internals.md
+++ b/.changeset/camelcase-internals.md
@@ -1,0 +1,15 @@
+---
+"zarrita": minor
+---
+
+**BREAKING**: `zarr.create` options now use camelCase (`chunkShape`, `dataType`, `fillValue`, `chunkSeparator`, `dimensionNames`).
+
+```ts
+zarr.create(store, {
+  shape: [100, 100],
+  chunkShape: [10, 10],
+  dataType: "float32",
+  fillValue: 0,
+  dimensionNames: ["y", "x"],
+});
+```

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -66,9 +66,9 @@ import { FileSystemStore } from "@zarrita/storage";
 
 const store = new FileSystemStore("tempstore");
 const arr = await zarr.create(store, {
-	shape: [10, 10],
-	chunks: [5, 5],
 	dtype: "int32",
+	shape: [10, 10],
+	chunkShape: [5, 5],
 });
 arr; // zarr.Array<"int32", FileSystemStore>
 ```

--- a/docs/packages/zarrita.md
+++ b/docs/packages/zarrita.md
@@ -147,7 +147,7 @@ let grp = await zarr.create(root);
 let arr = await zarr.create(root.resolve("foo"), {
 	dtype: "int32",
 	shape: [4, 4],
-	chunks: [2, 2],
+	chunkShape: [2, 2],
 });
 console.log(root.store);
 // Map(2) {
@@ -236,7 +236,7 @@ system correctly infers that the value of chunk `data` is a `BigInt64Array`:
 
 ```javascript
 let arr = await zarr.create(root.resolve("foo"), {
-	dataType: "int64",
+	dtype: "int64",
 	shape: [4, 4],
 	chunkShape: [2, 2],
 	dimensionNames: ["x", "y"],

--- a/docs/packages/zarrita.md
+++ b/docs/packages/zarrita.md
@@ -145,9 +145,9 @@ import * as zarr from "zarrita";
 let root = zarr.root(new Map());
 let grp = await zarr.create(root);
 let arr = await zarr.create(root.resolve("foo"), {
-	data_type: "int32",
+	dtype: "int32",
 	shape: [4, 4],
-	chunk_shape: [2, 2],
+	chunks: [2, 2],
 });
 console.log(root.store);
 // Map(2) {
@@ -236,9 +236,10 @@ system correctly infers that the value of chunk `data` is a `BigInt64Array`:
 
 ```javascript
 let arr = await zarr.create(root.resolve("foo"), {
-	data_type: "int64",
+	dataType: "int64",
 	shape: [4, 4],
-	chunk_shape: [2, 2],
+	chunkShape: [2, 2],
+	dimensionNames: ["x", "y"],
 });
 let chunk = await arr.getChunk([0, 0]);
 // ^ Chunk<"int64">

--- a/packages/@zarrita-ndarray/__tests__/setter.test.ts
+++ b/packages/@zarrita-ndarray/__tests__/setter.test.ts
@@ -2,10 +2,10 @@ import ndarray, { type TypedArray } from "ndarray";
 import { assign } from "ndarray-ops";
 import { describe, expect, it } from "vitest";
 import {
-	_zarrita_internal_get_strides as get_strides,
+	_zarrita_internal_getStrides as get_strides,
 	type Projection,
 	slice,
-	_zarrita_internal_slice_indices as slice_indices,
+	_zarrita_internal_sliceIndices as slice_indices,
 } from "zarrita";
 
 import { _internal_setter } from "../src/index.js";
@@ -23,7 +23,7 @@ function to_c<T extends TypedArray>({
 }
 
 describe("setter", () => {
-	it("setter.set_scalar - fill", async () => {
+	it("setter.setScalar - fill", async () => {
 		let a = _internal_setter.prepare(
 			new Float32Array(2 * 3 * 4),
 			[2, 3, 4],
@@ -31,7 +31,7 @@ describe("setter", () => {
 		);
 
 		let sel = [2, 3, 4].map((size) => slice_indices(slice(null), size));
-		_internal_setter.set_scalar(a, sel, 1);
+		_internal_setter.setScalar(a, sel, 1);
 		// biome-ignore format: the array should not be formatted
 		expect(a.data).toStrictEqual(new Float32Array([
 			1, 1, 1, 1,
@@ -44,14 +44,14 @@ describe("setter", () => {
 		]));
 	});
 
-	it("setter.set_scalar - point", async () => {
+	it("setter.setScalar - point", async () => {
 		let a = _internal_setter.prepare(
 			new Float32Array(2 * 3 * 4),
 			[2, 3, 4],
 			get_strides([2, 3, 4], "C"),
 		);
 
-		_internal_setter.set_scalar(a, [0, 0, 0], 1);
+		_internal_setter.setScalar(a, [0, 0, 0], 1);
 		// biome-ignore format: the array should not be formatted
 		expect(a.data).toStrictEqual(new Float32Array([
 			1, 0, 0, 0,
@@ -63,7 +63,7 @@ describe("setter", () => {
 			0, 0, 0, 0,
 		]));
 
-		_internal_setter.set_scalar(a, [1, 1, 1], 2);
+		_internal_setter.setScalar(a, [1, 1, 1], 2);
 		// biome-ignore format: the array should not be formatted
 		expect(a.data).toStrictEqual(new Float32Array([
 			1, 0, 0, 0,
@@ -75,7 +75,7 @@ describe("setter", () => {
 			0, 0, 0, 0,
 		]));
 
-		_internal_setter.set_scalar(a, [1, 2, 3], 3);
+		_internal_setter.setScalar(a, [1, 2, 3], 3);
 		// biome-ignore format: the array should not be formatted
 		expect(a.data).toStrictEqual(new Float32Array([
 			1, 0, 0, 0,
@@ -87,7 +87,7 @@ describe("setter", () => {
 			0, 0, 0, 3,
 		]));
 
-		_internal_setter.set_scalar(a, [1, 2, 2], 4);
+		_internal_setter.setScalar(a, [1, 2, 2], 4);
 		// biome-ignore format: the array should not be formatted
 		expect(a.data).toStrictEqual(new Float32Array([
 			1, 0, 0, 0,
@@ -100,7 +100,7 @@ describe("setter", () => {
 		]));
 	});
 
-	it("setter.set_scalar - mixed", async () => {
+	it("setter.setScalar - mixed", async () => {
 		let a = _internal_setter.prepare(
 			new Float32Array(2 * 3 * 4),
 			[2, 3, 4],
@@ -108,7 +108,7 @@ describe("setter", () => {
 		);
 
 		let sel = [slice_indices(slice(null), 2), slice_indices(slice(2), 3), 0];
-		_internal_setter.set_scalar(a, sel, 1);
+		_internal_setter.setScalar(a, sel, 1);
 		// biome-ignore format: the array should not be formatted
 		expect(a.data).toStrictEqual(new Float32Array([
 			1, 0, 0, 0,
@@ -121,7 +121,7 @@ describe("setter", () => {
 		]));
 
 		sel = [0, slice_indices(slice(null), 3), slice_indices(slice(null), 4)];
-		_internal_setter.set_scalar(a, sel, 2);
+		_internal_setter.setScalar(a, sel, 2);
 
 		// biome-ignore format: the array should not be formatted
 		expect(a.data).toStrictEqual(new Float32Array([
@@ -135,7 +135,7 @@ describe("setter", () => {
 		]));
 	});
 
-	it("setter.set_scalar - mixed F order", async () => {
+	it("setter.setScalar - mixed F order", async () => {
 		let f = _internal_setter.prepare<"float32">(
 			new Float32Array(2 * 3 * 4),
 			[2, 3, 4],
@@ -143,7 +143,7 @@ describe("setter", () => {
 		);
 
 		let sel = [slice_indices(slice(null), 2), slice_indices(slice(2), 3), 0];
-		_internal_setter.set_scalar(f, sel, 1);
+		_internal_setter.setScalar(f, sel, 1);
 		// biome-ignore format: the array should not be formatted
 		expect(f.data).toStrictEqual(new Float32Array([
 			1, 1, 1, 1, 0, 0,
@@ -153,7 +153,7 @@ describe("setter", () => {
 		]));
 
 		sel = [0, slice_indices(slice(null), 3), slice_indices(slice(null), 4)];
-		_internal_setter.set_scalar(f, sel, 2);
+		_internal_setter.setScalar(f, sel, 2);
 
 		// biome-ignore format: the array should not be formatted
 		expect(f.data).toStrictEqual(new Float32Array([
@@ -175,7 +175,7 @@ describe("setter", () => {
 		]));
 	});
 
-	it("set_from_chunk - complete", async () => {
+	it("setFromChunk - complete", async () => {
 		let dest = _internal_setter.prepare(
 			new Float32Array(2 * 3 * 4),
 			[2, 3, 4],
@@ -194,7 +194,7 @@ describe("setter", () => {
 			{ from: [0, 2, 1], to: [0, 2, 1] },
 		];
 
-		_internal_setter.set_from_chunk(dest, src, mapping);
+		_internal_setter.setFromChunk(dest, src, mapping);
 		// biome-ignore format: the array should not be formatted
 		expect(dest.data).toStrictEqual(new Float32Array([
 			1, 1, 0, 0,
@@ -207,7 +207,7 @@ describe("setter", () => {
 		]));
 	});
 
-	it("set_from_chunk - from complete to strided", async () => {
+	it("setFromChunk - from complete to strided", async () => {
 		let dest = _internal_setter.prepare(
 			new Float32Array(2 * 3 * 4),
 			[2, 3, 4],
@@ -226,7 +226,7 @@ describe("setter", () => {
 			{ from: [0, 2, 1], to: [0, 4, 2] },
 		];
 
-		_internal_setter.set_from_chunk(dest, src, mapping);
+		_internal_setter.setFromChunk(dest, src, mapping);
 		// biome-ignore format: the array should not be formatted
 		expect(dest.data).toStrictEqual(new Float32Array([
 			2, 0, 2, 0,
@@ -239,7 +239,7 @@ describe("setter", () => {
 		]));
 	});
 
-	it("set_from_chunk - from strided to complete", async () => {
+	it("setFromChunk - from strided to complete", async () => {
 		let dest = _internal_setter.prepare(
 			new Float32Array(2 * 2 * 2),
 			[2, 2, 2],
@@ -267,11 +267,11 @@ describe("setter", () => {
 			{ to: [0, 2, 1], from: [0, 4, 2] },
 		];
 
-		_internal_setter.set_from_chunk(dest, src, mapping);
+		_internal_setter.setFromChunk(dest, src, mapping);
 		expect(dest.data).toStrictEqual(new Float32Array(2 * 2 * 2).fill(2));
 	});
 
-	it("set_from_chunk - src squeezed", async () => {
+	it("setFromChunk - src squeezed", async () => {
 		let dest = _internal_setter.prepare(
 			new Float32Array(2 * 3 * 4),
 			[2, 3, 4],
@@ -290,7 +290,7 @@ describe("setter", () => {
 			{ to: 1, from: null },
 		];
 
-		_internal_setter.set_from_chunk(dest, src, mapping);
+		_internal_setter.setFromChunk(dest, src, mapping);
 		// biome-ignore format: the array should not be formatted
 		expect(dest.data).toStrictEqual(new Float32Array([
 			0, 2, 0, 0,
@@ -303,7 +303,7 @@ describe("setter", () => {
 		]));
 	});
 
-	it("set_from_chunk - dest squeezed", async () => {
+	it("setFromChunk - dest squeezed", async () => {
 		let dest = _internal_setter.prepare(
 			new Float32Array(4),
 			[4],
@@ -331,11 +331,11 @@ describe("setter", () => {
 			{ from: 1, to: null },
 		];
 
-		_internal_setter.set_from_chunk(dest, src, mapping);
+		_internal_setter.setFromChunk(dest, src, mapping);
 		expect(dest.data).toStrictEqual(new Float32Array([2, 0, 0, 2]));
 	});
 
-	it("set_from_chunk - complete F order", async () => {
+	it("setFromChunk - complete F order", async () => {
 		let dest = _internal_setter.prepare<"float32">(
 			new Float32Array(2 * 3 * 4),
 			[2, 3, 4],
@@ -354,7 +354,7 @@ describe("setter", () => {
 			{ from: [0, 2, 1], to: [0, 2, 1] },
 		];
 
-		_internal_setter.set_from_chunk(dest, src, mapping);
+		_internal_setter.setFromChunk(dest, src, mapping);
 		// biome-ignore format: the array should not be formatted
 		expect(to_c(dest).data).toStrictEqual(new Float32Array([
 			1, 1, 0, 0,
@@ -367,7 +367,7 @@ describe("setter", () => {
 		]));
 	});
 
-	it("set_from_chunk - F order", async () => {
+	it("setFromChunk - F order", async () => {
 		let dest = _internal_setter.prepare<"float32">(
 			new Float32Array(2 * 3 * 4),
 			[2, 3, 4],
@@ -386,7 +386,7 @@ describe("setter", () => {
 			{ to: 1, from: null },
 		];
 
-		_internal_setter.set_from_chunk(dest, src, mapping);
+		_internal_setter.setFromChunk(dest, src, mapping);
 		// biome-ignore format: the array should not be formatted
 		expect(to_c(dest).data).toStrictEqual(new Float32Array([
 			0, 2, 0, 0,
@@ -399,7 +399,7 @@ describe("setter", () => {
 		]));
 	});
 
-	it("set_from_chunk - dest=F order, src=C order", async () => {
+	it("setFromChunk - dest=F order, src=C order", async () => {
 		let dest = _internal_setter.prepare<"float32">(
 			new Float32Array(2 * 3 * 4),
 			[2, 3, 4],
@@ -418,7 +418,7 @@ describe("setter", () => {
 			{ to: 1, from: null },
 		];
 
-		_internal_setter.set_from_chunk(dest, src, mapping);
+		_internal_setter.setFromChunk(dest, src, mapping);
 		// biome-ignore format: the array should not be formatted
 		expect(to_c(dest).data).toStrictEqual(new Float32Array([
 			0, 2, 0, 0,
@@ -431,7 +431,7 @@ describe("setter", () => {
 		]));
 	});
 
-	it("set_from_chunk - dest=C order, src=F order", async () => {
+	it("setFromChunk - dest=C order, src=F order", async () => {
 		let dest = _internal_setter.prepare<"float32">(
 			new Float32Array(2 * 3 * 4),
 			[2, 3, 4],
@@ -450,7 +450,7 @@ describe("setter", () => {
 			{ to: 1, from: null },
 		];
 
-		_internal_setter.set_from_chunk(dest, src, mapping);
+		_internal_setter.setFromChunk(dest, src, mapping);
 		// biome-ignore format: the array should not be formatted
 		expect(dest.data).toStrictEqual(new Float32Array([
 			0, 2, 0, 0,

--- a/packages/@zarrita-ndarray/__tests__/slice.test.ts
+++ b/packages/@zarrita-ndarray/__tests__/slice.test.ts
@@ -14,7 +14,7 @@ const DATA = {
 describe("builtin slice", async () => {
 	let arr = await create(new Map(), {
 		shape: [2, 3, 4],
-		dataType: "int32",
+		dtype: "int32",
 		chunkShape: [1, 2, 2],
 	});
 	await set(arr, null, ndarray(DATA.data, DATA.shape, DATA.stride));

--- a/packages/@zarrita-ndarray/__tests__/slice.test.ts
+++ b/packages/@zarrita-ndarray/__tests__/slice.test.ts
@@ -14,8 +14,8 @@ const DATA = {
 describe("builtin slice", async () => {
 	let arr = await create(new Map(), {
 		shape: [2, 3, 4],
-		data_type: "int32",
-		chunk_shape: [1, 2, 2],
+		dataType: "int32",
+		chunkShape: [1, 2, 2],
 	});
 	await set(arr, null, ndarray(DATA.data, DATA.shape, DATA.stride));
 

--- a/packages/@zarrita-ndarray/src/index.ts
+++ b/packages/@zarrita-ndarray/src/index.ts
@@ -11,19 +11,19 @@ export const _internal_setter: {
 		shape: number[],
 		stride: number[],
 	) => ndarray.NdArray<zarr.TypedArray<D>>;
-	set_scalar: <D extends zarr.DataType>(
+	setScalar: <D extends zarr.DataType>(
 		target: ndarray.NdArray<zarr.TypedArray<D>>,
 		selection: (zarr.Indices | number)[],
 		value: zarr.Scalar<D>,
 	) => void;
-	set_from_chunk: <D extends zarr.DataType>(
+	setFromChunk: <D extends zarr.DataType>(
 		a: ndarray.NdArray<zarr.TypedArray<D>>,
 		b: ndarray.NdArray<zarr.TypedArray<D>>,
 		proj: zarr.Projection[],
 	) => void;
 } = {
 	prepare: ndarray,
-	set_scalar<D extends zarr.DataType>(
+	setScalar<D extends zarr.DataType>(
 		dest: ndarray.NdArray<zarr.TypedArray<D>>,
 		selection: (number | zarr.Indices)[],
 		value: zarr.Scalar<D>,
@@ -31,12 +31,12 @@ export const _internal_setter: {
 		// @ts-expect-error - ndarray-ops types are incorrect
 		ops.assigns(view(dest, selection), value);
 	},
-	set_from_chunk<D extends zarr.DataType>(
+	setFromChunk<D extends zarr.DataType>(
 		dest: ndarray.NdArray<zarr.TypedArray<D>>,
 		src: ndarray.NdArray<zarr.TypedArray<D>>,
 		mapping: zarr.Projection[],
 	) {
-		const s = unzip_selections(mapping);
+		const s = unzipSelections(mapping);
 		ops.assign(view(dest, s.to), view(src, s.from));
 	},
 };
@@ -81,7 +81,7 @@ export async function set<D extends zarr.DataType>(
 	);
 }
 
-function unzip_selections(mapping: zarr.Projection[]): {
+function unzipSelections(mapping: zarr.Projection[]): {
 	to: (number | zarr.Indices)[];
 	from: (number | zarr.Indices)[];
 } {

--- a/packages/@zarrita-storage/jsr.json
+++ b/packages/@zarrita-storage/jsr.json
@@ -5,7 +5,7 @@
 	"nodeModulesDir": "auto",
 	"imports": {
 		"reference-spec-reader": "npm:reference-spec-reader@^0.2.0",
-		"unzipit": "npm:unzipit@1.4.3"
+		"unzipit": "npm:unzipit@2.0.0"
 	},
 	"exports": {
 		".": "./src/index.ts",

--- a/packages/@zarrita-storage/src/fetch.ts
+++ b/packages/@zarrita-storage/src/fetch.ts
@@ -1,5 +1,5 @@
 import type { AbsolutePath, AsyncReadable, RangeQuery } from "./types.js";
-import { fetch_range, merge_init } from "./util.js";
+import { fetchRange, mergeInit } from "./util.js";
 
 function resolve(root: string | URL, path: AbsolutePath): URL {
 	const base = typeof root === "string" ? new URL(root) : root;
@@ -13,7 +13,7 @@ function resolve(root: string | URL, path: AbsolutePath): URL {
 	return resolved;
 }
 
-async function handle_response(
+async function handleResponse(
 	response: Response,
 ): Promise<Uint8Array | undefined> {
 	if (response.status === 404) {
@@ -27,26 +27,26 @@ async function handle_response(
 	);
 }
 
-async function fetch_suffix(
+async function fetchSuffix(
 	url: URL,
-	suffix_length: number,
+	suffixLength: number,
 	init: RequestInit,
-	use_suffix_request: boolean,
+	useSuffixRequest: boolean,
 ): Promise<Response> {
-	if (use_suffix_request) {
+	if (useSuffixRequest) {
 		return fetch(url, {
 			...init,
-			headers: { ...init.headers, Range: `bytes=-${suffix_length}` },
+			headers: { ...init.headers, Range: `bytes=-${suffixLength}` },
 		});
 	}
 	let response = await fetch(url, { ...init, method: "HEAD" });
 	if (!response.ok) {
-		// will be picked up by handle_response
+		// will be picked up by handleResponse
 		return response;
 	}
-	let content_length = response.headers.get("Content-Length");
-	let length = Number(content_length);
-	return fetch_range(url, length - suffix_length, length, init);
+	let contentLength = response.headers.get("Content-Length");
+	let length = Number(contentLength);
+	return fetchRange(url, length - suffixLength, length, init);
 }
 
 /**
@@ -61,18 +61,18 @@ async function fetch_suffix(
  */
 class FetchStore implements AsyncReadable<RequestInit> {
 	#overrides: RequestInit;
-	#use_suffix_request: boolean;
+	#useSuffixRequest: boolean;
 
 	constructor(
 		public url: string | URL,
 		options: { overrides?: RequestInit; useSuffixRequest?: boolean } = {},
 	) {
 		this.#overrides = options.overrides ?? {};
-		this.#use_suffix_request = options.useSuffixRequest ?? false;
+		this.#useSuffixRequest = options.useSuffixRequest ?? false;
 	}
 
-	#merge_init(overrides: RequestInit) {
-		return merge_init(this.#overrides, overrides);
+	#mergeInit(overrides: RequestInit) {
+		return mergeInit(this.#overrides, overrides);
 	}
 
 	async get(
@@ -80,8 +80,8 @@ class FetchStore implements AsyncReadable<RequestInit> {
 		options: RequestInit = {},
 	): Promise<Uint8Array | undefined> {
 		let href = resolve(this.url, key).href;
-		let response = await fetch(href, this.#merge_init(options));
-		return handle_response(response);
+		let response = await fetch(href, this.#mergeInit(options));
+		return handleResponse(response);
 	}
 
 	async getRange(
@@ -90,19 +90,19 @@ class FetchStore implements AsyncReadable<RequestInit> {
 		options: RequestInit = {},
 	): Promise<Uint8Array | undefined> {
 		let url = resolve(this.url, key);
-		let init = this.#merge_init(options);
+		let init = this.#mergeInit(options);
 		let response: Response;
 		if ("suffixLength" in range) {
-			response = await fetch_suffix(
+			response = await fetchSuffix(
 				url,
 				range.suffixLength,
 				init,
-				this.#use_suffix_request,
+				this.#useSuffixRequest,
 			);
 		} else {
-			response = await fetch_range(url, range.offset, range.length, init);
+			response = await fetchRange(url, range.offset, range.length, init);
 		}
-		return handle_response(response);
+		return handleResponse(response);
 	}
 }
 

--- a/packages/@zarrita-storage/src/fs.ts
+++ b/packages/@zarrita-storage/src/fs.ts
@@ -3,18 +3,18 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 import type { AbsolutePath, AsyncMutable, RangeQuery } from "./types.js";
-import { strip_prefix } from "./util.js";
+import { stripPrefix } from "./util.js";
 
-function is_error_no_entry(err: unknown): err is { code: "ENOENT" } {
-	const is_object = typeof err === "object" && err !== null;
-	return is_object && "code" in err && err.code === "ENOENT";
+function isErrorNoEntry(err: unknown): err is { code: "ENOENT" } {
+	const isObject = typeof err === "object" && err !== null;
+	return isObject && "code" in err && err.code === "ENOENT";
 }
 
 class FileSystemStore implements AsyncMutable {
 	constructor(public root: string) {}
 
 	async get(key: AbsolutePath): Promise<Uint8Array | undefined> {
-		let fp = path.join(this.root, strip_prefix(key));
+		let fp = path.join(this.root, stripPrefix(key));
 		return fs.promises.readFile(fp).catch((err: NodeJS.ErrnoException) => {
 			if (err.code === "ENOENT") return undefined;
 			throw err;
@@ -25,7 +25,7 @@ class FileSystemStore implements AsyncMutable {
 		key: AbsolutePath,
 		range: RangeQuery,
 	): Promise<Uint8Array | undefined> {
-		let fp = path.join(this.root, strip_prefix(key));
+		let fp = path.join(this.root, stripPrefix(key));
 		let filehandle: fs.promises.FileHandle | undefined;
 		try {
 			filehandle = await fs.promises.open(fp, "r");
@@ -45,7 +45,7 @@ class FileSystemStore implements AsyncMutable {
 			return data;
 		} catch (err: unknown) {
 			// return undefined is no file or directory
-			if (is_error_no_entry(err)) {
+			if (isErrorNoEntry(err)) {
 				return undefined;
 			}
 			throw err;
@@ -55,7 +55,7 @@ class FileSystemStore implements AsyncMutable {
 	}
 
 	async has(key: AbsolutePath): Promise<boolean> {
-		const fp = path.join(this.root, strip_prefix(key));
+		const fp = path.join(this.root, stripPrefix(key));
 		return fs.promises
 			.access(fp)
 			.then(() => true)
@@ -63,13 +63,13 @@ class FileSystemStore implements AsyncMutable {
 	}
 
 	async set(key: AbsolutePath, value: Uint8Array): Promise<void> {
-		const fp = path.join(this.root, strip_prefix(key));
+		const fp = path.join(this.root, stripPrefix(key));
 		await fs.promises.mkdir(path.dirname(fp), { recursive: true });
 		await fs.promises.writeFile(fp, value, null);
 	}
 
 	async delete(key: AbsolutePath): Promise<boolean> {
-		const fp = path.join(this.root, strip_prefix(key));
+		const fp = path.join(this.root, stripPrefix(key));
 		await fs.promises.unlink(fp);
 		return true;
 	}

--- a/packages/@zarrita-storage/src/ref.ts
+++ b/packages/@zarrita-storage/src/ref.ts
@@ -1,6 +1,6 @@
 import { parse } from "reference-spec-reader";
 import type { AbsolutePath, AsyncReadable } from "./types.js";
-import { fetch_range, merge_init, strip_prefix, uri2href } from "./util.js";
+import { fetchRange, mergeInit, stripPrefix, uri2href } from "./util.js";
 
 /**
  * This is for the "binary" loader (custom code is ~2x faster than "atob") from esbuild.
@@ -10,7 +10,7 @@ let table = new Uint8Array(128);
 for (let i = 0; i < 64; i++) {
 	table[i < 26 ? i + 65 : i < 52 ? i + 71 : i < 62 ? i - 4 : i * 4 - 205] = i;
 }
-export function to_binary(base64: string): Uint8Array {
+export function toBinary(base64: string): Uint8Array {
 	const n = base64.length;
 	const bytes = new Uint8Array(
 		// @ts-expect-error
@@ -57,13 +57,13 @@ class ReferenceStore implements AsyncReadable<RequestInit> {
 		key: AbsolutePath,
 		opts: RequestInit = {},
 	): Promise<Uint8Array | undefined> {
-		let ref = (await this.#refs).get(strip_prefix(key));
+		let ref = (await this.#refs).get(stripPrefix(key));
 
 		if (!ref) return;
 
 		if (typeof ref === "string") {
 			if (ref.startsWith("base64:")) {
-				return to_binary(ref.slice("base64:".length));
+				return toBinary(ref.slice("base64:".length));
 			}
 			return new TextEncoder().encode(ref);
 		}
@@ -74,11 +74,11 @@ class ReferenceStore implements AsyncReadable<RequestInit> {
 			throw Error(`No url for key ${key}, and no target url provided.`);
 		}
 
-		let res = await fetch_range(
+		let res = await fetchRange(
 			uri2href(url),
 			offset,
 			size,
-			merge_init(this.#overrides, opts),
+			mergeInit(this.#overrides, opts),
 		);
 
 		if (res.status === 200 || res.status === 206) {

--- a/packages/@zarrita-storage/src/util.ts
+++ b/packages/@zarrita-storage/src/util.ts
@@ -1,6 +1,6 @@
 import type { AbsolutePath } from "./types.js";
 
-export function strip_prefix<Path extends AbsolutePath>(
+export function stripPrefix<Path extends AbsolutePath>(
 	path: Path,
 ): Path extends AbsolutePath<infer Rest> ? Rest : never {
 	// @ts-expect-error - TS can't infer this type correctly
@@ -23,7 +23,7 @@ export function uri2href(url: string | URL) {
 	throw Error(`Protocol not supported, got: ${JSON.stringify(protocol)}`);
 }
 
-export function fetch_range(
+export function fetchRange(
 	url: string | URL,
 	offset?: number,
 	length?: number,
@@ -42,7 +42,7 @@ export function fetch_range(
 	return fetch(url, opts);
 }
 
-export function merge_init(
+export function mergeInit(
 	storeOverrides: RequestInit,
 	requestOverrides: RequestInit,
 ) {

--- a/packages/@zarrita-storage/src/zip.ts
+++ b/packages/@zarrita-storage/src/zip.ts
@@ -1,7 +1,7 @@
 import type { Reader, ZipEntry, ZipInfo } from "unzipit";
 import { unzip } from "unzipit";
 import type { AbsolutePath, AsyncReadable, RangeQuery } from "./types.js";
-import { assert, fetch_range, strip_prefix } from "./util.js";
+import { assert, fetchRange, stripPrefix } from "./util.js";
 
 /**
  * Shape of the private `_rawEntry` field on `ZipEntry` instances.
@@ -83,7 +83,7 @@ export class HTTPRangeReader implements Reader {
 		if (size === 0) {
 			return new Uint8Array(0);
 		}
-		const req = await fetch_range(this.url, offset, size, this.#overrides);
+		const req = await fetchRange(this.url, offset, size, this.#overrides);
 		assert(
 			req.ok,
 			`failed http request ${this.url}, status: ${req.status} offset: ${offset} size: ${size}: ${req.statusText}`,
@@ -124,7 +124,7 @@ class ZipFileStore<R extends Reader = Reader> implements AsyncReadable {
 	}
 
 	async get(key: AbsolutePath): Promise<Uint8Array | undefined> {
-		let entry = (await this.info).entries[strip_prefix(key)];
+		let entry = (await this.info).entries[stripPrefix(key)];
 		if (!entry) return;
 		return new Uint8Array(await entry.arrayBuffer());
 	}
@@ -133,7 +133,7 @@ class ZipFileStore<R extends Reader = Reader> implements AsyncReadable {
 		key: AbsolutePath,
 		range: RangeQuery,
 	): Promise<Uint8Array | undefined> {
-		const entry = (await this.info).entries[strip_prefix(key)];
+		const entry = (await this.info).entries[stripPrefix(key)];
 		if (!entry) return undefined;
 
 		const rawEntry = getRawEntry(entry);
@@ -165,7 +165,7 @@ class ZipFileStore<R extends Reader = Reader> implements AsyncReadable {
 	}
 
 	async has(key: AbsolutePath): Promise<boolean> {
-		return strip_prefix(key) in (await this.info).entries;
+		return stripPrefix(key) in (await this.info).entries;
 	}
 
 	static fromUrl(

--- a/packages/zarrita/__tests__/create.test.ts
+++ b/packages/zarrita/__tests__/create.test.ts
@@ -31,7 +31,7 @@ test("create array", async () => {
 	let a = await zarr.create(h.resolve("/arthur/dent"), {
 		shape: [5, 10],
 		chunkShape: [2, 5],
-		dataType: "int32",
+		dtype: "int32",
 		attributes,
 	});
 	expect(a).toBeInstanceOf(zarr.Array);
@@ -101,7 +101,7 @@ describe("create array with IEEE 754 special fill values", () => {
 		let a = await zarr.create(h.resolve("/test"), {
 			shape: [2],
 			chunkShape: [2],
-			dataType: "float32",
+			dtype: "float32",
 			fillValue: fill_value,
 			codecs: [],
 		});
@@ -116,7 +116,7 @@ test("create array with dimension_names", async () => {
 	let a = await zarr.create(h.resolve("/temp"), {
 		shape: [100, 200],
 		chunkShape: [10, 20],
-		dataType: "float32",
+		dtype: "float32",
 		dimensionNames: ["x", "y"],
 	});
 	expect(a.dimensionNames).toStrictEqual(["x", "y"]);
@@ -130,7 +130,7 @@ test("create array with fill_value", async () => {
 	let a = await zarr.create(h.resolve("/temp"), {
 		shape: [10],
 		chunkShape: [5],
-		dataType: "float32",
+		dtype: "float32",
 		fillValue: -9999,
 	});
 	expect(a.fillValue).toBe(-9999);
@@ -141,7 +141,7 @@ test("create array without dimension_names", async () => {
 	let a = await zarr.create(h.resolve("/temp"), {
 		shape: [10],
 		chunkShape: [5],
-		dataType: "int32",
+		dtype: "int32",
 	});
 	expect(a.dimensionNames).toBeUndefined();
 });
@@ -151,7 +151,7 @@ test("get scalar array returns fill value before set", async () => {
 	let arr = await zarr.create(h.resolve("/scalar"), {
 		shape: [],
 		chunkShape: [],
-		dataType: "float64",
+		dtype: "float64",
 		fillValue: -9999,
 	});
 	let value = await zarr.get(arr);
@@ -163,7 +163,7 @@ test("set and get scalar array (shape=[])", async () => {
 	let arr = await zarr.create(h.resolve("/scalar"), {
 		shape: [],
 		chunkShape: [],
-		dataType: "float64",
+		dtype: "float64",
 		fillValue: 0,
 	});
 	expect(arr.shape).toStrictEqual([]);
@@ -180,7 +180,7 @@ test("create nodes via groups", async () => {
 	let paranoid = await zarr.create(marvin.resolve("paranoid"));
 	let android = await zarr.create(marvin.resolve("android"), {
 		shape: [42, 42],
-		dataType: "uint8",
+		dtype: "uint8",
 		chunkShape: [2, 2],
 	});
 	expect(marvin).toBeInstanceOf(zarr.Group);

--- a/packages/zarrita/__tests__/create.test.ts
+++ b/packages/zarrita/__tests__/create.test.ts
@@ -1,11 +1,11 @@
 import { assert, describe, expect, test } from "vitest";
 
 import * as zarr from "../src/index.js";
-import { json_decode_object } from "../src/util.js";
+import { jsonDecodeObject } from "../src/util.js";
 
 function json_decode(x: Uint8Array | undefined) {
 	assert(x);
-	return json_decode_object(x);
+	return jsonDecodeObject(x);
 }
 
 test("create root group", async () => {
@@ -30,8 +30,8 @@ test("create array", async () => {
 	let attributes = { question: "life", answer: 42 };
 	let a = await zarr.create(h.resolve("/arthur/dent"), {
 		shape: [5, 10],
-		chunk_shape: [2, 5],
-		data_type: "int32",
+		chunkShape: [2, 5],
+		dataType: "int32",
 		attributes,
 	});
 	expect(a).toBeInstanceOf(zarr.Array);
@@ -100,9 +100,9 @@ describe("create array with IEEE 754 special fill values", () => {
 		let h = zarr.root();
 		let a = await zarr.create(h.resolve("/test"), {
 			shape: [2],
-			chunk_shape: [2],
-			data_type: "float32",
-			fill_value,
+			chunkShape: [2],
+			dataType: "float32",
+			fillValue: fill_value,
 			codecs: [],
 		});
 		let meta = json_decode(h.store.get("/test/zarr.json"));
@@ -115,9 +115,9 @@ test("create array with dimension_names", async () => {
 	let h = zarr.root();
 	let a = await zarr.create(h.resolve("/temp"), {
 		shape: [100, 200],
-		chunk_shape: [10, 20],
-		data_type: "float32",
-		dimension_names: ["x", "y"],
+		chunkShape: [10, 20],
+		dataType: "float32",
+		dimensionNames: ["x", "y"],
 	});
 	expect(a.dimensionNames).toStrictEqual(["x", "y"]);
 	expect(json_decode(h.store.get("/temp/zarr.json"))).toMatchObject({
@@ -129,9 +129,9 @@ test("create array with fill_value", async () => {
 	let h = zarr.root();
 	let a = await zarr.create(h.resolve("/temp"), {
 		shape: [10],
-		chunk_shape: [5],
-		data_type: "float32",
-		fill_value: -9999,
+		chunkShape: [5],
+		dataType: "float32",
+		fillValue: -9999,
 	});
 	expect(a.fillValue).toBe(-9999);
 });
@@ -140,8 +140,8 @@ test("create array without dimension_names", async () => {
 	let h = zarr.root();
 	let a = await zarr.create(h.resolve("/temp"), {
 		shape: [10],
-		chunk_shape: [5],
-		data_type: "int32",
+		chunkShape: [5],
+		dataType: "int32",
 	});
 	expect(a.dimensionNames).toBeUndefined();
 });
@@ -150,9 +150,9 @@ test("get scalar array returns fill value before set", async () => {
 	let h = zarr.root();
 	let arr = await zarr.create(h.resolve("/scalar"), {
 		shape: [],
-		chunk_shape: [],
-		data_type: "float64",
-		fill_value: -9999,
+		chunkShape: [],
+		dataType: "float64",
+		fillValue: -9999,
 	});
 	let value = await zarr.get(arr);
 	expect(value).toBe(-9999);
@@ -162,9 +162,9 @@ test("set and get scalar array (shape=[])", async () => {
 	let h = zarr.root();
 	let arr = await zarr.create(h.resolve("/scalar"), {
 		shape: [],
-		chunk_shape: [],
-		data_type: "float64",
-		fill_value: 0,
+		chunkShape: [],
+		dataType: "float64",
+		fillValue: 0,
 	});
 	expect(arr.shape).toStrictEqual([]);
 	expect(arr.chunks).toStrictEqual([]);
@@ -180,8 +180,8 @@ test("create nodes via groups", async () => {
 	let paranoid = await zarr.create(marvin.resolve("paranoid"));
 	let android = await zarr.create(marvin.resolve("android"), {
 		shape: [42, 42],
-		data_type: "uint8",
-		chunk_shape: [2, 2],
+		dataType: "uint8",
+		chunkShape: [2, 2],
 	});
 	expect(marvin).toBeInstanceOf(zarr.Group);
 	expect(marvin.path).toBe("/marvin");

--- a/packages/zarrita/__tests__/delta.test.ts
+++ b/packages/zarrita/__tests__/delta.test.ts
@@ -7,7 +7,7 @@ function makeChunk<T extends ArrayBufferView & { length: number }>(data: T) {
 
 describe("DeltaCodec", () => {
 	test("roundtrip int32", () => {
-		const codec = DeltaCodec.fromConfig({}, { data_type: "int32" });
+		const codec = DeltaCodec.fromConfig({}, { dataType: "int32" });
 		const original = makeChunk(new Int32Array([10, 12, 15, 19, 24]));
 		const encoded = codec.encode(original);
 		const decoded = codec.decode(encoded);
@@ -15,7 +15,7 @@ describe("DeltaCodec", () => {
 	});
 
 	test("roundtrip float64", () => {
-		const codec = DeltaCodec.fromConfig({}, { data_type: "float64" });
+		const codec = DeltaCodec.fromConfig({}, { dataType: "float64" });
 		const original = makeChunk(new Float64Array([0.5, 1.5, 3.0, 6.0, 10.0]));
 		const encoded = codec.encode(original);
 		const decoded = codec.decode(encoded);
@@ -23,14 +23,14 @@ describe("DeltaCodec", () => {
 	});
 
 	test("encode produces differences", () => {
-		const codec = DeltaCodec.fromConfig({}, { data_type: "int32" });
+		const codec = DeltaCodec.fromConfig({}, { dataType: "int32" });
 		const chunk = makeChunk(new Int32Array([10, 12, 15, 19, 24]));
 		const encoded = codec.encode(chunk);
 		expect(encoded.data).toStrictEqual(new Int32Array([10, 2, 3, 4, 5]));
 	});
 
 	test("shape and stride are preserved", () => {
-		const codec = DeltaCodec.fromConfig({}, { data_type: "int32" });
+		const codec = DeltaCodec.fromConfig({}, { dataType: "int32" });
 		const chunk = {
 			data: new Int32Array([1, 2, 3, 4, 5, 6]),
 			shape: [2, 3],
@@ -45,13 +45,13 @@ describe("DeltaCodec", () => {
 
 	test("throws for unsupported data type", () => {
 		expect(() =>
-			DeltaCodec.fromConfig({}, { data_type: "bool" as never }),
+			DeltaCodec.fromConfig({}, { dataType: "bool" as never }),
 		).toThrow();
 	});
 
 	test("int8 overflow wraps (two's complement, matches numpy)", () => {
 		// diff of -100 - 100 = -200, which overflows int8 and wraps to 56
-		const codec = DeltaCodec.fromConfig({}, { data_type: "int8" });
+		const codec = DeltaCodec.fromConfig({}, { dataType: "int8" });
 		const chunk = makeChunk(new Int8Array([100, -100]));
 		const encoded = codec.encode(chunk);
 		expect(encoded.data).toStrictEqual(new Int8Array([100, 56]));
@@ -60,7 +60,7 @@ describe("DeltaCodec", () => {
 
 	test("int32 overflow wraps at boundary (matches numpy)", () => {
 		// MAX_INT32 -> MIN_INT32: diff = 1 (wraps around)
-		const codec = DeltaCodec.fromConfig({}, { data_type: "int32" });
+		const codec = DeltaCodec.fromConfig({}, { dataType: "int32" });
 		const chunk = makeChunk(new Int32Array([2147483647, -2147483648]));
 		const encoded = codec.encode(chunk);
 		expect(encoded.data).toStrictEqual(new Int32Array([2147483647, 1]));
@@ -69,7 +69,7 @@ describe("DeltaCodec", () => {
 
 	test("float32 overflow stays as Infinity (IEEE 754, matches numpy)", () => {
 		// diff of -1e38 - 1e38 = -2e38 (within float32 range, round-trips)
-		const codec = DeltaCodec.fromConfig({}, { data_type: "float32" });
+		const codec = DeltaCodec.fromConfig({}, { dataType: "float32" });
 		const chunk = makeChunk(new Float32Array([1e38, -1e38]));
 		expect(codec.decode(codec.encode(chunk)).data).toStrictEqual(chunk.data);
 		// inf - inf = NaN, which propagates
@@ -82,7 +82,7 @@ describe("DeltaCodec", () => {
 	test("F-order (stride [1,3]): delta operates on linear memory, strides pass through unchanged", () => {
 		// Simulates what TransposeCodec([1,0]) produces before DeltaCodec during decode:
 		// data is in C-order memory [1..9] but stride [1,3] maps it as a column-major 3x3 matrix.
-		const codec = DeltaCodec.fromConfig({}, { data_type: "int32" });
+		const codec = DeltaCodec.fromConfig({}, { dataType: "int32" });
 		const chunk = {
 			data: new Int32Array([1, 2, 3, 4, 5, 6, 7, 8, 9]),
 			shape: [3, 3],
@@ -98,7 +98,7 @@ describe("DeltaCodec", () => {
 	});
 
 	test("throws for non-C/Fortran strides", () => {
-		const codec = DeltaCodec.fromConfig({}, { data_type: "int32" });
+		const codec = DeltaCodec.fromConfig({}, { dataType: "int32" });
 		const chunk = {
 			data: new Int32Array(27),
 			shape: [3, 3, 3],

--- a/packages/zarrita/__tests__/indexing/indexer.test.ts
+++ b/packages/zarrita/__tests__/indexing/indexer.test.ts
@@ -2,13 +2,13 @@ import { describe, expect, test } from "vitest";
 
 import {
 	BasicIndexer,
-	normalize_integer_selection,
-	normalize_selection,
+	normalizeIntegerSelection,
+	normalizeSelection,
 } from "../../src/indexing/indexer.js";
 import type { Slice } from "../../src/indexing/types.js";
 import { slice } from "../../src/indexing/util.js";
 
-describe("normalize_selection", () => {
+describe("normalizeSelection", () => {
 	// null !== null, so need custom compare
 	let eq = (a: (Slice | number)[], b: (Slice | number)[]) => {
 		expect(a.map((s) => s.toString())).toStrictEqual(
@@ -16,14 +16,14 @@ describe("normalize_selection", () => {
 		);
 	};
 	test("handles complete selection", () => {
-		eq(normalize_selection(null, [2, 3, 4]), [
+		eq(normalizeSelection(null, [2, 3, 4]), [
 			slice(null),
 			slice(null),
 			slice(null),
 		]);
 	});
 	test("handles partial complete selection", () => {
-		eq(normalize_selection([slice(2), null, 3], [2, 3, 4]), [
+		eq(normalizeSelection([slice(2), null, 3], [2, 3, 4]), [
 			slice(2),
 			slice(null),
 			3,
@@ -31,30 +31,28 @@ describe("normalize_selection", () => {
 	});
 	test("throws when dimensions don't match", () => {
 		expect(() =>
-			normalize_selection([slice(2), null, 3, 4], [2, 3, 4]),
+			normalizeSelection([slice(2), null, 3, 4], [2, 3, 4]),
 		).toThrowError();
 	});
 });
 
-describe("normalize_integer_selection", () => {
+describe("normalizeIntegerSelection", () => {
 	test.each([
 		[2, 5, 2],
 		[-1, 5, 4],
 		[-2, 5, 3],
 		[-2.2, 5, 3],
 		[4.3, 5, 4],
-	])("normalize_integer_selection(%i, %i) -> %i", (dim_selection, dim_length, expected) => {
-		expect(normalize_integer_selection(dim_selection, dim_length)).toBe(
-			expected,
-		);
+	])("normalizeIntegerSelection(%i, %i) -> %i", (dim_selection, dim_length, expected) => {
+		expect(normalizeIntegerSelection(dim_selection, dim_length)).toBe(expected);
 	});
 	test.each([
 		[5, 5],
 		[6, 5],
 		[-6, 5],
-	])("normalize_integer_selection(%i, %i) -> throws", (dim_selection, dim_length) => {
+	])("normalizeIntegerSelection(%i, %i) -> throws", (dim_selection, dim_length) => {
 		expect(() =>
-			normalize_integer_selection(dim_selection, dim_length),
+			normalizeIntegerSelection(dim_selection, dim_length),
 		).toThrowError();
 	});
 });
@@ -64,7 +62,7 @@ describe("BasicIndexer", () => {
 		let indexer = new BasicIndexer({
 			selection: null,
 			shape: [3, 4, 5],
-			chunk_shape: [3, 4, 5],
+			chunkShape: [3, 4, 5],
 		});
 		expect(indexer.shape).toStrictEqual([3, 4, 5]);
 		expect(Array.from(indexer).map((i) => i.mapping)).toMatchInlineSnapshot(`
@@ -115,12 +113,12 @@ describe("BasicIndexer", () => {
 		let indexer = new BasicIndexer({
 			selection: null,
 			shape: [3, 4, 5],
-			chunk_shape: [1, 2, 5],
+			chunkShape: [1, 2, 5],
 		});
 		expect(Array.from(indexer)).toMatchInlineSnapshot(`
 			[
 			  {
-			    "chunk_coords": [
+			    "chunkCoords": [
 			      0,
 			      0,
 			      0,
@@ -165,7 +163,7 @@ describe("BasicIndexer", () => {
 			    ],
 			  },
 			  {
-			    "chunk_coords": [
+			    "chunkCoords": [
 			      1,
 			      0,
 			      0,
@@ -210,7 +208,7 @@ describe("BasicIndexer", () => {
 			    ],
 			  },
 			  {
-			    "chunk_coords": [
+			    "chunkCoords": [
 			      2,
 			      0,
 			      0,
@@ -255,7 +253,7 @@ describe("BasicIndexer", () => {
 			    ],
 			  },
 			  {
-			    "chunk_coords": [
+			    "chunkCoords": [
 			      0,
 			      1,
 			      0,
@@ -300,7 +298,7 @@ describe("BasicIndexer", () => {
 			    ],
 			  },
 			  {
-			    "chunk_coords": [
+			    "chunkCoords": [
 			      1,
 			      1,
 			      0,
@@ -345,7 +343,7 @@ describe("BasicIndexer", () => {
 			    ],
 			  },
 			  {
-			    "chunk_coords": [
+			    "chunkCoords": [
 			      2,
 			      1,
 			      0,
@@ -397,13 +395,13 @@ describe("BasicIndexer", () => {
 		let indexer = new BasicIndexer({
 			selection: [null, 0],
 			shape: [3, 4],
-			chunk_shape: [1, 4],
+			chunkShape: [1, 4],
 		});
 		expect(indexer.shape).toStrictEqual([3]);
 		expect(Array.from(indexer)).toMatchInlineSnapshot(`
 			[
 			  {
-			    "chunk_coords": [
+			    "chunkCoords": [
 			      0,
 			      0,
 			    ],
@@ -427,7 +425,7 @@ describe("BasicIndexer", () => {
 			    ],
 			  },
 			  {
-			    "chunk_coords": [
+			    "chunkCoords": [
 			      1,
 			      0,
 			    ],
@@ -451,7 +449,7 @@ describe("BasicIndexer", () => {
 			    ],
 			  },
 			  {
-			    "chunk_coords": [
+			    "chunkCoords": [
 			      2,
 			      0,
 			    ],

--- a/packages/zarrita/__tests__/indexing/set.test.ts
+++ b/packages/zarrita/__tests__/indexing/set.test.ts
@@ -9,7 +9,7 @@ test("Read and write array data - builtin", async () => {
 	let h = zarr.root(new Map());
 	let a = await zarr.create(h.resolve("/arthur/dent"), {
 		shape: [5, 10],
-		dataType: "int32",
+		dtype: "int32",
 		chunkShape: [2, 5],
 	});
 
@@ -108,7 +108,7 @@ test("Read and write array data - builtin", async () => {
 
 	let b = await zarr.create(h.resolve("/deep/thought"), {
 		shape: [7500000],
-		dataType: "float64",
+		dtype: "float64",
 		chunkShape: [42],
 	});
 

--- a/packages/zarrita/__tests__/indexing/set.test.ts
+++ b/packages/zarrita/__tests__/indexing/set.test.ts
@@ -9,8 +9,8 @@ test("Read and write array data - builtin", async () => {
 	let h = zarr.root(new Map());
 	let a = await zarr.create(h.resolve("/arthur/dent"), {
 		shape: [5, 10],
-		data_type: "int32",
-		chunk_shape: [2, 5],
+		dataType: "int32",
+		chunkShape: [2, 5],
 	});
 
 	let res = await get(a, [null, null]);
@@ -108,8 +108,8 @@ test("Read and write array data - builtin", async () => {
 
 	let b = await zarr.create(h.resolve("/deep/thought"), {
 		shape: [7500000],
-		data_type: "float64",
-		chunk_shape: [42],
+		dataType: "float64",
+		chunkShape: [42],
 	});
 
 	let resb = await get(b, [slice(10)]);

--- a/packages/zarrita/__tests__/indexing/setter.test.ts
+++ b/packages/zarrita/__tests__/indexing/setter.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from "vitest";
 import type * as zarr from "../../src/index.js";
 import { setter } from "../../src/indexing/ops.js";
 import type { Projection } from "../../src/indexing/types.js";
-import { slice, slice_indices } from "../../src/indexing/util.js";
+import { slice, sliceIndices } from "../../src/indexing/util.js";
 
 /** Compute strides for 'C' or 'F' ordered array from shape */
 function get_strides(shape: readonly number[], order: "C" | "F") {
@@ -46,11 +46,11 @@ function to_c<D extends zarr.DataType>({
 }
 
 function indices(size: number) {
-	return slice_indices(slice(null), size);
+	return sliceIndices(slice(null), size);
 }
 
 describe("setter", () => {
-	it("setter.set_scalar - fill", async () => {
+	it("setter.setScalar - fill", async () => {
 		let a = setter.prepare(
 			new Float32Array(2 * 3 * 4),
 			[2, 3, 4],
@@ -58,7 +58,7 @@ describe("setter", () => {
 		);
 
 		let sel = [2, 3, 4].map(indices);
-		setter.set_scalar(a, sel, 1);
+		setter.setScalar(a, sel, 1);
 		// biome-ignore format: the array should not be formatted
 		expect(a.data).toStrictEqual(new Float32Array([
 			1, 1, 1, 1,
@@ -71,14 +71,14 @@ describe("setter", () => {
 		]));
 	});
 
-	it("setter.set_scalar - point", async () => {
+	it("setter.setScalar - point", async () => {
 		let a = setter.prepare(
 			new Float32Array(2 * 3 * 4),
 			[2, 3, 4],
 			get_strides([2, 3, 4], "C"),
 		);
 
-		setter.set_scalar(a, [0, 0, 0], 1);
+		setter.setScalar(a, [0, 0, 0], 1);
 		// biome-ignore format: the array should not be formatted
 		expect(a.data).toStrictEqual(new Float32Array([
 			1, 0, 0, 0,
@@ -90,7 +90,7 @@ describe("setter", () => {
 			0, 0, 0, 0,
 		]));
 
-		setter.set_scalar(a, [1, 1, 1], 2);
+		setter.setScalar(a, [1, 1, 1], 2);
 		// biome-ignore format: the array should not be formatted
 		expect(a.data).toStrictEqual(new Float32Array([
 			1, 0, 0, 0,
@@ -102,7 +102,7 @@ describe("setter", () => {
 			0, 0, 0, 0,
 		]));
 
-		setter.set_scalar(a, [1, 2, 3], 3);
+		setter.setScalar(a, [1, 2, 3], 3);
 		// biome-ignore format: the array should not be formatted
 		expect(a.data).toStrictEqual(new Float32Array([
 			1, 0, 0, 0,
@@ -114,7 +114,7 @@ describe("setter", () => {
 			0, 0, 0, 3,
 		]));
 
-		setter.set_scalar(a, [1, 2, 2], 4);
+		setter.setScalar(a, [1, 2, 2], 4);
 		// biome-ignore format: the array should not be formatted
 		expect(a.data).toStrictEqual(new Float32Array([
 			1, 0, 0, 0,
@@ -127,15 +127,15 @@ describe("setter", () => {
 		]));
 	});
 
-	it("setter.set_scalar - mixed", async () => {
+	it("setter.setScalar - mixed", async () => {
 		let a = setter.prepare(
 			new Float32Array(2 * 3 * 4),
 			[2, 3, 4],
 			get_strides([2, 3, 4], "C"),
 		);
 
-		let sel = [indices(2), slice_indices(slice(2), 3), 0];
-		setter.set_scalar(a, sel, 1);
+		let sel = [indices(2), sliceIndices(slice(2), 3), 0];
+		setter.setScalar(a, sel, 1);
 		// biome-ignore format: the array should not be formatted
 		expect(a.data).toStrictEqual(new Float32Array([
 			1, 0, 0, 0,
@@ -148,7 +148,7 @@ describe("setter", () => {
 		]));
 
 		sel = [0, indices(3), indices(4)];
-		setter.set_scalar(a, sel, 2);
+		setter.setScalar(a, sel, 2);
 
 		// biome-ignore format: the array should not be formatted
 		expect(a.data).toStrictEqual(new Float32Array([
@@ -162,15 +162,15 @@ describe("setter", () => {
 		]));
 	});
 
-	it("setter.set_scalar - mixed F order", async () => {
+	it("setter.setScalar - mixed F order", async () => {
 		let f = setter.prepare(
 			new Float32Array(2 * 3 * 4),
 			[2, 3, 4],
 			get_strides([2, 3, 4], "F"),
 		);
 
-		let sel = [slice_indices(slice(null), 2), slice_indices(slice(2), 3), 0];
-		setter.set_scalar(f, sel, 1);
+		let sel = [sliceIndices(slice(null), 2), sliceIndices(slice(2), 3), 0];
+		setter.setScalar(f, sel, 1);
 		// biome-ignore format: the array should not be formatted
 		expect(f.data).toStrictEqual(new Float32Array([
 			1, 1, 1, 1, 0, 0,
@@ -179,8 +179,8 @@ describe("setter", () => {
 			0, 0, 0, 0, 0, 0,
 		]));
 
-		sel = [0, slice_indices(slice(null), 3), slice_indices(slice(null), 4)];
-		setter.set_scalar(f, sel, 2);
+		sel = [0, sliceIndices(slice(null), 3), sliceIndices(slice(null), 4)];
+		setter.setScalar(f, sel, 2);
 
 		// biome-ignore format: the array should not be formatted
 		expect(f.data).toStrictEqual(new Float32Array([
@@ -221,7 +221,7 @@ describe("setter", () => {
 			{ from: [0, 2, 1], to: [0, 2, 1] },
 		];
 
-		setter.set_from_chunk(dest, src, mapping);
+		setter.setFromChunk(dest, src, mapping);
 		// biome-ignore format: the array should not be formatted
 		expect(dest.data).toStrictEqual(new Float32Array([
 			1, 1, 0, 0,
@@ -253,7 +253,7 @@ describe("setter", () => {
 			{ from: [0, 2, 1], to: [0, 4, 2] },
 		];
 
-		setter.set_from_chunk(dest, src, mapping);
+		setter.setFromChunk(dest, src, mapping);
 		// biome-ignore format: the array should not be formatted
 		expect(dest.data).toStrictEqual(new Float32Array([
 			2, 0, 2, 0,
@@ -294,7 +294,7 @@ describe("setter", () => {
 			{ to: [0, 2, 1], from: [0, 4, 2] },
 		];
 
-		setter.set_from_chunk(dest, src, mapping);
+		setter.setFromChunk(dest, src, mapping);
 		expect(dest.data).toStrictEqual(new Float32Array(2 * 2 * 2).fill(2));
 	});
 
@@ -317,7 +317,7 @@ describe("setter", () => {
 			{ to: 1, from: null },
 		];
 
-		setter.set_from_chunk(dest, src, mapping);
+		setter.setFromChunk(dest, src, mapping);
 		// biome-ignore format: the array should not be formatted
 		expect(dest.data).toStrictEqual(new Float32Array([
 			0, 2, 0, 0,
@@ -354,7 +354,7 @@ describe("setter", () => {
 			{ from: 1, to: null },
 		];
 
-		setter.set_from_chunk(dest, src, mapping);
+		setter.setFromChunk(dest, src, mapping);
 		expect(dest.data).toStrictEqual(new Float32Array([2, 0, 0, 2]));
 	});
 
@@ -377,7 +377,7 @@ describe("setter", () => {
 			{ from: [0, 2, 1], to: [0, 2, 1] },
 		];
 
-		setter.set_from_chunk(dest, src, mapping);
+		setter.setFromChunk(dest, src, mapping);
 		// biome-ignore format: the array should not be formatted
 		expect(to_c(dest).data).toStrictEqual(new Float32Array([
 			1, 1, 0, 0,
@@ -409,7 +409,7 @@ describe("setter", () => {
 			{ to: 1, from: null },
 		];
 
-		setter.set_from_chunk(dest, src, mapping);
+		setter.setFromChunk(dest, src, mapping);
 		// biome-ignore format: the array should not be formatted
 		expect(to_c(dest).data).toStrictEqual(new Float32Array([
 			0, 2, 0, 0,
@@ -441,7 +441,7 @@ describe("setter", () => {
 			{ to: 1, from: null },
 		];
 
-		setter.set_from_chunk(dest, src, mapping);
+		setter.setFromChunk(dest, src, mapping);
 		// biome-ignore format: the array should not be formatted
 		expect(to_c(dest).data).toStrictEqual(new Float32Array([
 			0, 2, 0, 0,
@@ -473,7 +473,7 @@ describe("setter", () => {
 			{ to: 1, from: null },
 		];
 
-		setter.set_from_chunk(dest, src, mapping);
+		setter.setFromChunk(dest, src, mapping);
 		// biome-ignore format: the array should not be formatted
 		expect(dest.data).toStrictEqual(new Float32Array([
 			0, 2, 0, 0,

--- a/packages/zarrita/__tests__/indexing/slice.test.ts
+++ b/packages/zarrita/__tests__/indexing/slice.test.ts
@@ -14,8 +14,8 @@ const DATA = {
 describe("slice", async () => {
 	let arr = await zarr.create(new Map(), {
 		shape: [2, 3, 4],
-		data_type: "int32",
-		chunk_shape: [1, 2, 2],
+		dataType: "int32",
+		chunkShape: [1, 2, 2],
 	});
 	await set(arr, null, DATA);
 

--- a/packages/zarrita/__tests__/indexing/slice.test.ts
+++ b/packages/zarrita/__tests__/indexing/slice.test.ts
@@ -14,7 +14,7 @@ const DATA = {
 describe("slice", async () => {
 	let arr = await zarr.create(new Map(), {
 		shape: [2, 3, 4],
-		dataType: "int32",
+		dtype: "int32",
 		chunkShape: [1, 2, 2],
 	});
 	await set(arr, null, DATA);

--- a/packages/zarrita/__tests__/indexing/util.test.ts
+++ b/packages/zarrita/__tests__/indexing/util.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "vitest";
 
-import { range, slice, slice_indices } from "../../src/indexing/util.js";
+import { range, slice, sliceIndices } from "../../src/indexing/util.js";
 
 describe("slice", () => {
 	test("slice(null)", () => {
@@ -13,8 +13,8 @@ describe("slice", () => {
 		`);
 	});
 
-	test("slice_indices(slice(null), 10)", () => {
-		expect(slice_indices(slice(null), 10)).toStrictEqual([0, 10, 1]);
+	test("sliceIndices(slice(null), 10)", () => {
+		expect(sliceIndices(slice(null), 10)).toStrictEqual([0, 10, 1]);
 	});
 
 	test("slice(3, 15, 2)", () => {
@@ -27,12 +27,12 @@ describe("slice", () => {
 		`);
 	});
 
-	test("slice_indices(slice(3, 15, 2), 10)", () => {
-		expect(slice_indices(slice(3, 15, 2), 10)).toStrictEqual([3, 10, 2]);
+	test("sliceIndices(slice(3, 15, 2), 10)", () => {
+		expect(sliceIndices(slice(3, 15, 2), 10)).toStrictEqual([3, 10, 2]);
 	});
 
-	test("slice_indices(slice(3, 15, 2), 30)", () => {
-		expect(slice_indices(slice(3, 15, 2), 30)).toStrictEqual([3, 15, 2]);
+	test("sliceIndices(slice(3, 15, 2), 30)", () => {
+		expect(sliceIndices(slice(3, 15, 2), 30)).toStrictEqual([3, 15, 2]);
 	});
 
 	test("slice(40)", () => {
@@ -45,12 +45,12 @@ describe("slice", () => {
 		`);
 	});
 
-	test("slice_indices(slice(40), 4)", () => {
-		expect(slice_indices(slice(40), 4)).toStrictEqual([0, 4, 1]);
+	test("sliceIndices(slice(40), 4)", () => {
+		expect(sliceIndices(slice(40), 4)).toStrictEqual([0, 4, 1]);
 	});
 
-	test("slice_indices(slice(40), 41)", () => {
-		expect(slice_indices(slice(40), 41)).toStrictEqual([0, 40, 1]);
+	test("sliceIndices(slice(40), 41)", () => {
+		expect(sliceIndices(slice(40), 41)).toStrictEqual([0, 40, 1]);
 	});
 
 	test("slice(10n, 15n) coerces bigint to number", () => {
@@ -72,8 +72,8 @@ describe("slice indices", () => {
 		[null, 10, [0, 10, 1]],
 		[40, 4, [0, 4, 1]],
 		[40, 41, [0, 40, 1]],
-	])("slice_indices(slice(%o), %i) -> %o", (arg, indices, expected) => {
-		expect(slice_indices(slice(arg), indices)).toStrictEqual(expected);
+	])("sliceIndices(slice(%o), %i) -> %o", (arg, indices, expected) => {
+		expect(sliceIndices(slice(arg), indices)).toStrictEqual(expected);
 	});
 
 	test.each([
@@ -83,17 +83,17 @@ describe("slice indices", () => {
 		[2, 10, -1, 4, [2, 3, -1]],
 		[null, null, -3, 14, [13, -1, -3]],
 		[null, null, -3, 2, [1, -1, -3]],
-	])("slice_indices(slice(%o, %o, %o), %i) -> %o", (start, stop, step, indices, expected) => {
-		expect(slice_indices(slice(start, stop, step), indices)).toStrictEqual(
+	])("sliceIndices(slice(%o, %o, %o), %i) -> %o", (start, stop, step, indices, expected) => {
+		expect(sliceIndices(slice(start, stop, step), indices)).toStrictEqual(
 			expected,
 		);
 	});
 
 	test.each([
 		[null, null, 0, 1],
-	])("slice_indices(slice(%o, %o, %o), %i) -> throws", (start, stop, step, indices) => {
+	])("sliceIndices(slice(%o, %o, %o), %i) -> throws", (start, stop, step, indices) => {
 		expect(() =>
-			slice_indices(slice(start, stop, step), indices),
+			sliceIndices(slice(start, stop, step), indices),
 		).toThrowError();
 	});
 });

--- a/packages/zarrita/__tests__/shared-array-buffer.test.ts
+++ b/packages/zarrita/__tests__/shared-array-buffer.test.ts
@@ -6,9 +6,9 @@ describe("SharedArrayBuffer support", () => {
 		let h = zarr.root();
 		let arr = await zarr.create(h.resolve("/test"), {
 			shape: [4, 4],
-			chunk_shape: [2, 2],
-			data_type: "int32",
-			fill_value: 42,
+			chunkShape: [2, 2],
+			dataType: "int32",
+			fillValue: 42,
 		});
 
 		let chunk = await zarr.get(arr, null, { useSharedArrayBuffer: true });
@@ -22,9 +22,9 @@ describe("SharedArrayBuffer support", () => {
 		let h = zarr.root();
 		let arr = await zarr.create(h.resolve("/test"), {
 			shape: [4, 4],
-			chunk_shape: [2, 2],
-			data_type: "int32",
-			fill_value: 42,
+			chunkShape: [2, 2],
+			dataType: "int32",
+			fillValue: 42,
 		});
 
 		let chunk = await zarr.get(arr);
@@ -36,9 +36,9 @@ describe("SharedArrayBuffer support", () => {
 		let h = zarr.root();
 		let arr = await zarr.create(h.resolve("/test"), {
 			shape: [4, 4],
-			chunk_shape: [2, 2],
-			data_type: "float32",
-			fill_value: 3.14,
+			chunkShape: [2, 2],
+			dataType: "float32",
+			fillValue: 3.14,
 		});
 
 		// No data written, so getChunk returns fill-value chunk
@@ -57,9 +57,9 @@ describe("SharedArrayBuffer support", () => {
 		let h = zarr.root();
 		let arr = await zarr.create(h.resolve("/test"), {
 			shape: [4, 4],
-			chunk_shape: [2, 2],
-			data_type: "float32",
-			fill_value: 3.14,
+			chunkShape: [2, 2],
+			dataType: "float32",
+			fillValue: 3.14,
 		});
 
 		let chunk = await arr.getChunk([0, 0]);
@@ -69,23 +69,23 @@ describe("SharedArrayBuffer support", () => {
 
 	test("useSharedArrayBuffer works with various numeric data types", async () => {
 		const testCases = [
-			{ data_type: "int8" as const, fill_value: -1 },
-			{ data_type: "int16" as const, fill_value: -100 },
-			{ data_type: "int32" as const, fill_value: -1000 },
-			{ data_type: "uint8" as const, fill_value: 255 },
-			{ data_type: "uint16" as const, fill_value: 1000 },
-			{ data_type: "uint32" as const, fill_value: 100000 },
-			{ data_type: "float32" as const, fill_value: 1.5 },
-			{ data_type: "float64" as const, fill_value: 2.5 },
+			{ dataType: "int8" as const, fillValue: -1 },
+			{ dataType: "int16" as const, fillValue: -100 },
+			{ dataType: "int32" as const, fillValue: -1000 },
+			{ dataType: "uint8" as const, fillValue: 255 },
+			{ dataType: "uint16" as const, fillValue: 1000 },
+			{ dataType: "uint32" as const, fillValue: 100000 },
+			{ dataType: "float32" as const, fillValue: 1.5 },
+			{ dataType: "float64" as const, fillValue: 2.5 },
 		];
 
-		for (const { data_type, fill_value } of testCases) {
+		for (const { dataType, fillValue } of testCases) {
 			let h = zarr.root();
 			let arr = await zarr.create(h.resolve("/test"), {
 				shape: [2],
-				chunk_shape: [2],
-				data_type,
-				fill_value,
+				chunkShape: [2],
+				dataType,
+				fillValue,
 			});
 
 			let chunk = await zarr.get(arr, null, { useSharedArrayBuffer: true });
@@ -98,9 +98,9 @@ describe("SharedArrayBuffer support", () => {
 		let h = zarr.root();
 		let arr = await zarr.create(h.resolve("/test"), {
 			shape: [4],
-			chunk_shape: [2],
-			data_type: "bool",
-			fill_value: true,
+			chunkShape: [2],
+			dataType: "bool",
+			fillValue: true,
 		});
 
 		let chunk = await zarr.get(arr, null, { useSharedArrayBuffer: true });
@@ -113,9 +113,9 @@ describe("SharedArrayBuffer support", () => {
 		let h = zarr.root();
 		let arr = await zarr.create(h.resolve("/test"), {
 			shape: [2],
-			chunk_shape: [2],
-			data_type: "string",
-			fill_value: "hello",
+			chunkShape: [2],
+			dataType: "string",
+			fillValue: "hello",
 		});
 
 		// Should warn but not throw, falling back to regular array
@@ -129,9 +129,9 @@ describe("SharedArrayBuffer support", () => {
 		let h = zarr.root();
 		let arr = await zarr.create(h.resolve("/test"), {
 			shape: [4],
-			chunk_shape: [2],
-			data_type: "int32",
-			fill_value: 0,
+			chunkShape: [2],
+			dataType: "int32",
+			fillValue: 0,
 		});
 
 		// Write some data
@@ -151,9 +151,9 @@ describe("SharedArrayBuffer support", () => {
 		let h = zarr.root();
 		let arr = await zarr.create(h.resolve("/test"), {
 			shape: [4, 4],
-			chunk_shape: [2, 2],
-			data_type: "int32",
-			fill_value: 0,
+			chunkShape: [2, 2],
+			dataType: "int32",
+			fillValue: 0,
 		});
 
 		// Write some data

--- a/packages/zarrita/__tests__/shared-array-buffer.test.ts
+++ b/packages/zarrita/__tests__/shared-array-buffer.test.ts
@@ -7,7 +7,7 @@ describe("SharedArrayBuffer support", () => {
 		let arr = await zarr.create(h.resolve("/test"), {
 			shape: [4, 4],
 			chunkShape: [2, 2],
-			dataType: "int32",
+			dtype: "int32",
 			fillValue: 42,
 		});
 
@@ -23,7 +23,7 @@ describe("SharedArrayBuffer support", () => {
 		let arr = await zarr.create(h.resolve("/test"), {
 			shape: [4, 4],
 			chunkShape: [2, 2],
-			dataType: "int32",
+			dtype: "int32",
 			fillValue: 42,
 		});
 
@@ -37,7 +37,7 @@ describe("SharedArrayBuffer support", () => {
 		let arr = await zarr.create(h.resolve("/test"), {
 			shape: [4, 4],
 			chunkShape: [2, 2],
-			dataType: "float32",
+			dtype: "float32",
 			fillValue: 3.14,
 		});
 
@@ -58,7 +58,7 @@ describe("SharedArrayBuffer support", () => {
 		let arr = await zarr.create(h.resolve("/test"), {
 			shape: [4, 4],
 			chunkShape: [2, 2],
-			dataType: "float32",
+			dtype: "float32",
 			fillValue: 3.14,
 		});
 
@@ -69,22 +69,22 @@ describe("SharedArrayBuffer support", () => {
 
 	test("useSharedArrayBuffer works with various numeric data types", async () => {
 		const testCases = [
-			{ dataType: "int8" as const, fillValue: -1 },
-			{ dataType: "int16" as const, fillValue: -100 },
-			{ dataType: "int32" as const, fillValue: -1000 },
-			{ dataType: "uint8" as const, fillValue: 255 },
-			{ dataType: "uint16" as const, fillValue: 1000 },
-			{ dataType: "uint32" as const, fillValue: 100000 },
-			{ dataType: "float32" as const, fillValue: 1.5 },
-			{ dataType: "float64" as const, fillValue: 2.5 },
+			{ dtype: "int8" as const, fillValue: -1 },
+			{ dtype: "int16" as const, fillValue: -100 },
+			{ dtype: "int32" as const, fillValue: -1000 },
+			{ dtype: "uint8" as const, fillValue: 255 },
+			{ dtype: "uint16" as const, fillValue: 1000 },
+			{ dtype: "uint32" as const, fillValue: 100000 },
+			{ dtype: "float32" as const, fillValue: 1.5 },
+			{ dtype: "float64" as const, fillValue: 2.5 },
 		];
 
-		for (const { dataType, fillValue } of testCases) {
+		for (const { dtype, fillValue } of testCases) {
 			let h = zarr.root();
 			let arr = await zarr.create(h.resolve("/test"), {
 				shape: [2],
 				chunkShape: [2],
-				dataType,
+				dtype,
 				fillValue,
 			});
 
@@ -99,7 +99,7 @@ describe("SharedArrayBuffer support", () => {
 		let arr = await zarr.create(h.resolve("/test"), {
 			shape: [4],
 			chunkShape: [2],
-			dataType: "bool",
+			dtype: "bool",
 			fillValue: true,
 		});
 
@@ -114,7 +114,7 @@ describe("SharedArrayBuffer support", () => {
 		let arr = await zarr.create(h.resolve("/test"), {
 			shape: [2],
 			chunkShape: [2],
-			dataType: "string",
+			dtype: "string",
 			fillValue: "hello",
 		});
 
@@ -130,7 +130,7 @@ describe("SharedArrayBuffer support", () => {
 		let arr = await zarr.create(h.resolve("/test"), {
 			shape: [4],
 			chunkShape: [2],
-			dataType: "int32",
+			dtype: "int32",
 			fillValue: 0,
 		});
 
@@ -152,7 +152,7 @@ describe("SharedArrayBuffer support", () => {
 		let arr = await zarr.create(h.resolve("/test"), {
 			shape: [4, 4],
 			chunkShape: [2, 2],
-			dataType: "int32",
+			dtype: "int32",
 			fillValue: 0,
 		});
 

--- a/packages/zarrita/__tests__/util.test.ts
+++ b/packages/zarrita/__tests__/util.test.ts
@@ -8,15 +8,15 @@ import {
 	UnicodeStringArray,
 } from "../src/typedarray.js";
 import {
-	byteswap_inplace,
-	ensure_correct_scalar,
-	get_ctr,
-	get_strides,
-	is_dtype,
-	v2_to_v3_array_metadata,
+	byteswapInplace,
+	ensureCorrectScalar,
+	getCtr,
+	getStrides,
+	isDtype,
+	v2ToV3ArrayMetadata,
 } from "../src/util.js";
 
-describe("get_ctr", () => {
+describe("getCtr", () => {
 	describe("without Float16Array", () => {
 		beforeAll(() => {
 			vi.stubGlobal("Float16Array", undefined);
@@ -40,12 +40,12 @@ describe("get_ctr", () => {
 			["v2:S6", ByteStringArray],
 			["string", Array],
 		])("%s -> %o", (dtype, ctr) => {
-			const T = get_ctr(dtype);
+			const T = getCtr(dtype);
 			expect(new T(1)).toBeInstanceOf(ctr);
 		});
 
 		test.each(["float16"])("%s -> throws", (dtype) => {
-			expect(() => get_ctr(dtype as DataType)).toThrowError();
+			expect(() => getCtr(dtype as DataType)).toThrowError();
 		});
 	});
 
@@ -74,13 +74,13 @@ describe("get_ctr", () => {
 			["v2:S6", ByteStringArray],
 			["string", Array],
 		])("%s -> %o", (dtype, ctr) => {
-			const T = get_ctr(dtype);
+			const T = getCtr(dtype);
 			expect(new T(1)).toBeInstanceOf(ctr);
 		});
 	});
 });
 
-describe("byteswap_inplace", () => {
+describe("byteswapInplace", () => {
 	test.each([
 		new Uint32Array([1, 2, 3, 4, 5]),
 		new Float64Array([20, 3333, 444.4, 222, 3123]),
@@ -90,13 +90,13 @@ describe("byteswap_inplace", () => {
 	])("%o", (arr) => {
 		// make a copy and then byteswap original twice
 		const expected = arr.slice();
-		byteswap_inplace(new Uint8Array(arr.buffer), arr.BYTES_PER_ELEMENT);
-		byteswap_inplace(new Uint8Array(arr.buffer), arr.BYTES_PER_ELEMENT);
+		byteswapInplace(new Uint8Array(arr.buffer), arr.BYTES_PER_ELEMENT);
+		byteswapInplace(new Uint8Array(arr.buffer), arr.BYTES_PER_ELEMENT);
 		expect(arr).toStrictEqual(expected);
 	});
 });
 
-describe("get_strides", () => {
+describe("getStrides", () => {
 	test.each<[number[], "C" | "F", number[]]>([
 		[[3], "C", [1]],
 		[[3], "F", [1]],
@@ -106,12 +106,12 @@ describe("get_strides", () => {
 		[[3, 4, 10], "F", [1, 3, 12]],
 		[[3, 4, 10, 2], "C", [80, 20, 2, 1]],
 		[[3, 4, 10, 2], "F", [1, 3, 12, 120]],
-	])("get_strides(%o, %s) -> %o", (shape, order, expected) => {
-		expect(get_strides(shape, order)).toStrictEqual(expected);
+	])("getStrides(%o, %s) -> %o", (shape, order, expected) => {
+		expect(getStrides(shape, order)).toStrictEqual(expected);
 	});
 });
 
-describe("is_dtype", () => {
+describe("isDtype", () => {
 	test.each<[DataType, boolean]>([
 		["int8", true],
 		["int16", true],
@@ -129,8 +129,8 @@ describe("is_dtype", () => {
 		["v2:S6", false],
 		["v2:object", false],
 		["string", false],
-	])("is_dtype(%s, 'number') -> %s", (dtype, expected) => {
-		expect(is_dtype(dtype, "number")).toBe(expected);
+	])("isDtype(%s, 'number') -> %s", (dtype, expected) => {
+		expect(isDtype(dtype, "number")).toBe(expected);
 	});
 
 	test.each<[DataType, boolean]>([
@@ -150,8 +150,8 @@ describe("is_dtype", () => {
 		["v2:S6", false],
 		["v2:object", false],
 		["string", false],
-	])("is_dtype(%s, 'boolean') -> %s", (dtype, expected) => {
-		expect(is_dtype(dtype, "boolean")).toBe(expected);
+	])("isDtype(%s, 'boolean') -> %s", (dtype, expected) => {
+		expect(isDtype(dtype, "boolean")).toBe(expected);
 	});
 
 	test.each<[DataType, boolean]>([
@@ -171,8 +171,8 @@ describe("is_dtype", () => {
 		["v2:S6", false],
 		["v2:object", false],
 		["string", false],
-	])("is_dtype(%s, 'bigint') -> %s", (dtype, expected) => {
-		expect(is_dtype(dtype, "bigint")).toBe(expected);
+	])("isDtype(%s, 'bigint') -> %s", (dtype, expected) => {
+		expect(isDtype(dtype, "bigint")).toBe(expected);
 	});
 
 	test.each<[DataType, boolean]>([
@@ -192,8 +192,8 @@ describe("is_dtype", () => {
 		["v2:S6", true],
 		["v2:object", false],
 		["string", true],
-	])("is_dtype(%s, 'string') -> %s", (dtype, expected) => {
-		expect(is_dtype(dtype, "string")).toBe(expected);
+	])("isDtype(%s, 'string') -> %s", (dtype, expected) => {
+		expect(isDtype(dtype, "string")).toBe(expected);
 	});
 
 	test.each<DataType>([
@@ -213,12 +213,12 @@ describe("is_dtype", () => {
 		"v2:S6",
 		"v2:object",
 		"string",
-	])("is_dtype(%s, %s) -> true", (dtype) => {
-		expect(is_dtype(dtype, dtype)).toBe(true);
+	])("isDtype(%s, %s) -> true", (dtype) => {
+		expect(isDtype(dtype, dtype)).toBe(true);
 	});
 });
 
-describe("ensure_correct_scalar", () => {
+describe("ensureCorrectScalar", () => {
 	function make_metadata(
 		data_type: DataType,
 		fill_value: unknown,
@@ -241,7 +241,7 @@ describe("ensure_correct_scalar", () => {
 		["Infinity", Infinity],
 		["-Infinity", -Infinity],
 	])("float32 fill_value %s -> %s", (str, expected) => {
-		let result = ensure_correct_scalar(make_metadata("float32", str));
+		let result = ensureCorrectScalar(make_metadata("float32", str));
 		if (Number.isNaN(expected)) {
 			expect(result).toBeNaN();
 		} else {
@@ -254,26 +254,26 @@ describe("ensure_correct_scalar", () => {
 		"float32",
 		"float64",
 	] as const)("%s preserves numeric fill_value", (dtype) => {
-		expect(ensure_correct_scalar(make_metadata(dtype, 1.5))).toBe(1.5);
+		expect(ensureCorrectScalar(make_metadata(dtype, 1.5))).toBe(1.5);
 	});
 
 	test("string dtype fill_value 'NaN' stays as string", () => {
-		expect(ensure_correct_scalar(make_metadata("string", "NaN"))).toBe("NaN");
+		expect(ensureCorrectScalar(make_metadata("string", "NaN"))).toBe("NaN");
 	});
 
 	test("int64 fill_value converts to BigInt", () => {
-		expect(ensure_correct_scalar(make_metadata("int64", 42))).toBe(42n);
+		expect(ensureCorrectScalar(make_metadata("int64", 42))).toBe(42n);
 	});
 });
 
 describe("sel", () => {
-	async function make_array(dimension_names?: string[]) {
+	async function make_array(dimensionNames?: string[]) {
 		let h = zarr.root();
 		return zarr.create(h.resolve("/test"), {
 			shape: [100, 200, 300],
-			chunk_shape: [10, 20, 30],
-			data_type: "float32",
-			dimension_names,
+			chunkShape: [10, 20, 30],
+			dataType: "float32",
+			dimensionNames,
 		});
 	}
 
@@ -306,7 +306,7 @@ describe("sel", () => {
 	});
 });
 
-describe("v2_to_v3_array_metadata", () => {
+describe("v2ToV3ArrayMetadata", () => {
 	let v2meta = {
 		zarr_format: 2 as const,
 		shape: [100, 200],
@@ -319,7 +319,7 @@ describe("v2_to_v3_array_metadata", () => {
 	};
 
 	test("basic conversion", () => {
-		let result = v2_to_v3_array_metadata(v2meta);
+		let result = v2ToV3ArrayMetadata(v2meta);
 		expect(result).toMatchInlineSnapshot(`
 			{
 			  "attributes": {},
@@ -353,7 +353,7 @@ describe("v2_to_v3_array_metadata", () => {
 	});
 
 	test("maps _ARRAY_DIMENSIONS to dimension_names", () => {
-		let result = v2_to_v3_array_metadata(v2meta, {
+		let result = v2ToV3ArrayMetadata(v2meta, {
 			_ARRAY_DIMENSIONS: ["x", "y"],
 		});
 		expect(result).toMatchInlineSnapshot(`
@@ -397,7 +397,7 @@ describe("v2_to_v3_array_metadata", () => {
 	});
 
 	test("Fortran order adds transpose codec", () => {
-		let result = v2_to_v3_array_metadata({ ...v2meta, order: "F" });
+		let result = v2ToV3ArrayMetadata({ ...v2meta, order: "F" });
 		expect(result).toMatchInlineSnapshot(`
 			{
 			  "attributes": {},
@@ -438,7 +438,7 @@ describe("v2_to_v3_array_metadata", () => {
 	});
 
 	test("big-endian dtype adds bytes codec", () => {
-		let result = v2_to_v3_array_metadata({ ...v2meta, dtype: ">f4" });
+		let result = v2ToV3ArrayMetadata({ ...v2meta, dtype: ">f4" });
 		expect(result).toMatchInlineSnapshot(`
 			{
 			  "attributes": {},
@@ -479,7 +479,7 @@ describe("v2_to_v3_array_metadata", () => {
 	});
 
 	test("compressor is converted to codec", () => {
-		let result = v2_to_v3_array_metadata({
+		let result = v2ToV3ArrayMetadata({
 			...v2meta,
 			compressor: { id: "zlib", level: 5 },
 		});
@@ -523,7 +523,7 @@ describe("v2_to_v3_array_metadata", () => {
 	});
 
 	test("filters are converted to codecs", () => {
-		let result = v2_to_v3_array_metadata({
+		let result = v2ToV3ArrayMetadata({
 			...v2meta,
 			filters: [{ id: "delta", dtype: "<f4" }],
 		});
@@ -567,7 +567,7 @@ describe("v2_to_v3_array_metadata", () => {
 	});
 
 	test("dimension_separator is preserved", () => {
-		let result = v2_to_v3_array_metadata({
+		let result = v2ToV3ArrayMetadata({
 			...v2meta,
 			dimension_separator: "/",
 		});
@@ -604,7 +604,7 @@ describe("v2_to_v3_array_metadata", () => {
 	});
 
 	test("codec order: transpose, bytes, filters, compressor", () => {
-		let result = v2_to_v3_array_metadata({
+		let result = v2ToV3ArrayMetadata({
 			...v2meta,
 			dtype: ">f4",
 			order: "F",

--- a/packages/zarrita/__tests__/util.test.ts
+++ b/packages/zarrita/__tests__/util.test.ts
@@ -12,7 +12,7 @@ import {
 	ensureCorrectScalar,
 	getCtr,
 	getStrides,
-	isDtype,
+	isDataType,
 	v2ToV3ArrayMetadata,
 } from "../src/util.js";
 
@@ -45,7 +45,7 @@ describe("getCtr", () => {
 		});
 
 		test.each(["float16"])("%s -> throws", (dtype) => {
-			expect(() => getCtr(dtype as DataType)).toThrowError();
+			expect(() => getCtr(dtype as DataType)).toThrow();
 		});
 	});
 
@@ -111,7 +111,7 @@ describe("getStrides", () => {
 	});
 });
 
-describe("isDtype", () => {
+describe("isDataType", () => {
 	test.each<[DataType, boolean]>([
 		["int8", true],
 		["int16", true],
@@ -129,8 +129,8 @@ describe("isDtype", () => {
 		["v2:S6", false],
 		["v2:object", false],
 		["string", false],
-	])("isDtype(%s, 'number') -> %s", (dtype, expected) => {
-		expect(isDtype(dtype, "number")).toBe(expected);
+	])("isDataType(%s, 'number') -> %s", (dtype, expected) => {
+		expect(isDataType(dtype, "number")).toBe(expected);
 	});
 
 	test.each<[DataType, boolean]>([
@@ -150,8 +150,8 @@ describe("isDtype", () => {
 		["v2:S6", false],
 		["v2:object", false],
 		["string", false],
-	])("isDtype(%s, 'boolean') -> %s", (dtype, expected) => {
-		expect(isDtype(dtype, "boolean")).toBe(expected);
+	])("isDataType(%s, 'boolean') -> %s", (dtype, expected) => {
+		expect(isDataType(dtype, "boolean")).toBe(expected);
 	});
 
 	test.each<[DataType, boolean]>([
@@ -171,8 +171,8 @@ describe("isDtype", () => {
 		["v2:S6", false],
 		["v2:object", false],
 		["string", false],
-	])("isDtype(%s, 'bigint') -> %s", (dtype, expected) => {
-		expect(isDtype(dtype, "bigint")).toBe(expected);
+	])("isDataType(%s, 'bigint') -> %s", (dtype, expected) => {
+		expect(isDataType(dtype, "bigint")).toBe(expected);
 	});
 
 	test.each<[DataType, boolean]>([
@@ -192,8 +192,8 @@ describe("isDtype", () => {
 		["v2:S6", true],
 		["v2:object", false],
 		["string", true],
-	])("isDtype(%s, 'string') -> %s", (dtype, expected) => {
-		expect(isDtype(dtype, "string")).toBe(expected);
+	])("isDataType(%s, 'string') -> %s", (dtype, expected) => {
+		expect(isDataType(dtype, "string")).toBe(expected);
 	});
 
 	test.each<DataType>([
@@ -213,8 +213,8 @@ describe("isDtype", () => {
 		"v2:S6",
 		"v2:object",
 		"string",
-	])("isDtype(%s, %s) -> true", (dtype) => {
-		expect(isDtype(dtype, dtype)).toBe(true);
+	])("isDataType(%s, %s) -> true", (dtype) => {
+		expect(isDataType(dtype, dtype)).toBe(true);
 	});
 });
 
@@ -272,7 +272,7 @@ describe("sel", () => {
 		return zarr.create(h.resolve("/test"), {
 			shape: [100, 200, 300],
 			chunkShape: [10, 20, 30],
-			dataType: "float32",
+			dtype: "float32",
 			dimensionNames,
 		});
 	}
@@ -293,14 +293,12 @@ describe("sel", () => {
 
 	test("throws for unknown dimension name", async () => {
 		let arr = await make_array(["time", "lat", "lon"]);
-		expect(() => sel(arr, { bad: 0 })).toThrowError(
-			/Unknown dimension name: "bad"/,
-		);
+		expect(() => sel(arr, { bad: 0 })).toThrow(/Unknown dimension name: "bad"/);
 	});
 
 	test("throws when array has no dimension_names", async () => {
 		let arr = await make_array();
-		expect(() => sel(arr, { time: 0 })).toThrowError(
+		expect(() => sel(arr, { time: 0 })).toThrow(
 			/does not have dimension_names/,
 		);
 	});

--- a/packages/zarrita/src/codecs.ts
+++ b/packages/zarrita/src/codecs.ts
@@ -13,7 +13,7 @@ import type { Chunk, CodecMetadata, DataType } from "./metadata.js";
 import { assert } from "./util.js";
 
 type ChunkMetadata<D extends DataType> = {
-	data_type: D;
+	dataType: D;
 	shape: number[];
 	codecs: CodecMetadata[];
 };
@@ -25,7 +25,7 @@ type CodecEntry = {
 
 type Codec = _Codec & { kind: CodecEntry["kind"] };
 
-function create_default_registry(): Map<string, () => Promise<CodecEntry>> {
+function createDefaultRegistry(): Map<string, () => Promise<CodecEntry>> {
 	let blosc = () => import("numcodecs/blosc").then((m) => m.default);
 	let lz4 = () => import("numcodecs/lz4").then((m) => m.default);
 	let zstd = () => import("numcodecs/zstd").then((m) => m.default);
@@ -58,35 +58,35 @@ function create_default_registry(): Map<string, () => Promise<CodecEntry>> {
 }
 
 export const registry: Map<string, () => Promise<CodecEntry>> =
-	create_default_registry();
+	createDefaultRegistry();
 
-export function create_codec_pipeline<Dtype extends DataType>(
-	chunk_metadata: ChunkMetadata<Dtype>,
+export function createCodecPipeline<Dtype extends DataType>(
+	chunkMetadata: ChunkMetadata<Dtype>,
 ): {
 	encode(chunk: Chunk<Dtype>): Promise<Uint8Array>;
 	decode(bytes: Uint8Array): Promise<Chunk<Dtype>>;
 } {
-	let codecs: Awaited<ReturnType<typeof load_codecs>>;
+	let codecs: Awaited<ReturnType<typeof loadCodecs>>;
 	return {
 		async encode(chunk: Chunk<Dtype>): Promise<Uint8Array> {
-			if (!codecs) codecs = await load_codecs(chunk_metadata);
-			for (const codec of codecs.array_to_array) {
+			if (!codecs) codecs = await loadCodecs(chunkMetadata);
+			for (const codec of codecs.arrayToArray) {
 				chunk = await codec.encode(chunk);
 			}
-			let bytes = await codecs.array_to_bytes.encode(chunk);
-			for (const codec of codecs.bytes_to_bytes) {
+			let bytes = await codecs.arrayToBytes.encode(chunk);
+			for (const codec of codecs.bytesToBytes) {
 				bytes = await codec.encode(bytes);
 			}
 			return bytes;
 		},
 		async decode(bytes: Uint8Array): Promise<Chunk<Dtype>> {
-			if (!codecs) codecs = await load_codecs(chunk_metadata);
-			for (let i = codecs.bytes_to_bytes.length - 1; i >= 0; i--) {
-				bytes = await codecs.bytes_to_bytes[i].decode(bytes);
+			if (!codecs) codecs = await loadCodecs(chunkMetadata);
+			for (let i = codecs.bytesToBytes.length - 1; i >= 0; i--) {
+				bytes = await codecs.bytesToBytes[i].decode(bytes);
 			}
-			let chunk = await codecs.array_to_bytes.decode(bytes);
-			for (let i = codecs.array_to_array.length - 1; i >= 0; i--) {
-				chunk = await codecs.array_to_array[i].decode(chunk);
+			let chunk = await codecs.arrayToBytes.decode(bytes);
+			for (let i = codecs.arrayToArray.length - 1; i >= 0; i--) {
+				chunk = await codecs.arrayToArray[i].decode(chunk);
 			}
 			return chunk;
 		},
@@ -108,40 +108,40 @@ type BytesToBytesCodec = {
 	decode: (data: Uint8Array) => Promise<Uint8Array>;
 };
 
-async function load_codecs<D extends DataType>(chunk_meta: ChunkMetadata<D>) {
-	let promises = chunk_meta.codecs.map(async (meta) => {
+async function loadCodecs<D extends DataType>(chunkMeta: ChunkMetadata<D>) {
+	let promises = chunkMeta.codecs.map(async (meta) => {
 		let Codec = await registry.get(meta.name)?.();
 		assert(Codec, `Unknown codec: ${meta.name}`);
 		return { Codec, meta };
 	});
-	let array_to_array: ArrayToArrayCodec<D>[] = [];
-	let array_to_bytes: ArrayToBytesCodec<D> | undefined;
-	let bytes_to_bytes: BytesToBytesCodec[] = [];
+	let arrayToArray: ArrayToArrayCodec<D>[] = [];
+	let arrayToBytes: ArrayToBytesCodec<D> | undefined;
+	let bytesToBytes: BytesToBytesCodec[] = [];
 	for await (let { Codec, meta } of promises) {
-		let codec = Codec.fromConfig(meta.configuration, chunk_meta);
+		let codec = Codec.fromConfig(meta.configuration, chunkMeta);
 		switch (codec.kind) {
 			case "array_to_array":
-				array_to_array.push(codec as unknown as ArrayToArrayCodec<D>);
+				arrayToArray.push(codec as unknown as ArrayToArrayCodec<D>);
 				break;
 			case "array_to_bytes":
-				array_to_bytes = codec as unknown as ArrayToBytesCodec<D>;
+				arrayToBytes = codec as unknown as ArrayToBytesCodec<D>;
 				break;
 			default:
-				bytes_to_bytes.push(codec as unknown as BytesToBytesCodec);
+				bytesToBytes.push(codec as unknown as BytesToBytesCodec);
 		}
 	}
-	if (!array_to_bytes) {
+	if (!arrayToBytes) {
 		assert(
-			is_typed_array_like_meta(chunk_meta),
-			`Cannot encode ${chunk_meta.data_type} to bytes without a codec`,
+			isTypedArrayLikeMeta(chunkMeta),
+			`Cannot encode ${chunkMeta.dataType} to bytes without a codec`,
 		);
-		array_to_bytes = BytesCodec.fromConfig({ endian: "little" }, chunk_meta);
+		arrayToBytes = BytesCodec.fromConfig({ endian: "little" }, chunkMeta);
 	}
-	return { array_to_array, array_to_bytes, bytes_to_bytes };
+	return { arrayToArray, arrayToBytes, bytesToBytes };
 }
 
-function is_typed_array_like_meta<D extends DataType>(
+function isTypedArrayLikeMeta<D extends DataType>(
 	meta: ChunkMetadata<D>,
 ): meta is ChunkMetadata<Exclude<D, "v2:object" | "string">> {
-	return meta.data_type !== "v2:object" && meta.data_type !== "string";
+	return meta.dataType !== "v2:object" && meta.dataType !== "string";
 }

--- a/packages/zarrita/src/codecs/bitround.ts
+++ b/packages/zarrita/src/codecs/bitround.ts
@@ -20,13 +20,13 @@ import { assert } from "../util.js";
 export class BitroundCodec<D extends Float64 | Float32> {
 	kind = "array_to_array";
 
-	constructor(configuration: { keepbits: number }, _meta: { data_type: D }) {
+	constructor(configuration: { keepbits: number }, _meta: { dataType: D }) {
 		assert(configuration.keepbits >= 0, "keepbits must be zero or positive");
 	}
 
 	static fromConfig<D extends Float32 | Float64>(
 		configuration: { keepbits: number },
-		meta: { data_type: D },
+		meta: { dataType: D },
 	): BitroundCodec<D> {
 		return new BitroundCodec(configuration, meta);
 	}

--- a/packages/zarrita/src/codecs/bytes.ts
+++ b/packages/zarrita/src/codecs/bytes.ts
@@ -4,17 +4,17 @@ import type {
 	DataType,
 	TypedArrayConstructor,
 } from "../metadata.js";
-import { byteswap_inplace, get_ctr, get_strides } from "../util.js";
+import { byteswapInplace, getCtr, getStrides } from "../util.js";
 
-const LITTLE_ENDIAN_OS = system_is_little_endian();
+const LITTLE_ENDIAN_OS = systemIsLittleEndian();
 
-function system_is_little_endian(): boolean {
+function systemIsLittleEndian(): boolean {
 	const a = new Uint32Array([0x12345678]);
 	const b = new Uint8Array(a.buffer, a.byteOffset, a.byteLength);
 	return !(b[0] === 0x12);
 }
 
-function bytes_per_element<D extends DataType>(
+function bytesPerElement<D extends DataType>(
 	TypedArray: TypedArrayConstructor<D>,
 ): number {
 	if ("BYTES_PER_ELEMENT" in TypedArray) {
@@ -34,12 +34,12 @@ export class BytesCodec<D extends Exclude<DataType, "v2:object" | "string">> {
 
 	constructor(
 		configuration: { endian?: "little" | "big" } | undefined,
-		meta: { data_type: D; shape: number[]; codecs: CodecMetadata[] },
+		meta: { dataType: D; shape: number[]; codecs: CodecMetadata[] },
 	) {
 		this.#endian = configuration?.endian;
-		this.#TypedArray = get_ctr(meta.data_type);
+		this.#TypedArray = getCtr(meta.dataType);
 		this.#shape = meta.shape;
-		this.#stride = get_strides(meta.shape, "C");
+		this.#stride = getStrides(meta.shape, "C");
 		// TODO: fix me.
 		// hack to get bytes per element since it's dynamic for string types.
 		const sample = new this.#TypedArray(0);
@@ -48,7 +48,7 @@ export class BytesCodec<D extends Exclude<DataType, "v2:object" | "string">> {
 
 	static fromConfig<D extends Exclude<DataType, "v2:object" | "string">>(
 		configuration: { endian: "little" | "big" },
-		meta: { data_type: D; shape: number[]; codecs: CodecMetadata[] },
+		meta: { dataType: D; shape: number[]; codecs: CodecMetadata[] },
 	): BytesCodec<D> {
 		return new BytesCodec(configuration, meta);
 	}
@@ -56,14 +56,14 @@ export class BytesCodec<D extends Exclude<DataType, "v2:object" | "string">> {
 	encode(arr: Chunk<D>): Uint8Array {
 		let bytes = new Uint8Array(arr.data.buffer);
 		if (LITTLE_ENDIAN_OS && this.#endian === "big") {
-			byteswap_inplace(bytes, bytes_per_element(this.#TypedArray));
+			byteswapInplace(bytes, bytesPerElement(this.#TypedArray));
 		}
 		return bytes;
 	}
 
 	decode(bytes: Uint8Array): Chunk<D> {
 		if (LITTLE_ENDIAN_OS && this.#endian === "big") {
-			byteswap_inplace(bytes, bytes_per_element(this.#TypedArray));
+			byteswapInplace(bytes, bytesPerElement(this.#TypedArray));
 		}
 		return {
 			data: new this.#TypedArray(

--- a/packages/zarrita/src/codecs/delta.ts
+++ b/packages/zarrita/src/codecs/delta.ts
@@ -1,5 +1,5 @@
 import type { BigintDataType, Chunk, NumberDataType } from "../metadata.js";
-import { get_ctr } from "../util.js";
+import { getCtr } from "../util.js";
 
 type DeltaCompatibleType = NumberDataType | BigintDataType;
 
@@ -20,7 +20,7 @@ const SUPPORTED: ReadonlySet<string> = new Set<DeltaCompatibleType>([
 // The python codecs flatten with arr.reshape(-1, order='A').
 // The zarrita codec uses the byte order of the data.
 // These two are only equivalent if the array strides are C style or Fortran style.
-function assert_c_or_f_contiguous(shape: number[], stride: number[]): void {
+function assertCOrFContiguous(shape: number[], stride: number[]): void {
 	const n = shape.length;
 	let c = n === 0 || stride[n - 1] === 1;
 	for (let i = n - 2; i >= 0 && c; i--) {
@@ -41,25 +41,25 @@ function assert_c_or_f_contiguous(shape: number[], stride: number[]): void {
 
 export class DeltaCodec<D extends DeltaCompatibleType> {
 	kind = "array_to_array" as const;
-	#ctr: ReturnType<typeof get_ctr<D>>;
+	#ctr: ReturnType<typeof getCtr<D>>;
 
-	constructor(ctr: ReturnType<typeof get_ctr<D>>) {
+	constructor(ctr: ReturnType<typeof getCtr<D>>) {
 		this.#ctr = ctr;
 	}
 
 	static fromConfig<D extends DeltaCompatibleType>(
 		_config: unknown,
-		meta: { data_type: D },
+		meta: { dataType: D },
 	): DeltaCodec<D> {
-		if (!SUPPORTED.has(meta.data_type))
+		if (!SUPPORTED.has(meta.dataType))
 			throw new Error(
-				`Delta codec does not support data type: ${meta.data_type}`,
+				`Delta codec does not support data type: ${meta.dataType}`,
 			);
-		return new DeltaCodec(get_ctr(meta.data_type));
+		return new DeltaCodec(getCtr(meta.dataType));
 	}
 
 	encode(chunk: Chunk<D>): Chunk<D> {
-		assert_c_or_f_contiguous(chunk.shape, chunk.stride);
+		assertCOrFContiguous(chunk.shape, chunk.stride);
 		const src = chunk.data;
 		const out = new this.#ctr(src.length) as Chunk<D>["data"];
 		out[0] = src[0];
@@ -71,7 +71,7 @@ export class DeltaCodec<D extends DeltaCompatibleType> {
 	}
 
 	decode(chunk: Chunk<D>): Chunk<D> {
-		assert_c_or_f_contiguous(chunk.shape, chunk.stride);
+		assertCOrFContiguous(chunk.shape, chunk.stride);
 		const src = chunk.data;
 		const out = new this.#ctr(src.length) as Chunk<D>["data"];
 		out[0] = src[0];

--- a/packages/zarrita/src/codecs/json2.ts
+++ b/packages/zarrita/src/codecs/json2.ts
@@ -1,6 +1,6 @@
 // Adapted from https://github.com/hms-dbmi/vizarr/blob/5b0e3ea6fbb42d19d0e38e60e49bb73d1aca0693/src/utils.ts#L26
 import type { Chunk, ObjectType } from "../metadata.js";
-import { assert, get_strides, json_decode_object } from "../util.js";
+import { assert, getStrides, jsonDecodeObject } from "../util.js";
 
 type EncoderConfig = {
 	encoding?: "utf-8";
@@ -23,7 +23,7 @@ type JsonCodecConfig = EncoderConfig & DecoderConfig;
 type ReplacerFunction = (key: string | number, value: any) => any;
 
 // Reference: https://stackoverflow.com/a/21897413
-function throw_on_nan_replacer(_key: string | number, value: number): number {
+function throwOnNanReplacer(_key: string | number, value: number): number {
 	assert(
 		!Number.isNaN(value),
 		"JsonCodec allow_nan is false but NaN was encountered during encoding.",
@@ -40,7 +40,7 @@ function throw_on_nan_replacer(_key: string | number, value: number): number {
 }
 
 // Reference: https://gist.github.com/davidfurlong/463a83a33b70a3b6618e97ec9679e490
-function sort_keys_replacer(
+function sortKeysReplacer(
 	_key: string | number,
 	value: Record<string, unknown>,
 ) {
@@ -60,8 +60,8 @@ function sort_keys_replacer(
 export class JsonCodec {
 	kind = "array_to_bytes";
 
-	#encoder_config: EncoderConfig;
-	#decoder_config: DecoderConfig;
+	#encoderConfig: EncoderConfig;
+	#decoderConfig: DecoderConfig;
 
 	constructor(public configuration: JsonCodecConfig = {}) {
 		// Reference: https://github.com/zarr-developers/numcodecs/blob/0878717a3613d91a453fe3d3716aa9c67c023a8b/numcodecs/json.py#L36
@@ -87,7 +87,7 @@ export class JsonCodec {
 			}
 		}
 
-		this.#encoder_config = {
+		this.#encoderConfig = {
 			encoding,
 			skipkeys,
 			ensure_ascii,
@@ -97,7 +97,7 @@ export class JsonCodec {
 			separators,
 			sort_keys,
 		};
-		this.#decoder_config = { strict };
+		this.#decoderConfig = { strict };
 	}
 	static fromConfig(configuration: JsonCodecConfig) {
 		return new JsonCodec(configuration);
@@ -111,12 +111,12 @@ export class JsonCodec {
 			check_circular,
 			allow_nan,
 			sort_keys,
-		} = this.#encoder_config;
+		} = this.#encoderConfig;
 		assert(
 			encoding === "utf-8",
 			"JsonCodec does not yet support non-utf-8 encoding.",
 		);
-		const replacer_functions: ReplacerFunction[] = [];
+		const replacerFunctions: ReplacerFunction[] = [];
 
 		// By default, for JSON.stringify,
 		// a TypeError will be thrown if one attempts to encode an object with circular references
@@ -127,12 +127,12 @@ export class JsonCodec {
 
 		if (!allow_nan) {
 			// Throw if NaN/Infinity/-Infinity are encountered during encoding.
-			replacer_functions.push(throw_on_nan_replacer);
+			replacerFunctions.push(throwOnNanReplacer);
 		}
 		if (sort_keys) {
 			// We can ensure keys are sorted but not really the opposite since
 			// there is no guarantee of key ordering in JS.
-			replacer_functions.push(sort_keys_replacer);
+			replacerFunctions.push(sortKeysReplacer);
 		}
 
 		const items = Array.from(buf.data);
@@ -140,43 +140,43 @@ export class JsonCodec {
 		items.push(buf.shape);
 
 		let replacer: ReplacerFunction | undefined;
-		if (replacer_functions.length) {
+		if (replacerFunctions.length) {
 			replacer = (key, value) => {
-				let new_value = value;
-				for (let sub_replacer of replacer_functions) {
-					new_value = sub_replacer(key, new_value);
+				let newValue = value;
+				for (let subReplacer of replacerFunctions) {
+					newValue = subReplacer(key, newValue);
 				}
-				return new_value;
+				return newValue;
 			};
 		}
-		let json_str = JSON.stringify(items, replacer, indent);
+		let jsonStr = JSON.stringify(items, replacer, indent);
 
 		if (ensure_ascii) {
 			// If ensure_ascii is true (the default), the output is guaranteed
 			// to have all incoming non-ASCII characters escaped.
 			// If ensure_ascii is false, these characters will be output as-is.
 			// Reference: https://stackoverflow.com/a/31652607
-			json_str = json_str.replace(/[\u007F-\uFFFF]/g, (chr) => {
-				const full_str = `0000${chr.charCodeAt(0).toString(16)}`;
-				const sub_str = full_str.substring(full_str.length - 4);
-				return `\\u${sub_str}`;
+			jsonStr = jsonStr.replace(/[\u007F-\uFFFF]/g, (chr) => {
+				const fullStr = `0000${chr.charCodeAt(0).toString(16)}`;
+				const subStr = fullStr.substring(fullStr.length - 4);
+				return `\\u${subStr}`;
 			});
 		}
-		return new TextEncoder().encode(json_str);
+		return new TextEncoder().encode(jsonStr);
 	}
 
 	decode(bytes: Uint8Array): Chunk<ObjectType> {
-		const { strict } = this.#decoder_config;
+		const { strict } = this.#decoderConfig;
 		// (i.e., allowing control characters inside strings)
 		assert(strict, "JsonCodec does not yet support non-strict decoding.");
 
-		const items = json_decode_object(bytes);
+		const items = jsonDecodeObject(bytes);
 		const shape = items.pop();
 		items.pop(); // Pop off dtype (unused)
 
 		// O-d case
 		assert(shape, "0D not implemented for JsonCodec.");
-		const stride = get_strides(shape, "C");
+		const stride = getStrides(shape, "C");
 		const data = items;
 		return { data, shape, stride };
 	}

--- a/packages/zarrita/src/codecs/sharding.ts
+++ b/packages/zarrita/src/codecs/sharding.ts
@@ -1,72 +1,70 @@
 import type { Readable } from "@zarrita/storage";
-import { create_codec_pipeline } from "../codecs.js";
+import { createCodecPipeline } from "../codecs.js";
 import type { Location } from "../hierarchy.js";
 import type { Chunk } from "../metadata.js";
 import { assert, type ShardingCodecMetadata } from "../util.js";
 
 const MAX_BIG_UINT = 18446744073709551615n;
 
-export function create_sharded_chunk_getter<Store extends Readable>(
+export function createShardedChunkGetter<Store extends Readable>(
 	location: Location<Store>,
-	shard_shape: number[],
-	encode_shard_key: (coord: number[]) => string,
-	sharding_config: ShardingCodecMetadata["configuration"],
+	shardShape: number[],
+	encodeShardKey: (coord: number[]) => string,
+	shardingConfig: ShardingCodecMetadata["configuration"],
 ) {
 	assert(location.store.getRange, "Store does not support range requests");
-	let get_range = location.store.getRange.bind(location.store);
-	let index_shape = shard_shape.map(
-		(d, i) => d / sharding_config.chunk_shape[i],
-	);
-	let index_codec = create_codec_pipeline({
-		data_type: "uint64",
-		shape: [...index_shape, 2],
-		codecs: sharding_config.index_codecs,
+	let getRange = location.store.getRange.bind(location.store);
+	let indexShape = shardShape.map((d, i) => d / shardingConfig.chunk_shape[i]);
+	let indexCodec = createCodecPipeline({
+		dataType: "uint64",
+		shape: [...indexShape, 2],
+		codecs: shardingConfig.index_codecs,
 	});
 
-	let checksum_size = 4;
-	let index_size = 16 * index_shape.reduce((a, b) => a * b, 1);
+	let checksumSize = 4;
+	let indexSize = 16 * indexShape.reduce((a, b) => a * b, 1);
 	let cache: Record<string, Promise<Chunk<"uint64"> | null>> = {};
 	return async (
-		chunk_coord: number[],
+		chunkCoord: number[],
 		options?: Parameters<Store["get"]>[1],
 	) => {
-		let shard_coord = chunk_coord.map((d, i) => Math.floor(d / index_shape[i]));
-		let shard_path = location.resolve(encode_shard_key(shard_coord)).path;
+		let shardCoord = chunkCoord.map((d, i) => Math.floor(d / indexShape[i]));
+		let shardPath = location.resolve(encodeShardKey(shardCoord)).path;
 
-		if (!(shard_path in cache)) {
-			cache[shard_path] = (async () => {
-				let bytes = await get_range(
-					shard_path,
+		if (!(shardPath in cache)) {
+			cache[shardPath] = (async () => {
+				let bytes = await getRange(
+					shardPath,
 					{
-						suffixLength: index_size + checksum_size,
+						suffixLength: indexSize + checksumSize,
 					},
 					options,
 				);
-				return bytes ? await index_codec.decode(bytes) : null;
+				return bytes ? await indexCodec.decode(bytes) : null;
 			})().catch((err) => {
-				delete cache[shard_path];
+				delete cache[shardPath];
 				throw err;
 			});
 		}
-		let index = await cache[shard_path];
+		let index = await cache[shardPath];
 
 		if (index === null) {
 			return undefined;
 		}
 
 		let { data, shape, stride } = index;
-		let linear_offset = chunk_coord
+		let linearOffset = chunkCoord
 			.map((d, i) => d % shape[i])
 			.reduce((acc, sel, idx) => acc + sel * stride[idx], 0);
 
-		let offset = data[linear_offset];
-		let length = data[linear_offset + 1];
+		let offset = data[linearOffset];
+		let length = data[linearOffset + 1];
 		// write null chunk when 2^64-1 indicates fill value
 		if (offset === MAX_BIG_UINT && length === MAX_BIG_UINT) {
 			return undefined;
 		}
-		return get_range(
-			shard_path,
+		return getRange(
+			shardPath,
 			{
 				offset: Number(offset),
 				length: Number(length),

--- a/packages/zarrita/src/codecs/shuffle.ts
+++ b/packages/zarrita/src/codecs/shuffle.ts
@@ -1,5 +1,5 @@
 import type { DataType } from "../metadata.js";
-import { assert, get_ctr } from "../util.js";
+import { assert, getCtr } from "../util.js";
 
 /**
  * Shuffle filter codec (numcodecs compat).
@@ -11,15 +11,12 @@ export class ShuffleCodec<D extends DataType> {
 	kind = "bytes_to_bytes";
 	#BYTES_PER_ELEMENT: number;
 
-	constructor(
-		configuration: { elementsize?: number },
-		meta?: { data_type: D },
-	) {
+	constructor(configuration: { elementsize?: number }, meta?: { dataType: D }) {
 		if (meta) {
-			let sample = new (get_ctr(meta.data_type))(0);
+			let sample = new (getCtr(meta.dataType))(0);
 			assert(
 				"BYTES_PER_ELEMENT" in sample,
-				`Shuffle codec requires a fixed-size dtype, got "${meta.data_type}"`,
+				`Shuffle codec requires a fixed-size dtype, got "${meta.dataType}"`,
 			);
 			this.#BYTES_PER_ELEMENT = sample.BYTES_PER_ELEMENT as number;
 		} else {
@@ -29,7 +26,7 @@ export class ShuffleCodec<D extends DataType> {
 
 	static fromConfig<D extends DataType>(
 		configuration: { elementsize?: number },
-		meta?: { data_type: D },
+		meta?: { dataType: D },
 	): ShuffleCodec<D> {
 		return new ShuffleCodec(configuration, meta);
 	}

--- a/packages/zarrita/src/codecs/transpose.ts
+++ b/packages/zarrita/src/codecs/transpose.ts
@@ -10,7 +10,7 @@ import {
 	ByteStringArray,
 	UnicodeStringArray,
 } from "../typedarray.js";
-import { assert, get_strides } from "../util.js";
+import { assert, getStrides } from "../util.js";
 
 type TypedArrayProxy<D extends DataType> = {
 	[x: number]: Scalar<D>;
@@ -39,7 +39,7 @@ function proxy<D extends DataType>(arr: TypedArray<D>): TypedArrayProxy<D> {
 	return arr;
 }
 
-function empty_like<D extends DataType>(
+function emptyLike<D extends DataType>(
 	chunk: Chunk<D>,
 	order: Order,
 ): Chunk<D> {
@@ -61,33 +61,33 @@ function empty_like<D extends DataType>(
 	return {
 		data,
 		shape: chunk.shape,
-		stride: get_strides(chunk.shape, order),
+		stride: getStrides(chunk.shape, order),
 	};
 }
 
-function convert_array_order<D extends DataType>(
+function convertArrayOrder<D extends DataType>(
 	src: Chunk<D>,
 	target: Order,
 ): Chunk<D> {
-	let out = empty_like(src, target);
-	let n_dims = src.shape.length;
+	let out = emptyLike(src, target);
+	let nDims = src.shape.length;
 	let size = src.data.length;
-	let index = Array(n_dims).fill(0);
+	let index = Array(nDims).fill(0);
 
-	let src_data = proxy(src.data);
-	let out_data = proxy(out.data);
+	let srcData = proxy(src.data);
+	let outData = proxy(out.data);
 
-	for (let src_idx = 0; src_idx < size; src_idx++) {
-		let out_idx = 0;
-		for (let dim = 0; dim < n_dims; dim++) {
-			out_idx += index[dim] * out.stride[dim];
+	for (let srcIdx = 0; srcIdx < size; srcIdx++) {
+		let outIdx = 0;
+		for (let dim = 0; dim < nDims; dim++) {
+			outIdx += index[dim] * out.stride[dim];
 		}
-		out_data[out_idx] = src_data[src_idx];
+		outData[outIdx] = srcData[srcIdx];
 
 		index[0] += 1;
-		for (let dim = 0; dim < n_dims; dim++) {
+		for (let dim = 0; dim < nDims; dim++) {
 			if (index[dim] === src.shape[dim]) {
-				if (dim + 1 === n_dims) {
+				if (dim + 1 === nDims) {
 					break;
 				}
 				index[dim] = 0;
@@ -100,7 +100,7 @@ function convert_array_order<D extends DataType>(
 }
 
 /** Determine the memory order (axis permutation) for a chunk */
-function get_order(chunk: Chunk<DataType>): number[] {
+function getOrder(chunk: Chunk<DataType>): number[] {
 	let rank = chunk.shape.length;
 	assert(
 		rank === chunk.stride.length,
@@ -112,8 +112,8 @@ function get_order(chunk: Chunk<DataType>): number[] {
 		.map((entry) => entry.index);
 }
 
-function matches_order(chunk: Chunk<DataType>, target: Order) {
-	let source = get_order(chunk);
+function matchesOrder(chunk: Chunk<DataType>, target: Order) {
+	let source = getOrder(chunk);
 	assert(source.length === target.length, "Orders must match");
 	return source.every((dim, i) => dim === target[i]);
 }
@@ -164,18 +164,18 @@ export class TransposeCodec {
 	}
 
 	encode<D extends DataType>(arr: Chunk<D>): Chunk<D> {
-		if (matches_order(arr, this.#inverseOrder)) {
+		if (matchesOrder(arr, this.#inverseOrder)) {
 			// can skip making a copy
 			return arr;
 		}
-		return convert_array_order(arr, this.#inverseOrder);
+		return convertArrayOrder(arr, this.#inverseOrder);
 	}
 
 	decode<D extends DataType>(arr: Chunk<D>): Chunk<D> {
 		return {
 			data: arr.data,
 			shape: arr.shape,
-			stride: get_strides(arr.shape, this.#order),
+			stride: getStrides(arr.shape, this.#order),
 		};
 	}
 }

--- a/packages/zarrita/src/codecs/vlen-utf8.ts
+++ b/packages/zarrita/src/codecs/vlen-utf8.ts
@@ -1,5 +1,5 @@
 import type { Chunk, String } from "../metadata.js";
-import { get_strides } from "../util.js";
+import { getStrides } from "../util.js";
 
 export class VLenUTF8 {
 	readonly kind = "array_to_bytes";
@@ -8,7 +8,7 @@ export class VLenUTF8 {
 
 	constructor(shape: number[]) {
 		this.#shape = shape;
-		this.#strides = get_strides(shape, "C");
+		this.#strides = getStrides(shape, "C");
 	}
 	static fromConfig(_: unknown, meta: { shape: number[] }) {
 		return new VLenUTF8(meta.shape);
@@ -24,12 +24,12 @@ export class VLenUTF8 {
 		let data: Array<string> = Array(view.getUint32(0, true));
 		let pos = 4;
 		for (let i = 0; i < data.length; i++) {
-			let item_length = view.getUint32(pos, true);
+			let itemLength = view.getUint32(pos, true);
 			pos += 4;
 			data[i] = decoder.decode(
-				(bytes.buffer as ArrayBuffer).slice(pos, pos + item_length),
+				(bytes.buffer as ArrayBuffer).slice(pos, pos + itemLength),
 			);
-			pos += item_length;
+			pos += itemLength;
 		}
 		return { data, shape: this.#shape, stride: this.#strides };
 	}

--- a/packages/zarrita/src/consolidated.ts
+++ b/packages/zarrita/src/consolidated.ts
@@ -10,10 +10,10 @@ import type {
 } from "./metadata.js";
 import { VERSION_COUNTER } from "./open.js";
 import {
-	ensure_correct_scalar,
-	json_decode_object,
-	json_encode_object,
-	rethrow_unless,
+	ensureCorrectScalar,
+	jsonDecodeObject,
+	jsonEncodeObject,
+	rethrowUnless,
 } from "./util.js";
 
 type ConsolidatedMetadataV2 = {
@@ -27,7 +27,7 @@ type ConsolidatedMetadataV3 = {
 	metadata: Record<string, ArrayMetadata | GroupMetadata>;
 };
 
-function is_consolidated_v2(meta: unknown): meta is ConsolidatedMetadataV2 {
+function isConsolidatedV2(meta: unknown): meta is ConsolidatedMetadataV2 {
 	return (
 		typeof meta === "object" &&
 		meta !== null &&
@@ -39,7 +39,7 @@ function is_consolidated_v2(meta: unknown): meta is ConsolidatedMetadataV2 {
 	);
 }
 
-function is_consolidated_v3(meta: unknown): meta is GroupMetadata & {
+function isConsolidatedV3(meta: unknown): meta is GroupMetadata & {
 	consolidated_metadata: ConsolidatedMetadataV3;
 } {
 	return (
@@ -102,7 +102,7 @@ type Metadata =
 	| GroupMetadata
 	| Attributes;
 
-function is_meta_key(key: string): boolean {
+function isMetaKey(key: string): boolean {
 	return (
 		key.endsWith(".zarray") ||
 		key.endsWith(".zgroup") ||
@@ -111,11 +111,11 @@ function is_meta_key(key: string): boolean {
 	);
 }
 
-function is_v3(meta: Metadata): meta is ArrayMetadata | GroupMetadata {
+function isV3(meta: Metadata): meta is ArrayMetadata | GroupMetadata {
 	return "zarr_format" in meta && meta.zarr_format === 3;
 }
 
-async function load_consolidated_v2(
+async function loadConsolidatedV2(
 	store: Readable,
 	metadataKey: string | undefined,
 ): Promise<Record<AbsolutePath, Metadata>> {
@@ -126,20 +126,20 @@ async function load_consolidated_v2(
 			cause: new KeyError(`/${key}`),
 		});
 	}
-	let meta: unknown = json_decode_object(bytes);
-	if (!is_consolidated_v2(meta)) {
+	let meta: unknown = jsonDecodeObject(bytes);
+	if (!isConsolidatedV2(meta)) {
 		throw new NodeNotFoundError("v2 consolidated metadata", {
 			cause: new Error("Invalid or unsupported v2 consolidated format."),
 		});
 	}
-	let known_meta: Record<AbsolutePath, Metadata> = {};
+	let knownMeta: Record<AbsolutePath, Metadata> = {};
 	for (let [k, value] of Object.entries(meta.metadata)) {
-		known_meta[`/${k}`] = value;
+		knownMeta[`/${k}`] = value;
 	}
-	return known_meta;
+	return knownMeta;
 }
 
-async function load_consolidated_v3(
+async function loadConsolidatedV3(
 	store: Readable,
 ): Promise<Record<AbsolutePath, Metadata>> {
 	let bytes = await store.get("/zarr.json");
@@ -148,38 +148,38 @@ async function load_consolidated_v3(
 			cause: new KeyError("/zarr.json"),
 		});
 	}
-	let root_meta: unknown = json_decode_object(bytes);
-	if (!is_consolidated_v3(root_meta)) {
+	let rootMeta: unknown = jsonDecodeObject(bytes);
+	if (!isConsolidatedV3(rootMeta)) {
 		throw new NodeNotFoundError("v3 consolidated metadata", {
 			cause: new Error(
 				"Root zarr.json does not contain consolidated_metadata.",
 			),
 		});
 	}
-	let known_meta: Record<AbsolutePath, Metadata> = {};
+	let knownMeta: Record<AbsolutePath, Metadata> = {};
 	// Add root group metadata
-	known_meta["/zarr.json"] = {
+	knownMeta["/zarr.json"] = {
 		zarr_format: 3,
 		node_type: "group",
-		attributes: root_meta.attributes ?? {},
+		attributes: rootMeta.attributes ?? {},
 	} satisfies GroupMetadata;
 	for (let [path, meta] of Object.entries(
-		root_meta.consolidated_metadata.metadata,
+		rootMeta.consolidated_metadata.metadata,
 	)) {
 		// Normalize path: ensure it starts with /
 		let normalized = path.startsWith("/") ? path : `/${path}`;
 		let key = `${normalized}/zarr.json` as AbsolutePath;
 		if (meta.node_type === "array") {
-			(meta as ArrayMetadata<DataType>).fill_value = ensure_correct_scalar(
+			(meta as ArrayMetadata<DataType>).fill_value = ensureCorrectScalar(
 				meta as ArrayMetadata<DataType>,
 			);
 		}
-		known_meta[key] = meta;
+		knownMeta[key] = meta;
 	}
-	return known_meta;
+	return knownMeta;
 }
 
-function resolve_formats(
+function resolveFormats(
 	store: Readable,
 	format: ConsolidatedFormat | ConsolidatedFormat[] | undefined,
 ): ConsolidatedFormat[] {
@@ -187,39 +187,39 @@ function resolve_formats(
 		return globalThis.Array.isArray(format) ? format : [format];
 	}
 	// Auto-detect: use version counter to decide priority
-	let version_max = VERSION_COUNTER.version_max(store);
-	return version_max === "v3" ? ["v3", "v2"] : ["v2", "v3"];
+	let versionMax = VERSION_COUNTER.versionMax(store);
+	return versionMax === "v3" ? ["v3", "v2"] : ["v2", "v3"];
 }
 
-function create_listable<Store extends Readable>(
+function createListable<Store extends Readable>(
 	store: Store,
-	known_meta: Record<AbsolutePath, Metadata>,
+	knownMeta: Record<AbsolutePath, Metadata>,
 ): Listable<Store> {
 	return {
 		async get(
 			...args: Parameters<Store["get"]>
 		): Promise<Uint8Array | undefined> {
 			let [key, opts] = args;
-			if (known_meta[key]) {
-				return json_encode_object(known_meta[key]);
+			if (knownMeta[key]) {
+				return jsonEncodeObject(knownMeta[key]);
 			}
-			let maybe_bytes = await store.get(key, opts);
-			if (is_meta_key(key) && maybe_bytes) {
-				let meta = json_decode_object(maybe_bytes);
-				known_meta[key] = meta;
+			let maybeBytes = await store.get(key, opts);
+			if (isMetaKey(key) && maybeBytes) {
+				let meta = jsonDecodeObject(maybeBytes);
+				knownMeta[key] = meta;
 			}
-			return maybe_bytes;
+			return maybeBytes;
 		},
 		getRange: store.getRange?.bind(store),
 		contents(): { path: AbsolutePath; kind: "array" | "group" }[] {
 			let contents: { path: AbsolutePath; kind: "array" | "group" }[] = [];
-			for (let [key, value] of Object.entries(known_meta)) {
+			for (let [key, value] of Object.entries(knownMeta)) {
 				let parts = key.split("/");
 				let filename = parts.pop();
 				let path = (parts.join("/") || "/") as AbsolutePath;
 				if (filename === ".zarray") contents.push({ path, kind: "array" });
 				if (filename === ".zgroup") contents.push({ path, kind: "group" });
-				if (is_v3(value)) {
+				if (isV3(value)) {
 					contents.push({ path, kind: value.node_type });
 				}
 			}
@@ -261,21 +261,21 @@ export async function withConsolidated<Store extends Readable>(
 	store: Store,
 	opts: WithConsolidatedOptions = {},
 ): Promise<Listable<Store>> {
-	let formats = resolve_formats(store, opts.format);
-	let last_error: unknown;
+	let formats = resolveFormats(store, opts.format);
+	let lastError: unknown;
 	for (let format of formats) {
 		try {
-			let known_meta =
+			let knownMeta =
 				format === "v2"
-					? await load_consolidated_v2(store, opts.metadataKey)
-					: await load_consolidated_v3(store);
-			return create_listable(store, known_meta);
+					? await loadConsolidatedV2(store, opts.metadataKey)
+					: await loadConsolidatedV3(store);
+			return createListable(store, knownMeta);
 		} catch (err) {
-			rethrow_unless(err, NodeNotFoundError);
-			last_error = err;
+			rethrowUnless(err, NodeNotFoundError);
+			lastError = err;
 		}
 	}
-	throw last_error;
+	throw lastError;
 }
 
 /**
@@ -296,7 +296,7 @@ export async function tryWithConsolidated<Store extends Readable>(
 	opts: WithConsolidatedOptions = {},
 ): Promise<Listable<Store> | Store> {
 	return withConsolidated(store, opts).catch((error: unknown) => {
-		rethrow_unless(error, NodeNotFoundError);
+		rethrowUnless(error, NodeNotFoundError);
 		return store;
 	});
 }

--- a/packages/zarrita/src/create.ts
+++ b/packages/zarrita/src/create.ts
@@ -18,7 +18,7 @@ interface CreateGroupOptions {
 interface CreateArrayOptions<Dtype extends DataType> {
 	shape: number[];
 	chunkShape: number[];
-	dataType: Dtype;
+	dtype: Dtype;
 	codecs?: CodecMetadata[];
 	fillValue?: Scalar<Dtype>;
 	chunkSeparator?: "." | "/";
@@ -80,7 +80,7 @@ async function createArray<Store extends Mutable, Dtype extends DataType>(
 		zarr_format: 3,
 		node_type: "array",
 		shape: options.shape,
-		data_type: options.dataType,
+		data_type: options.dtype,
 		chunk_grid: {
 			name: "regular",
 			configuration: {

--- a/packages/zarrita/src/create.ts
+++ b/packages/zarrita/src/create.ts
@@ -9,7 +9,7 @@ import type {
 	GroupMetadata,
 	Scalar,
 } from "./metadata.js";
-import { json_encode_object } from "./util.js";
+import { jsonEncodeObject } from "./util.js";
 
 interface CreateGroupOptions {
 	attributes?: Record<string, unknown>;
@@ -17,12 +17,12 @@ interface CreateGroupOptions {
 
 interface CreateArrayOptions<Dtype extends DataType> {
 	shape: number[];
-	chunk_shape: number[];
-	data_type: Dtype;
+	chunkShape: number[];
+	dataType: Dtype;
 	codecs?: CodecMetadata[];
-	fill_value?: Scalar<Dtype>;
-	chunk_separator?: "." | "/";
-	dimension_names?: string[];
+	fillValue?: Scalar<Dtype>;
+	chunkSeparator?: "." | "/";
+	dimensionNames?: string[];
 	attributes?: Attributes;
 }
 
@@ -50,13 +50,13 @@ export async function create<Store extends Mutable, Dtype extends DataType>(
 ): Promise<Array<Dtype, Store> | Group<Store>> {
 	let loc = "store" in location ? location : new Location(location);
 	if ("shape" in options) {
-		let arr = await create_array(loc, options);
+		let arr = await createArray(loc, options);
 		return arr as Array<Dtype, Store>;
 	}
-	return create_group(loc, options);
+	return createGroup(loc, options);
 }
 
-async function create_group<Store extends Mutable>(
+async function createGroup<Store extends Mutable>(
 	location: Location<Store>,
 	options: CreateGroupOptions = {},
 ): Promise<Group<Store>> {
@@ -67,12 +67,12 @@ async function create_group<Store extends Mutable>(
 	} satisfies GroupMetadata;
 	await location.store.set(
 		location.resolve("zarr.json").path,
-		json_encode_object(metadata),
+		jsonEncodeObject(metadata),
 	);
 	return new Group(location.store, location.path, metadata);
 }
 
-async function create_array<Store extends Mutable, Dtype extends DataType>(
+async function createArray<Store extends Mutable, Dtype extends DataType>(
 	location: Location<Store>,
 	options: CreateArrayOptions<Dtype>,
 ): Promise<Array<DataType, Store>> {
@@ -80,27 +80,27 @@ async function create_array<Store extends Mutable, Dtype extends DataType>(
 		zarr_format: 3,
 		node_type: "array",
 		shape: options.shape,
-		data_type: options.data_type,
+		data_type: options.dataType,
 		chunk_grid: {
 			name: "regular",
 			configuration: {
-				chunk_shape: options.chunk_shape,
+				chunk_shape: options.chunkShape,
 			},
 		},
 		chunk_key_encoding: {
 			name: "default",
 			configuration: {
-				separator: options.chunk_separator ?? "/",
+				separator: options.chunkSeparator ?? "/",
 			},
 		},
 		codecs: options.codecs ?? [],
-		fill_value: options.fill_value ?? null,
-		dimension_names: options.dimension_names,
+		fill_value: options.fillValue ?? null,
+		dimension_names: options.dimensionNames,
 		attributes: options.attributes ?? {},
 	} satisfies ArrayMetadata<Dtype>;
 	await location.store.set(
 		location.resolve("zarr.json").path,
-		json_encode_object(metadata),
+		jsonEncodeObject(metadata),
 	);
 	return new Array(location.store, location.path, metadata);
 }

--- a/packages/zarrita/src/hierarchy.ts
+++ b/packages/zarrita/src/hierarchy.ts
@@ -20,7 +20,7 @@ import {
 	ensureCorrectScalar,
 	getCtr,
 	getStrides,
-	isDtype,
+	isDataType,
 	isShardingCodec,
 	type NarrowDataType,
 } from "./util.js";
@@ -258,6 +258,6 @@ export class Array<
 	is<Query extends DataTypeQuery>(
 		query: Query,
 	): this is Array<NarrowDataType<Dtype, Query>, Store> {
-		return isDtype(this.dtype, query);
+		return isDataType(this.dtype, query);
 	}
 }

--- a/packages/zarrita/src/hierarchy.ts
+++ b/packages/zarrita/src/hierarchy.ts
@@ -1,6 +1,6 @@
 import type { AbsolutePath, Readable } from "@zarrita/storage";
-import { create_sharded_chunk_getter } from "./codecs/sharding.js";
-import { create_codec_pipeline } from "./codecs.js";
+import { createShardedChunkGetter } from "./codecs/sharding.js";
+import { createCodecPipeline } from "./codecs.js";
 import type {
 	ArrayMetadata,
 	Attributes,
@@ -14,14 +14,14 @@ import type {
 } from "./metadata.js";
 import {
 	assertSharedArrayBufferAvailable,
-	create_chunk_key_encoder,
 	createBuffer,
+	createChunkKeyEncoder,
 	type DataTypeQuery,
-	ensure_correct_scalar,
-	get_ctr,
-	get_strides,
-	is_dtype,
-	is_sharding_codec,
+	ensureCorrectScalar,
+	getCtr,
+	getStrides,
+	isDtype,
+	isShardingCodec,
 	type NarrowDataType,
 } from "./util.js";
 
@@ -64,71 +64,71 @@ export class Group<Store extends Readable> extends Location<Store> {
 	}
 }
 
-function get_array_order(
+function getArrayOrder(
 	codecs: CodecMetadata[],
 ): "C" | "F" | globalThis.Array<number> {
-	const maybe_transpose_codec = codecs.find((c) => c.name === "transpose");
+	const maybeTransposeCodec = codecs.find((c) => c.name === "transpose");
 	// @ts-expect-error - TODO: Should validate?
-	return maybe_transpose_codec?.configuration?.order ?? "C";
+	return maybeTransposeCodec?.configuration?.order ?? "C";
 }
 
 const CONTEXT_MARKER = Symbol("zarrita.context");
 
-export function get_context<T>(obj: { [CONTEXT_MARKER]: T }): T {
+export function getContext<T>(obj: { [CONTEXT_MARKER]: T }): T {
 	return obj[CONTEXT_MARKER];
 }
 
-function create_context<Store extends Readable, D extends DataType>(
+function createContext<Store extends Readable, D extends DataType>(
 	location: Location<Readable>,
 	metadata: ArrayMetadata<D>,
 ): ArrayContext<Store, D> {
-	let { configuration } = metadata.codecs.find(is_sharding_codec) ?? {};
-	let shared_context = {
-		encode_chunk_key: create_chunk_key_encoder(metadata.chunk_key_encoding),
-		TypedArray: get_ctr(metadata.data_type),
-		fill_value: metadata.fill_value,
+	let { configuration } = metadata.codecs.find(isShardingCodec) ?? {};
+	let sharedContext = {
+		encodeChunkKey: createChunkKeyEncoder(metadata.chunk_key_encoding),
+		TypedArray: getCtr(metadata.data_type),
+		fillValue: metadata.fill_value,
 	};
 
 	if (configuration) {
-		let native_order = get_array_order(configuration.codecs);
+		let nativeOrder = getArrayOrder(configuration.codecs);
 		return {
-			...shared_context,
+			...sharedContext,
 			kind: "sharded",
-			chunk_shape: configuration.chunk_shape,
-			codec: create_codec_pipeline({
-				data_type: metadata.data_type,
+			chunkShape: configuration.chunk_shape,
+			codec: createCodecPipeline({
+				dataType: metadata.data_type,
 				shape: configuration.chunk_shape,
 				codecs: configuration.codecs,
 			}),
-			get_strides(shape: number[]) {
-				return get_strides(shape, native_order);
+			getStrides(shape: number[]) {
+				return getStrides(shape, nativeOrder);
 			},
-			get_chunk_bytes: create_sharded_chunk_getter(
+			getChunkBytes: createShardedChunkGetter(
 				location,
 				metadata.chunk_grid.configuration.chunk_shape,
-				shared_context.encode_chunk_key,
+				sharedContext.encodeChunkKey,
 				configuration,
 			),
 		};
 	}
 
-	let native_order = get_array_order(metadata.codecs);
+	let nativeOrder = getArrayOrder(metadata.codecs);
 	return {
-		...shared_context,
+		...sharedContext,
 		kind: "regular",
-		chunk_shape: metadata.chunk_grid.configuration.chunk_shape,
-		codec: create_codec_pipeline({
-			data_type: metadata.data_type,
+		chunkShape: metadata.chunk_grid.configuration.chunk_shape,
+		codec: createCodecPipeline({
+			dataType: metadata.data_type,
 			shape: metadata.chunk_grid.configuration.chunk_shape,
 			codecs: metadata.codecs,
 		}),
-		get_strides(shape: number[]) {
-			return get_strides(shape, native_order);
+		getStrides(shape: number[]) {
+			return getStrides(shape, nativeOrder);
 		},
-		async get_chunk_bytes(chunk_coords, options) {
-			let chunk_key = shared_context.encode_chunk_key(chunk_coords);
-			let chunk_path = location.resolve(chunk_key).path;
-			return location.store.get(chunk_path, options);
+		async getChunkBytes(chunkCoords, options) {
+			let chunkKey = sharedContext.encodeChunkKey(chunkCoords);
+			let chunkPath = location.resolve(chunkKey).path;
+			return location.store.get(chunkPath, options);
 		},
 	};
 }
@@ -137,22 +137,22 @@ function create_context<Store extends Readable, D extends DataType>(
 interface ArrayContext<Store extends Readable, D extends DataType> {
 	kind: "sharded" | "regular";
 	/** The codec pipeline for this array. */
-	codec: ReturnType<typeof create_codec_pipeline<D>>;
+	codec: ReturnType<typeof createCodecPipeline<D>>;
 	/** Encode a chunk key from chunk coordinates. */
-	encode_chunk_key(chunk_coords: number[]): string;
+	encodeChunkKey(chunkCoords: number[]): string;
 	/** The TypedArray constructor for this array chunks. */
 	TypedArray: TypedArrayConstructor<D>;
 	/** A function to get the strides for a given shape, using the array order */
-	get_strides(shape: number[]): number[];
+	getStrides(shape: number[]): number[];
 	/** The fill value for this array. */
-	fill_value: Scalar<D> | null;
+	fillValue: Scalar<D> | null;
 	/** A function to get the bytes for a given chunk. */
-	get_chunk_bytes(
-		chunk_coords: number[],
+	getChunkBytes(
+		chunkCoords: number[],
 		options?: Parameters<Store["get"]>[1],
 	): Promise<Uint8Array | undefined>;
 	/** The chunk shape for this array. */
-	chunk_shape: number[];
+	chunkShape: number[];
 }
 
 export class Array<
@@ -171,9 +171,9 @@ export class Array<
 		super(store, path);
 		this.#metadata = {
 			...metadata,
-			fill_value: ensure_correct_scalar(metadata),
+			fill_value: ensureCorrectScalar(metadata),
 		};
-		this[CONTEXT_MARKER] = create_context(this, this.#metadata);
+		this[CONTEXT_MARKER] = createContext(this, this.#metadata);
 	}
 
 	get attrs(): Attributes {
@@ -193,7 +193,7 @@ export class Array<
 	}
 
 	get chunks(): number[] {
-		return this[CONTEXT_MARKER].chunk_shape;
+		return this[CONTEXT_MARKER].chunkShape;
 	}
 
 	get dtype(): Dtype {
@@ -201,7 +201,7 @@ export class Array<
 	}
 
 	async getChunk(
-		chunk_coords: number[],
+		chunkCoords: number[],
 		options?: Parameters<Store["get"]>[1],
 		opts?: { useSharedArrayBuffer?: boolean },
 	): Promise<Chunk<Dtype>> {
@@ -209,9 +209,9 @@ export class Array<
 			assertSharedArrayBufferAvailable();
 		}
 		let context = this[CONTEXT_MARKER];
-		let maybe_bytes = await context.get_chunk_bytes(chunk_coords, options);
-		if (!maybe_bytes) {
-			let size = context.chunk_shape.reduce((a, b) => a * b, 1);
+		let maybeBytes = await context.getChunkBytes(chunkCoords, options);
+		if (!maybeBytes) {
+			let size = context.chunkShape.reduce((a, b) => a * b, 1);
 			let data: TypedArray<Dtype>;
 			if (opts?.useSharedArrayBuffer) {
 				let sample = new context.TypedArray(0);
@@ -227,15 +227,15 @@ export class Array<
 			} else {
 				data = new context.TypedArray(size);
 			}
-			// @ts-expect-error: TS can't infer that `fill_value` is union (assumes never) but this is ok
-			data.fill(context.fill_value);
+			// @ts-expect-error: TS can't infer that `fillValue` is union (assumes never) but this is ok
+			data.fill(context.fillValue);
 			return {
 				data,
-				shape: context.chunk_shape,
-				stride: context.get_strides(context.chunk_shape),
+				shape: context.chunkShape,
+				stride: context.getStrides(context.chunkShape),
 			};
 		}
-		return context.codec.decode(maybe_bytes);
+		return context.codec.decode(maybeBytes);
 	}
 
 	/**
@@ -258,6 +258,6 @@ export class Array<
 	is<Query extends DataTypeQuery>(
 		query: Query,
 	): this is Array<NarrowDataType<Dtype, Query>, Store> {
-		return is_dtype(this.dtype, query);
+		return isDtype(this.dtype, query);
 	}
 }

--- a/packages/zarrita/src/index.ts
+++ b/packages/zarrita/src/index.ts
@@ -32,7 +32,7 @@ export type {
 export {
 	sel,
 	slice,
-	slice_indices as _zarrita_internal_slice_indices,
+	sliceIndices as _zarrita_internal_sliceIndices,
 } from "./indexing/util.js";
 export type * from "./metadata.js";
 export { open } from "./open.js";
@@ -41,4 +41,4 @@ export {
 	ByteStringArray,
 	UnicodeStringArray,
 } from "./typedarray.js";
-export { get_strides as _zarrita_internal_get_strides } from "./util.js";
+export { getStrides as _zarrita_internal_getStrides } from "./util.js";

--- a/packages/zarrita/src/indexing/get.ts
+++ b/packages/zarrita/src/indexing/get.ts
@@ -1,6 +1,6 @@
 import type { Readable } from "@zarrita/storage";
 
-import { type Array, get_context } from "../hierarchy.js";
+import { type Array, getContext } from "../hierarchy.js";
 import type { Chunk, DataType, Scalar, TypedArray } from "../metadata.js";
 import {
 	assertSharedArrayBufferAvailable,
@@ -15,7 +15,7 @@ import type {
 	SetScalar,
 	Slice,
 } from "./types.js";
-import { create_queue } from "./util.js";
+import { createQueue } from "./util.js";
 
 function unwrap<D extends DataType>(
 	arr: TypedArray<D>,
@@ -35,8 +35,8 @@ export async function get<
 	opts: GetOptions<Parameters<Store["get"]>[1]>,
 	setter: {
 		prepare: Prepare<D, Arr>;
-		set_scalar: SetScalar<D, Arr>;
-		set_from_chunk: SetFromChunk<D, Arr>;
+		setScalar: SetScalar<D, Arr>;
+		setFromChunk: SetFromChunk<D, Arr>;
 	},
 ): Promise<
 	null extends Sel[number] ? Arr : Slice extends Sel[number] ? Arr : Scalar<D>
@@ -45,11 +45,11 @@ export async function get<
 		assertSharedArrayBufferAvailable();
 	}
 
-	let context = get_context(arr);
+	let context = getContext(arr);
 	let indexer = new BasicIndexer({
 		selection,
 		shape: arr.shape,
-		chunk_shape: arr.chunks,
+		chunkShape: arr.chunks,
 	});
 
 	// Handle scalar arrays (shape=[]) directly, since the indexer yields nothing
@@ -81,22 +81,20 @@ export async function get<
 	let out = setter.prepare(
 		data,
 		indexer.shape,
-		context.get_strides(indexer.shape),
+		context.getStrides(indexer.shape),
 	);
 
-	let queue = opts.create_queue?.() ?? create_queue();
-	for (const { chunk_coords, mapping } of indexer) {
+	let queue = opts.createQueue?.() ?? createQueue();
+	for (const { chunkCoords, mapping } of indexer) {
 		queue.add(async () => {
 			if (isAbortable(opts.opts)) {
 				opts.opts.signal.throwIfAborted();
 			}
-			let { data, shape, stride } = await arr.getChunk(
-				chunk_coords,
-				opts.opts,
-				{ useSharedArrayBuffer: opts.useSharedArrayBuffer },
-			);
+			let { data, shape, stride } = await arr.getChunk(chunkCoords, opts.opts, {
+				useSharedArrayBuffer: opts.useSharedArrayBuffer,
+			});
 			let chunk = setter.prepare(data, shape, stride);
-			setter.set_from_chunk(out, chunk, mapping);
+			setter.setFromChunk(out, chunk, mapping);
 		});
 	}
 

--- a/packages/zarrita/src/indexing/index.ts
+++ b/packages/zarrita/src/indexing/index.ts
@@ -1,5 +1,5 @@
-export { get as get_with_setter } from "./get.js";
+export { get as getWithSetter } from "./get.js";
 export { get, set } from "./ops.js";
-export { set as set_with_setter } from "./set.js";
+export { set as setWithSetter } from "./set.js";
 export type * from "./types.js";
-export { slice, slice_indices as _slice_indices } from "./util.js";
+export { slice, sliceIndices as _sliceIndices } from "./util.js";

--- a/packages/zarrita/src/indexing/indexer.ts
+++ b/packages/zarrita/src/indexing/indexer.ts
@@ -1,5 +1,5 @@
 import type { Indices, Slice } from "./types.js";
-import { product, range, slice, slice_indices } from "./util.js";
+import { product, range, slice, sliceIndices } from "./util.js";
 
 export class IndexError extends Error {
 	constructor(msg: string) {
@@ -8,7 +8,7 @@ export class IndexError extends Error {
 	}
 }
 
-function err_too_many_indices(
+function errTooManyIndices(
 	selection: (number | Slice)[],
 	shape: readonly number[],
 ) {
@@ -17,84 +17,84 @@ function err_too_many_indices(
 	);
 }
 
-function err_boundscheck(dim_len: number) {
+function errBoundscheck(dimLen: number) {
 	throw new IndexError(
-		`index out of bounds for dimension with length ${dim_len}`,
+		`index out of bounds for dimension with length ${dimLen}`,
 	);
 }
 
-function err_negative_step() {
+function errNegativeStep() {
 	throw new IndexError("only slices with step >= 1 are supported");
 }
 
-function check_selection_length(
+function checkSelectionLength(
 	selection: (number | Slice)[],
 	shape: readonly number[],
 ) {
 	if (selection.length > shape.length) {
-		err_too_many_indices(selection, shape);
+		errTooManyIndices(selection, shape);
 	}
 }
 
-export function normalize_integer_selection(dim_sel: number, dim_len: number) {
+export function normalizeIntegerSelection(dimSel: number, dimLen: number) {
 	// normalize type to int
-	dim_sel = Math.trunc(dim_sel);
+	dimSel = Math.trunc(dimSel);
 	// handle wraparound
-	if (dim_sel < 0) {
-		dim_sel = dim_len + dim_sel;
+	if (dimSel < 0) {
+		dimSel = dimLen + dimSel;
 	}
 	// handle out of bounds
-	if (dim_sel >= dim_len || dim_sel < 0) {
-		err_boundscheck(dim_len);
+	if (dimSel >= dimLen || dimSel < 0) {
+		errBoundscheck(dimLen);
 	}
-	return dim_sel;
+	return dimSel;
 }
 
 interface IntChunkDimProjection {
-	dim_chunk_ix: number;
-	dim_chunk_sel: number;
+	dimChunkIx: number;
+	dimChunkSel: number;
 }
 
 interface IntDimIndexerProps {
-	dim_sel: number;
-	dim_len: number;
-	dim_chunk_len: number;
+	dimSel: number;
+	dimLen: number;
+	dimChunkLen: number;
 }
 
 class IntDimIndexer {
-	dim_sel: number;
-	dim_len: number;
-	dim_chunk_len: number;
+	dimSel: number;
+	dimLen: number;
+	dimChunkLen: number;
 	nitems: 1;
 
-	constructor({ dim_sel, dim_len, dim_chunk_len }: IntDimIndexerProps) {
+	constructor({ dimSel, dimLen, dimChunkLen }: IntDimIndexerProps) {
 		// normalize
-		dim_sel = normalize_integer_selection(dim_sel, dim_len);
+		dimSel = normalizeIntegerSelection(dimSel, dimLen);
 		// store properties
-		this.dim_sel = dim_sel;
-		this.dim_len = dim_len;
-		this.dim_chunk_len = dim_chunk_len;
+		this.dimSel = dimSel;
+		this.dimLen = dimLen;
+		this.dimChunkLen = dimChunkLen;
 		this.nitems = 1;
 	}
 
 	*[Symbol.iterator](): IterableIterator<IntChunkDimProjection> {
-		const dim_chunk_ix = Math.floor(this.dim_sel / this.dim_chunk_len);
-		const dim_offset = dim_chunk_ix * this.dim_chunk_len;
-		const dim_chunk_sel = this.dim_sel - dim_offset;
-		yield { dim_chunk_ix, dim_chunk_sel };
+		const dimChunkIx = Math.floor(this.dimSel / this.dimChunkLen);
+		const dimOffset = dimChunkIx * this.dimChunkLen;
+		const dimChunkSel = this.dimSel - dimOffset;
+		yield { dimChunkIx, dimChunkSel };
 	}
 }
 
 interface SliceChunkDimProjection {
-	dim_chunk_ix: number;
-	dim_chunk_sel: Indices;
-	dim_out_sel: Indices;
+	dimChunkIx: number;
+	dimChunkSel: Indices;
+	dimOutSel: Indices;
 }
 
 interface SliceDimIndexerProps {
-	dim_sel: Slice;
-	dim_len: number;
-	dim_chunk_len: number;
+	dimSel: Slice;
+	dimLen: number;
+	dimChunkLen: number;
 }
 
 class SliceDimIndexer {
@@ -102,76 +102,76 @@ class SliceDimIndexer {
 	stop: number;
 	step: number;
 
-	dim_len: number;
-	dim_chunk_len: number;
+	dimLen: number;
+	dimChunkLen: number;
 	nitems: number;
 	nchunks: number;
 
-	constructor({ dim_sel, dim_len, dim_chunk_len }: SliceDimIndexerProps) {
+	constructor({ dimSel, dimLen, dimChunkLen }: SliceDimIndexerProps) {
 		// normalize
-		const [start, stop, step] = slice_indices(dim_sel, dim_len);
+		const [start, stop, step] = sliceIndices(dimSel, dimLen);
 		this.start = start;
 		this.stop = stop;
 		this.step = step;
-		if (this.step < 1) err_negative_step();
+		if (this.step < 1) errNegativeStep();
 		// store properties
-		this.dim_len = dim_len;
-		this.dim_chunk_len = dim_chunk_len;
+		this.dimLen = dimLen;
+		this.dimChunkLen = dimChunkLen;
 		this.nitems = Math.max(0, Math.ceil((this.stop - this.start) / this.step));
-		this.nchunks = Math.ceil(this.dim_len / this.dim_chunk_len);
+		this.nchunks = Math.ceil(this.dimLen / this.dimChunkLen);
 	}
 
 	*[Symbol.iterator](): IterableIterator<SliceChunkDimProjection> {
 		// figure out the range of chunks we need to visit
-		const dim_chunk_ix_from = Math.floor(this.start / this.dim_chunk_len);
-		const dim_chunk_ix_to = Math.ceil(this.stop / this.dim_chunk_len);
-		for (const dim_chunk_ix of range(dim_chunk_ix_from, dim_chunk_ix_to)) {
+		const dimChunkIx_from = Math.floor(this.start / this.dimChunkLen);
+		const dimChunkIx_to = Math.ceil(this.stop / this.dimChunkLen);
+		for (const dimChunkIx of range(dimChunkIx_from, dimChunkIx_to)) {
 			// compute offsets for chunk within overall array
-			const dim_offset = dim_chunk_ix * this.dim_chunk_len;
-			const dim_limit = Math.min(
-				this.dim_len,
-				(dim_chunk_ix + 1) * this.dim_chunk_len,
+			const dimOffset = dimChunkIx * this.dimChunkLen;
+			const dimLimit = Math.min(
+				this.dimLen,
+				(dimChunkIx + 1) * this.dimChunkLen,
 			);
 			// determine chunk length, accounting for trailing chunk
-			const dim_chunk_len = dim_limit - dim_offset;
+			const dimChunkLen = dimLimit - dimOffset;
 
-			let dim_out_offset = 0;
-			let dim_chunk_sel_start = 0;
-			if (this.start < dim_offset) {
+			let dimOutOffset = 0;
+			let dimChunkSelStart = 0;
+			if (this.start < dimOffset) {
 				// selection start before current chunk
-				const remainder = (dim_offset - this.start) % this.step;
-				if (remainder) dim_chunk_sel_start += this.step - remainder;
+				const remainder = (dimOffset - this.start) % this.step;
+				if (remainder) dimChunkSelStart += this.step - remainder;
 				// compute number of previous items, provides offset into output array
-				dim_out_offset = Math.ceil((dim_offset - this.start) / this.step);
+				dimOutOffset = Math.ceil((dimOffset - this.start) / this.step);
 			} else {
 				// selection starts within current chunk
-				dim_chunk_sel_start = this.start - dim_offset;
+				dimChunkSelStart = this.start - dimOffset;
 			}
 			// selection starts within current chunk if true,
 			// otherwise selection ends after current chunk.
-			const dim_chunk_sel_stop =
-				this.stop > dim_limit ? dim_chunk_len : this.stop - dim_offset;
+			const dimChunkSelStop =
+				this.stop > dimLimit ? dimChunkLen : this.stop - dimOffset;
 
-			const dim_chunk_sel: Indices = [
-				dim_chunk_sel_start,
-				dim_chunk_sel_stop,
+			const dimChunkSel: Indices = [
+				dimChunkSelStart,
+				dimChunkSelStop,
 				this.step,
 			];
-			const dim_chunk_nitems = Math.ceil(
-				(dim_chunk_sel_stop - dim_chunk_sel_start) / this.step,
+			const dimChunkNitems = Math.ceil(
+				(dimChunkSelStop - dimChunkSelStart) / this.step,
 			);
 
-			const dim_out_sel: Indices = [
-				dim_out_offset,
-				dim_out_offset + dim_chunk_nitems,
+			const dimOutSel: Indices = [
+				dimOutOffset,
+				dimOutOffset + dimChunkNitems,
 				1,
 			];
-			yield { dim_chunk_ix, dim_chunk_sel, dim_out_sel };
+			yield { dimChunkIx, dimChunkSel, dimOutSel };
 		}
 	}
 }
 
-export function normalize_selection(
+export function normalizeSelection(
 	selection: null | (Slice | null | number)[],
 	shape: readonly number[],
 ): (number | Slice)[] {
@@ -181,14 +181,14 @@ export function normalize_selection(
 	} else if (Array.isArray(selection)) {
 		normalized = selection.map((s) => s ?? slice(null));
 	}
-	check_selection_length(normalized, shape);
+	checkSelectionLength(normalized, shape);
 	return normalized;
 }
 
 interface BasicIndexerProps {
 	selection: null | (null | number | Slice)[];
 	shape: readonly number[];
-	chunk_shape: readonly number[];
+	chunkShape: readonly number[];
 }
 
 export type IndexerProjection =
@@ -199,43 +199,41 @@ export type IndexerProjection =
 	  };
 
 interface ChunkProjection {
-	chunk_coords: number[];
+	chunkCoords: number[];
 	mapping: IndexerProjection[];
 }
 
 export class BasicIndexer {
-	dim_indexers: (SliceDimIndexer | IntDimIndexer)[];
+	dimIndexers: (SliceDimIndexer | IntDimIndexer)[];
 	shape: number[];
 
-	constructor({ selection, shape, chunk_shape }: BasicIndexerProps) {
+	constructor({ selection, shape, chunkShape }: BasicIndexerProps) {
 		// setup per-dimension indexers
-		this.dim_indexers = normalize_selection(selection, shape).map(
-			(dim_sel, i) => {
-				return new (
-					typeof dim_sel === "number" ? IntDimIndexer : SliceDimIndexer
-				)({
+		this.dimIndexers = normalizeSelection(selection, shape).map((dimSel, i) => {
+			return new (typeof dimSel === "number" ? IntDimIndexer : SliceDimIndexer)(
+				{
 					// @ts-expect-error ts inference not strong enough to know correct chunk
-					dim_sel: dim_sel,
-					dim_len: shape[i],
-					dim_chunk_len: chunk_shape[i],
-				});
-			},
-		);
-		this.shape = this.dim_indexers
+					dimSel: dimSel,
+					dimLen: shape[i],
+					dimChunkLen: chunkShape[i],
+				},
+			);
+		});
+		this.shape = this.dimIndexers
 			.filter((ixr) => ixr instanceof SliceDimIndexer)
 			.map((sixr) => sixr.nitems);
 	}
 
 	*[Symbol.iterator](): IterableIterator<ChunkProjection> {
-		for (const dim_projections of product(...this.dim_indexers)) {
-			const chunk_coords = dim_projections.map((p) => p.dim_chunk_ix);
-			const mapping: IndexerProjection[] = dim_projections.map((p) => {
-				if ("dim_out_sel" in p) {
-					return { from: p.dim_chunk_sel, to: p.dim_out_sel };
+		for (const dimProjections of product(...this.dimIndexers)) {
+			const chunkCoords = dimProjections.map((p) => p.dimChunkIx);
+			const mapping: IndexerProjection[] = dimProjections.map((p) => {
+				if ("dimOutSel" in p) {
+					return { from: p.dimChunkSel, to: p.dimOutSel };
 				}
-				return { from: p.dim_chunk_sel, to: null };
+				return { from: p.dimChunkSel, to: null };
 			});
-			yield { chunk_coords, mapping };
+			yield { chunkCoords, mapping };
 		}
 	}
 }

--- a/packages/zarrita/src/indexing/ops.ts
+++ b/packages/zarrita/src/indexing/ops.ts
@@ -19,12 +19,12 @@ import type {
 } from "./types.js";
 
 /** A 1D "view" of an array that can be used to set values in the array. */
-function object_array_view<T>(arr: T[], offset = 0, size?: number) {
+function objectArrayView<T>(arr: T[], offset = 0, size?: number) {
 	let length = size ?? arr.length - offset;
 	return {
 		length,
 		subarray(from: number, to: number = length) {
-			return object_array_view(arr, offset + from, to - from);
+			return objectArrayView(arr, offset + from, to - from);
 		},
 		set(data: { get(idx: number): T; length: number }, start = 0) {
 			for (let i = 0; i < data.length; i++) {
@@ -44,22 +44,22 @@ function object_array_view<T>(arr: T[], offset = 0, size?: number) {
  * just the browser's TypedArray objects.
  *
  * WARNING: This function is not meant to be used directly and is NOT type-safe.
- * In the case of `Array` instances, it will return a `object_array_view` of
+ * In the case of `Array` instances, it will return a `objectArrayView` of
  * the underlying, which is supported by our binary set functions.
  */
-function compat_chunk<D extends DataType>(
+function compatChunk<D extends DataType>(
 	arr: Chunk<D>,
 ): {
 	data: Uint8Array;
 	stride: number[];
-	bytes_per_element: number;
+	bytesPerElement: number;
 } {
 	if (globalThis.Array.isArray(arr.data)) {
 		return {
 			// @ts-expect-error
-			data: object_array_view(arr.data),
+			data: objectArrayView(arr.data),
 			stride: arr.stride,
-			bytes_per_element: 1,
+			bytesPerElement: 1,
 		};
 	}
 	return {
@@ -69,12 +69,12 @@ function compat_chunk<D extends DataType>(
 			arr.data.byteLength,
 		),
 		stride: arr.stride,
-		bytes_per_element: arr.data.BYTES_PER_ELEMENT,
+		bytesPerElement: arr.data.BYTES_PER_ELEMENT,
 	};
 }
 
 /** Hack to get the constructor of a typed array constructor from an existing TypedArray. */
-function get_typed_array_constructor<
+function getTypedArrayConstructor<
 	D extends Exclude<DataType, "v2:object" | "string">,
 >(arr: TypedArray<D>): TypedArrayConstructor<D> {
 	if ("chars" in arr) {
@@ -92,18 +92,18 @@ function get_typed_array_constructor<
  * than just the browser's TypedArray objects.
  *
  * WARNING: This function is not meant to be used directly and is NOT type-safe.
- * In the case of `Array` instances, it will return a `object_array_view` of
+ * In the case of `Array` instances, it will return a `objectArrayView` of
  * the scalar, which is supported by our binary set functions.
  */
-function compat_scalar<D extends DataType>(
+function compatScalar<D extends DataType>(
 	arr: Chunk<D>,
 	value: Scalar<D>,
 ): Uint8Array {
 	if (globalThis.Array.isArray(arr.data)) {
 		// @ts-expect-error
-		return object_array_view([value]);
+		return objectArrayView([value]);
 	}
-	let TypedArray = get_typed_array_constructor(arr.data);
+	let TypedArray = getTypedArrayConstructor(arr.data);
 	// @ts-expect-error - value is a scalar and matches
 	let data = new TypedArray([value]);
 	return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
@@ -117,29 +117,24 @@ export const setter = {
 	) {
 		return { data, shape, stride };
 	},
-	set_scalar<D extends DataType>(
+	setScalar<D extends DataType>(
 		dest: Chunk<D>,
 		sel: (number | Indices)[],
 		value: Scalar<D>,
 	) {
-		let view = compat_chunk(dest);
-		set_scalar_binary(
-			view,
-			sel,
-			compat_scalar(dest, value),
-			view.bytes_per_element,
-		);
+		let view = compatChunk(dest);
+		setScalarBinary(view, sel, compatScalar(dest, value), view.bytesPerElement);
 	},
-	set_from_chunk<D extends DataType>(
+	setFromChunk<D extends DataType>(
 		dest: Chunk<D>,
 		src: Chunk<D>,
 		projections: Projection[],
 	) {
-		let view = compat_chunk(dest);
-		set_from_chunk_binary(
+		let view = compatChunk(dest);
+		setFromChunkBinary(
 			view,
-			compat_chunk(src),
-			view.bytes_per_element,
+			compatChunk(src),
+			view.bytesPerElement,
 			projections,
 		);
 	},
@@ -174,7 +169,7 @@ export async function set<D extends DataType>(
 	return set_with_setter<D, Chunk<D>>(arr, selection, value, opts, setter);
 }
 
-function indices_len(start: number, stop: number, step: number) {
+function indicesLen(start: number, stop: number, step: number) {
 	if (step < 0 && stop < start) {
 		return Math.floor((start - stop - 1) / -step) + 1;
 	}
@@ -182,43 +177,43 @@ function indices_len(start: number, stop: number, step: number) {
 	return 0;
 }
 
-function set_scalar_binary(
+function setScalarBinary(
 	out: { data: Uint8Array; stride: number[] },
-	out_selection: (Indices | number)[],
+	outSelection: (Indices | number)[],
 	value: Uint8Array,
-	bytes_per_element: number,
+	bytesPerElement: number,
 ) {
-	if (out_selection.length === 0) {
+	if (outSelection.length === 0) {
 		out.data.set(value, 0);
 		return;
 	}
-	const [slice, ...slices] = out_selection;
-	const [curr_stride, ...stride] = out.stride;
+	const [slice, ...slices] = outSelection;
+	const [currStride, ...stride] = out.stride;
 	if (typeof slice === "number") {
-		const data = out.data.subarray(curr_stride * slice * bytes_per_element);
-		set_scalar_binary({ data, stride }, slices, value, bytes_per_element);
+		const data = out.data.subarray(currStride * slice * bytesPerElement);
+		setScalarBinary({ data, stride }, slices, value, bytesPerElement);
 		return;
 	}
 	const [from, to, step] = slice;
-	const len = indices_len(from, to, step);
+	const len = indicesLen(from, to, step);
 	if (slices.length === 0) {
 		for (let i = 0; i < len; i++) {
-			out.data.set(value, curr_stride * (from + step * i) * bytes_per_element);
+			out.data.set(value, currStride * (from + step * i) * bytesPerElement);
 		}
 		return;
 	}
 	for (let i = 0; i < len; i++) {
 		const data = out.data.subarray(
-			curr_stride * (from + step * i) * bytes_per_element,
+			currStride * (from + step * i) * bytesPerElement,
 		);
-		set_scalar_binary({ data, stride }, slices, value, bytes_per_element);
+		setScalarBinary({ data, stride }, slices, value, bytesPerElement);
 	}
 }
 
-function set_from_chunk_binary(
+function setFromChunkBinary(
 	dest: { data: Uint8Array; stride: number[] },
 	src: { data: Uint8Array; stride: number[] },
-	bytes_per_element: number,
+	bytesPerElement: number,
 	projections: Projection[],
 ) {
 	const [proj, ...projs] = projections;
@@ -227,79 +222,77 @@ function set_from_chunk_binary(
 	if (proj.from === null) {
 		if (projs.length === 0) {
 			dest.data.set(
-				src.data.subarray(0, bytes_per_element),
-				proj.to * bytes_per_element,
+				src.data.subarray(0, bytesPerElement),
+				proj.to * bytesPerElement,
 			);
 			return;
 		}
-		set_from_chunk_binary(
+		setFromChunkBinary(
 			{
-				data: dest.data.subarray(dstride * proj.to * bytes_per_element),
+				data: dest.data.subarray(dstride * proj.to * bytesPerElement),
 				stride: dstrides,
 			},
 			src,
-			bytes_per_element,
+			bytesPerElement,
 			projs,
 		);
 		return;
 	}
 	if (proj.to === null) {
 		if (projs.length === 0) {
-			let offset = proj.from * bytes_per_element;
-			dest.data.set(src.data.subarray(offset, offset + bytes_per_element), 0);
+			let offset = proj.from * bytesPerElement;
+			dest.data.set(src.data.subarray(offset, offset + bytesPerElement), 0);
 			return;
 		}
-		set_from_chunk_binary(
+		setFromChunkBinary(
 			dest,
 			{
-				data: src.data.subarray(sstride * proj.from * bytes_per_element),
+				data: src.data.subarray(sstride * proj.from * bytesPerElement),
 				stride: sstrides,
 			},
-			bytes_per_element,
+			bytesPerElement,
 			projs,
 		);
 		return;
 	}
 	const [from, to, step] = proj.to;
 	const [sfrom, _, sstep] = proj.from;
-	const len = indices_len(from, to, step);
+	const len = indicesLen(from, to, step);
 	if (projs.length === 0) {
 		// NB: we have a contiguous block of memory
 		// so we can just copy over all the data at once.
 		if (step === 1 && sstep === 1 && dstride === 1 && sstride === 1) {
-			let offset = sfrom * bytes_per_element;
-			let size = len * bytes_per_element;
+			let offset = sfrom * bytesPerElement;
+			let size = len * bytesPerElement;
 			dest.data.set(
 				src.data.subarray(offset, offset + size),
-				from * bytes_per_element,
+				from * bytesPerElement,
 			);
 			return;
 		}
 		// Otherwise, we have to copy over each element individually.
 		for (let i = 0; i < len; i++) {
-			let offset = sstride * (sfrom + sstep * i) * bytes_per_element;
+			let offset = sstride * (sfrom + sstep * i) * bytesPerElement;
 			dest.data.set(
-				src.data.subarray(offset, offset + bytes_per_element),
-				dstride * (from + step * i) * bytes_per_element,
+				src.data.subarray(offset, offset + bytesPerElement),
+				dstride * (from + step * i) * bytesPerElement,
 			);
 		}
 		return;
 	}
 	for (let i = 0; i < len; i++) {
-		set_from_chunk_binary(
+		setFromChunkBinary(
 			{
-				data: dest.data.subarray(
-					dstride * (from + i * step) * bytes_per_element,
-				),
+				data: dest.data.subarray(dstride * (from + i * step) * bytesPerElement),
 				stride: dstrides,
 			},
 			{
 				data: src.data.subarray(
-					sstride * (sfrom + i * sstep) * bytes_per_element,
+					sstride * (sfrom + i * sstep) * bytesPerElement,
 				),
 				stride: sstrides,
 			},
-			bytes_per_element,
+			bytesPerElement,
 			projs,
 		);
 	}

--- a/packages/zarrita/src/indexing/set.ts
+++ b/packages/zarrita/src/indexing/set.ts
@@ -1,6 +1,6 @@
 import type { Mutable } from "@zarrita/storage";
 
-import { type Array, get_context } from "../hierarchy.js";
+import { type Array, getContext } from "../hierarchy.js";
 import type { Chunk, DataType, Scalar, TypedArray } from "../metadata.js";
 import { isAbortable } from "../util.js";
 import { BasicIndexer, type IndexerProjection } from "./indexer.js";
@@ -12,9 +12,9 @@ import type {
 	SetScalar,
 	Slice,
 } from "./types.js";
-import { create_queue } from "./util.js";
+import { createQueue } from "./util.js";
 
-function flip_indexer_projection(m: IndexerProjection) {
+function flipIndexerProjection(m: IndexerProjection) {
 	if (m.to == null) return { from: m.to, to: m.from };
 	return { from: m.to, to: m.from };
 }
@@ -26,34 +26,34 @@ export async function set<Dtype extends DataType, Arr extends Chunk<Dtype>>(
 	opts: SetOptions,
 	setter: {
 		prepare: Prepare<Dtype, Arr>;
-		set_scalar: SetScalar<Dtype, Arr>;
-		set_from_chunk: SetFromChunk<Dtype, Arr>;
+		setScalar: SetScalar<Dtype, Arr>;
+		setFromChunk: SetFromChunk<Dtype, Arr>;
 	},
 ) {
-	const context = get_context(arr);
+	const context = getContext(arr);
 	if (context.kind === "sharded") {
 		throw new Error("Set not supported for sharded arrays.");
 	}
 	const indexer = new BasicIndexer({
 		selection,
 		shape: arr.shape,
-		chunk_shape: arr.chunks,
+		chunkShape: arr.chunks,
 	});
 
 	// Handle scalar arrays (shape=[]) directly, since the indexer yields nothing
 	// for zero-dimensional arrays.
 	if (arr.shape.length === 0) {
-		const chunk_data = new context.TypedArray(1);
+		const chunkData = new context.TypedArray(1);
 		if (typeof value === "object") {
 			throw new Error("Cannot set a scalar array with a non-scalar value.");
 		}
 		// @ts-expect-error - Value is a scalar
-		chunk_data.fill(value);
-		const chunk_path = arr.resolve(context.encode_chunk_key([])).path;
+		chunkData.fill(value);
+		const chunkPath = arr.resolve(context.encodeChunkKey([])).path;
 		await arr.store.set(
-			chunk_path,
+			chunkPath,
 			await context.codec.encode({
-				data: chunk_data,
+				data: chunkData,
 				shape: [],
 				stride: [],
 			}),
@@ -65,70 +65,68 @@ export async function set<Dtype extends DataType, Arr extends Chunk<Dtype>>(
 	// that needs to be replaced. Each chunk is processed in turn, extracting the
 	// necessary data from the value array and storing into the chunk array.
 
-	const chunk_size = arr.chunks.reduce((a, b) => a * b, 1);
-	const queue = opts.create_queue ? opts.create_queue() : create_queue();
+	const chunkSize = arr.chunks.reduce((a, b) => a * b, 1);
+	const queue = opts.createQueue ? opts.createQueue() : createQueue();
 
 	// N.B., it is an important optimisation that we only visit chunks which overlap
 	// the selection. This minimises the number of iterations in the main for loop.
-	for (const { chunk_coords, mapping } of indexer) {
-		const chunk_selection = mapping.map((i) => i.from);
-		const flipped = mapping.map(flip_indexer_projection);
+	for (const { chunkCoords, mapping } of indexer) {
+		const chunkSelection = mapping.map((i) => i.from);
+		const flipped = mapping.map(flipIndexerProjection);
 		queue.add(async () => {
 			if (isAbortable(opts.opts)) {
 				opts.opts.signal.throwIfAborted();
 			}
 
 			// obtain key for chunk storage
-			const chunk_path = arr.resolve(
-				context.encode_chunk_key(chunk_coords),
-			).path;
+			const chunkPath = arr.resolve(context.encodeChunkKey(chunkCoords)).path;
 
-			let chunk_data: TypedArray<Dtype>;
-			const chunk_shape = arr.chunks.slice();
-			const chunk_stride = context.get_strides(chunk_shape);
+			let chunkData: TypedArray<Dtype>;
+			const chunkShape = arr.chunks.slice();
+			const chunkStride = context.getStrides(chunkShape);
 
-			if (is_total_slice(chunk_selection, chunk_shape)) {
+			if (isTotalSlice(chunkSelection, chunkShape)) {
 				// totally replace
-				chunk_data = new context.TypedArray(chunk_size);
+				chunkData = new context.TypedArray(chunkSize);
 				// optimization: we are completely replacing the chunk, so no need
 				// to access the exisiting chunk data
 				if (typeof value === "object") {
 					// Otherwise data just contiguous TypedArray
 					const chunk = setter.prepare(
-						chunk_data,
-						chunk_shape.slice(),
-						chunk_stride.slice(),
+						chunkData,
+						chunkShape.slice(),
+						chunkStride.slice(),
 					);
 					// @ts-expect-error - Value is not a scalar
-					setter.set_from_chunk(chunk, value, flipped);
+					setter.setFromChunk(chunk, value, flipped);
 				} else {
 					// @ts-expect-error - Value is a scalar
-					chunk_data.fill(value);
+					chunkData.fill(value);
 				}
 			} else {
 				// partially replace the contents of this chunk
-				chunk_data = await arr.getChunk(chunk_coords).then(({ data }) => data);
+				chunkData = await arr.getChunk(chunkCoords).then(({ data }) => data);
 
 				const chunk = setter.prepare(
-					chunk_data,
-					chunk_shape.slice(),
-					chunk_stride.slice(),
+					chunkData,
+					chunkShape.slice(),
+					chunkStride.slice(),
 				);
 
 				// Modify chunk data
 				if (typeof value === "object") {
 					// @ts-expect-error - Value is not a scalar
-					setter.set_from_chunk(chunk, value, flipped);
+					setter.setFromChunk(chunk, value, flipped);
 				} else {
-					setter.set_scalar(chunk, chunk_selection, value);
+					setter.setScalar(chunk, chunkSelection, value);
 				}
 			}
 			await arr.store.set(
-				chunk_path,
+				chunkPath,
 				await context.codec.encode({
-					data: chunk_data,
-					shape: chunk_shape,
-					stride: chunk_stride,
+					data: chunkData,
+					shape: chunkShape,
+					stride: chunkStride,
 				}),
 			);
 		});
@@ -136,7 +134,7 @@ export async function set<Dtype extends DataType, Arr extends Chunk<Dtype>>(
 	await queue.onIdle();
 }
 
-function is_total_slice(
+function isTotalSlice(
 	selection: (number | Indices)[],
 	shape: readonly number[],
 ): selection is Indices[] {

--- a/packages/zarrita/src/indexing/types.ts
+++ b/packages/zarrita/src/indexing/types.ts
@@ -36,12 +36,12 @@ export type SetFromChunk<D extends DataType, NdArray extends Chunk<D>> = (
 
 export type Setter<D extends DataType, Arr extends Chunk<D>> = {
 	prepare: Prepare<D, Arr>;
-	set_from_chunk: SetFromChunk<D, Arr>;
-	set_scalar: SetScalar<D, Arr>;
+	setFromChunk: SetFromChunk<D, Arr>;
+	setScalar: SetScalar<D, Arr>;
 };
 
 export type Options = {
-	create_queue?: () => ChunkQueue;
+	createQueue?: () => ChunkQueue;
 	useSharedArrayBuffer?: boolean;
 };
 

--- a/packages/zarrita/src/indexing/util.ts
+++ b/packages/zarrita/src/indexing/util.ts
@@ -55,7 +55,7 @@ export function* product<T extends Array<Iterable<unknown>>>(
 }
 
 // https://github.com/python/cpython/blob/263c0dd16017613c5ea2fbfc270be4de2b41b5ad/Objects/sliceobject.c#L376-L519
-export function slice_indices(
+export function sliceIndices(
 	{ start, stop, step }: Slice,
 	length: number,
 ): Indices {
@@ -63,14 +63,14 @@ export function slice_indices(
 		throw new Error("slice step cannot be zero");
 	}
 	step = step ?? 1;
-	const step_is_negative = step < 0;
+	const stepIsNegative = step < 0;
 
 	/* Find lower and upper bounds for start and stop. */
-	const [lower, upper] = step_is_negative ? [-1, length - 1] : [0, length];
+	const [lower, upper] = stepIsNegative ? [-1, length - 1] : [0, length];
 
 	/* Compute start. */
 	if (start === null) {
-		start = step_is_negative ? upper : lower;
+		start = stepIsNegative ? upper : lower;
 	} else {
 		if (start < 0) {
 			start += length;
@@ -84,7 +84,7 @@ export function slice_indices(
 
 	/* Compute stop. */
 	if (stop === null) {
-		stop = step_is_negative ? lower : upper;
+		stop = stepIsNegative ? lower : upper;
 	} else {
 		if (stop < 0) {
 			stop += length;
@@ -99,7 +99,7 @@ export function slice_indices(
 	return [start, stop, step];
 }
 
-function to_int(value: bigint | number | null): number | null {
+function toInt(value: bigint | number | null): number | null {
 	if (value == null) return null;
 	if (typeof value === "bigint") {
 		if (value > Number.MAX_SAFE_INTEGER || value < Number.MIN_SAFE_INTEGER) {
@@ -129,9 +129,9 @@ export function slice(
 		start = null;
 	}
 	return {
-		start: to_int(start),
-		stop: to_int(stop),
-		step: to_int(step),
+		start: toInt(start),
+		stop: toInt(stop),
+		step: toInt(step),
 	};
 }
 
@@ -155,7 +155,7 @@ export function sel<D extends DataType, Store extends Readable>(
 }
 
 /** Built-in "queue" for awaiting promises. */
-export function create_queue(): ChunkQueue {
+export function createQueue(): ChunkQueue {
 	const promises: Promise<void>[] = [];
 	return {
 		add: (fn) => promises.push(fn()),

--- a/packages/zarrita/src/open.ts
+++ b/packages/zarrita/src/open.ts
@@ -8,78 +8,78 @@ import type {
 	GroupMetadata,
 } from "./metadata.js";
 import {
-	ensure_correct_scalar,
+	ensureCorrectScalar,
 	isAbortable,
-	json_decode_object,
-	rethrow_unless,
-	v2_to_v3_array_metadata,
-	v2_to_v3_group_metadata,
+	jsonDecodeObject,
+	rethrowUnless,
+	v2ToV3ArrayMetadata,
+	v2ToV3GroupMetadata,
 } from "./util.js";
 
-export let VERSION_COUNTER = create_version_counter();
-function create_version_counter() {
-	let version_counts = new WeakMap<Readable, { v2: number; v3: number }>();
-	function get_counts(store: Readable) {
-		let counts = version_counts.get(store) ?? { v2: 0, v3: 0 };
-		version_counts.set(store, counts);
+export let VERSION_COUNTER = createVersionCounter();
+function createVersionCounter() {
+	let versionCounts = new WeakMap<Readable, { v2: number; v3: number }>();
+	function getCounts(store: Readable) {
+		let counts = versionCounts.get(store) ?? { v2: 0, v3: 0 };
+		versionCounts.set(store, counts);
 		return counts;
 	}
 	return {
 		increment(store: Readable, version: "v2" | "v3") {
-			get_counts(store)[version] += 1;
+			getCounts(store)[version] += 1;
 		},
-		version_max(store: Readable): "v2" | "v3" {
-			let counts = get_counts(store);
+		versionMax(store: Readable): "v2" | "v3" {
+			let counts = getCounts(store);
 			return counts.v3 > counts.v2 ? "v3" : "v2";
 		},
 	};
 }
 
-async function load_attrs(
+async function loadAttrs(
 	location: Location<Readable>,
 	opts?: unknown,
 ): Promise<Attributes> {
-	let meta_bytes = await location.store.get(
+	let metaBytes = await location.store.get(
 		location.resolve(".zattrs").path,
 		opts,
 	);
-	if (!meta_bytes) return {};
-	return json_decode_object(meta_bytes);
+	if (!metaBytes) return {};
+	return jsonDecodeObject(metaBytes);
 }
 
-function open_v2<Store extends Readable>(
+function openV2<Store extends Readable>(
 	location: Location<Store> | Store,
 	options: { kind: "group"; attrs?: boolean; opts?: unknown },
 ): Promise<Group<Store>>;
 
-function open_v2<Store extends Readable>(
+function openV2<Store extends Readable>(
 	location: Location<Store> | Store,
 	options: { kind: "array"; attrs?: boolean; opts?: unknown },
 ): Promise<Array<DataType, Store>>;
 
-function open_v2<Store extends Readable>(
+function openV2<Store extends Readable>(
 	location: Location<Store> | Store,
 	options?: { kind?: "array" | "group"; attrs?: boolean; opts?: unknown },
 ): Promise<Array<DataType, Store> | Group<Store>>;
 
-async function open_v2<Store extends Readable>(
+async function openV2<Store extends Readable>(
 	location: Location<Store> | Store,
 	options: { kind?: "array" | "group"; attrs?: boolean; opts?: unknown } = {},
 ) {
 	let loc = "store" in location ? location : new Location(location);
 	let { opts } = options;
 	let attrs = {};
-	if (options.attrs ?? true) attrs = await load_attrs(loc, opts);
+	if (options.attrs ?? true) attrs = await loadAttrs(loc, opts);
 	if (isAbortable(opts)) opts.signal.throwIfAborted();
-	if (options.kind === "array") return open_array_v2(loc, attrs, opts);
-	if (options.kind === "group") return open_group_v2(loc, attrs, opts);
-	return open_array_v2(loc, attrs, opts).catch((err) => {
-		rethrow_unless(err, NodeNotFoundError, JsonDecodeError);
-		return open_group_v2(loc, attrs, opts);
+	if (options.kind === "array") return openArrayV2(loc, attrs, opts);
+	if (options.kind === "group") return openGroupV2(loc, attrs, opts);
+	return openArrayV2(loc, attrs, opts).catch((err) => {
+		rethrowUnless(err, NodeNotFoundError, JsonDecodeError);
+		return openGroupV2(loc, attrs, opts);
 	});
 }
 
-async function open_array_v2<Store extends Readable>(
+async function openArrayV2<Store extends Readable>(
 	location: Location<Store>,
 	attrs: Attributes,
 	opts?: unknown,
@@ -95,11 +95,11 @@ async function open_array_v2<Store extends Readable>(
 	return new Array(
 		location.store,
 		location.path,
-		v2_to_v3_array_metadata(json_decode_object(meta), attrs),
+		v2ToV3ArrayMetadata(jsonDecodeObject(meta), attrs),
 	);
 }
 
-async function open_group_v2<Store extends Readable>(
+async function openGroupV2<Store extends Readable>(
 	location: Location<Store>,
 	attrs: Attributes,
 	opts?: unknown,
@@ -115,11 +115,11 @@ async function open_group_v2<Store extends Readable>(
 	return new Group(
 		location.store,
 		location.path,
-		v2_to_v3_group_metadata(json_decode_object(meta), attrs),
+		v2ToV3GroupMetadata(jsonDecodeObject(meta), attrs),
 	);
 }
 
-async function _open_v3<Store extends Readable>(
+async function _openV3<Store extends Readable>(
 	location: Location<Store>,
 	opts?: unknown,
 ) {
@@ -130,42 +130,41 @@ async function _open_v3<Store extends Readable>(
 			cause: new KeyError(path),
 		});
 	}
-	let meta_doc: ArrayMetadata<DataType> | GroupMetadata =
-		json_decode_object(meta);
-	if (meta_doc.node_type === "array") {
-		meta_doc.fill_value = ensure_correct_scalar(meta_doc);
+	let metaDoc: ArrayMetadata<DataType> | GroupMetadata = jsonDecodeObject(meta);
+	if (metaDoc.node_type === "array") {
+		metaDoc.fill_value = ensureCorrectScalar(metaDoc);
 	}
-	return meta_doc.node_type === "array"
-		? new Array(store, location.path, meta_doc)
-		: new Group(store, location.path, meta_doc);
+	return metaDoc.node_type === "array"
+		? new Array(store, location.path, metaDoc)
+		: new Group(store, location.path, metaDoc);
 }
 
-function open_v3<Store extends Readable>(
+function openV3<Store extends Readable>(
 	location: Location<Store> | Store,
 	options: { kind: "group"; opts?: unknown },
 ): Promise<Group<Store>>;
 
-function open_v3<Store extends Readable>(
+function openV3<Store extends Readable>(
 	location: Location<Store> | Store,
 	options: { kind: "array"; opts?: unknown },
 ): Promise<Array<DataType, Store>>;
 
-function open_v3<Store extends Readable>(
+function openV3<Store extends Readable>(
 	location: Location<Store> | Store,
 	options?: { opts?: unknown },
 ): Promise<Array<DataType, Store> | Group<Store>>;
 
-function open_v3<Store extends Readable>(
+function openV3<Store extends Readable>(
 	location: Location<Store> | Store,
 	options?: { opts?: unknown },
 ): Promise<Array<DataType, Store> | Group<Store>>;
 
-async function open_v3<Store extends Readable>(
+async function openV3<Store extends Readable>(
 	location: Location<Store>,
 	options: { kind?: "array" | "group"; opts?: unknown } = {},
 ): Promise<Array<DataType, Store> | Group<Store>> {
 	let loc = "store" in location ? location : new Location(location);
-	let node = await _open_v3(loc, options.opts);
+	let node = await _openV3(loc, options.opts);
 	VERSION_COUNTER.increment(loc.store, "v3");
 	if (options.kind === undefined) return node;
 	if (options.kind === "array" && node instanceof Array) return node;
@@ -202,17 +201,17 @@ export async function open<Store extends Readable>(
 	options: { kind?: "array" | "group"; attrs?: boolean; opts?: unknown } = {},
 ): Promise<Array<DataType, Store> | Group<Store>> {
 	let store = "store" in location ? location.store : location;
-	let version_max = VERSION_COUNTER.version_max(store);
+	let versionMax = VERSION_COUNTER.versionMax(store);
 	// Use the open function for the version with the most successful opens.
 	// Note that here we use the dot syntax to access the open functions
 	// because this enables us to use vi.spyOn during testing.
-	let open_primary = version_max === "v2" ? open.v2 : open.v3;
-	let open_secondary = version_max === "v2" ? open.v3 : open.v2;
-	return open_primary(location, options).catch((err) => {
-		rethrow_unless(err, NodeNotFoundError, JsonDecodeError);
-		return open_secondary(location, options);
+	let openPrimary = versionMax === "v2" ? open.v2 : open.v3;
+	let openSecondary = versionMax === "v2" ? open.v3 : open.v2;
+	return openPrimary(location, options).catch((err) => {
+		rethrowUnless(err, NodeNotFoundError, JsonDecodeError);
+		return openSecondary(location, options);
 	});
 }
 
-open.v2 = open_v2;
-open.v3 = open_v3;
+open.v2 = openV2;
+open.v3 = openV3;

--- a/packages/zarrita/src/util.ts
+++ b/packages/zarrita/src/util.ts
@@ -280,7 +280,7 @@ export type NarrowDataType<
 					? ObjectType
 					: Extract<Query, Dtype>;
 
-export function isDtype<Query extends DataTypeQuery>(
+export function isDataType<Query extends DataTypeQuery>(
 	dtype: DataType,
 	query: Query,
 ): dtype is NarrowDataType<DataType, Query> {

--- a/packages/zarrita/src/util.ts
+++ b/packages/zarrita/src/util.ts
@@ -19,7 +19,7 @@ import {
 	UnicodeStringArray,
 } from "./typedarray.js";
 
-export function json_encode_object(o: Record<string, unknown>): Uint8Array {
+export function jsonEncodeObject(o: Record<string, unknown>): Uint8Array {
 	const str = JSON.stringify(
 		o,
 		(_key, value) => {
@@ -57,7 +57,7 @@ export function createBuffer(
 	return new ArrayBuffer(byteLength);
 }
 
-export function json_decode_object(bytes: Uint8Array) {
+export function jsonDecodeObject(bytes: Uint8Array) {
 	const str = new TextDecoder().decode(bytes);
 	try {
 		return JSON.parse(str);
@@ -66,11 +66,11 @@ export function json_decode_object(bytes: Uint8Array) {
 	}
 }
 
-export function byteswap_inplace(view: Uint8Array, bytes_per_element: number) {
-	const numFlips = bytes_per_element / 2;
-	const endByteIndex = bytes_per_element - 1;
+export function byteswapInplace(view: Uint8Array, bytesPerElement: number) {
+	const numFlips = bytesPerElement / 2;
+	const endByteIndex = bytesPerElement - 1;
 	let t = 0;
-	for (let i = 0; i < view.length; i += bytes_per_element) {
+	for (let i = 0; i < view.length; i += bytesPerElement) {
 		for (let j = 0; j < numFlips; j += 1) {
 			t = view[i + j];
 			view[i + j] = view[i + endByteIndex - j];
@@ -79,13 +79,13 @@ export function byteswap_inplace(view: Uint8Array, bytes_per_element: number) {
 	}
 }
 
-export function get_ctr<D extends DataType>(
-	data_type: D,
+export function getCtr<D extends DataType>(
+	dataType: D,
 ): TypedArrayConstructor<D> {
-	if (data_type === "v2:object") {
+	if (dataType === "v2:object") {
 		return globalThis.Array as unknown as TypedArrayConstructor<D>;
 	}
-	let match = data_type.match(/v2:([US])(\d+)/);
+	let match = dataType.match(/v2:([US])(\d+)/);
 	if (match) {
 		let [, kind, chars] = match;
 		// @ts-expect-error
@@ -95,7 +95,7 @@ export function get_ctr<D extends DataType>(
 		);
 	}
 	// Handle v3 variable-length string type
-	if (data_type === "string") {
+	if (dataType === "string") {
 		return globalThis.Array as unknown as TypedArrayConstructor<D>;
 	}
 	// @ts-expect-error - We've checked that the key exists
@@ -114,13 +114,13 @@ export function get_ctr<D extends DataType>(
 			float64: Float64Array,
 			bool: BoolArray,
 		} as const
-	)[data_type];
-	assert(ctr, `Unknown or unsupported data_type: ${data_type}`);
+	)[dataType];
+	assert(ctr, `Unknown or unsupported dataType: ${dataType}`);
 	return ctr;
 }
 
 /** Compute strides for 'C' or 'F' ordered array from shape */
-export function get_strides(
+export function getStrides(
 	shape: readonly number[],
 	order: "C" | "F" | Array<number>,
 ): Array<number> {
@@ -147,33 +147,33 @@ export function get_strides(
 }
 
 // https://zarr-specs.readthedocs.io/en/latest/v3/core/v3.0.html#chunk-key-encoding
-export function create_chunk_key_encoder({
+export function createChunkKeyEncoder({
 	name,
 	configuration,
-}: ArrayMetadata["chunk_key_encoding"]): (chunk_coords: number[]) => string {
+}: ArrayMetadata["chunk_key_encoding"]): (chunkCoords: number[]) => string {
 	if (name === "default") {
 		const separator = configuration?.separator ?? "/";
-		return (chunk_coords) => ["c", ...chunk_coords].join(separator);
+		return (chunkCoords) => ["c", ...chunkCoords].join(separator);
 	}
 	if (name === "v2") {
 		const separator = configuration?.separator ?? ".";
-		return (chunk_coords) => chunk_coords.join(separator) || "0";
+		return (chunkCoords) => chunkCoords.join(separator) || "0";
 	}
 	throw new Error(`Unknown chunk key encoding: ${name}`);
 }
 
-function coerce_dtype(
+function coerceDtype(
 	dtype: string,
-): { data_type: DataType } | { data_type: DataType; endian: "little" | "big" } {
+): { dataType: DataType } | { dataType: DataType; endian: "little" | "big" } {
 	if (dtype === "|O") {
-		return { data_type: "v2:object" };
+		return { dataType: "v2:object" };
 	}
 
 	let match = dtype.match(/^([<|>])(.*)$/);
 	assert(match, `Invalid dtype: ${dtype}`);
 
 	let [, endian, rest] = match;
-	let data_type =
+	let dataType =
 		{
 			b1: "bool",
 			i1: "int8",
@@ -189,22 +189,22 @@ function coerce_dtype(
 			f8: "float64",
 		}[rest] ??
 		(rest.startsWith("S") || rest.startsWith("U") ? `v2:${rest}` : undefined);
-	assert(data_type, `Unsupported or unknown dtype: ${dtype}`);
+	assert(dataType, `Unsupported or unknown dtype: ${dtype}`);
 	if (endian === "|") {
-		return { data_type } as { data_type: DataType };
+		return { dataType } as { dataType: DataType };
 	}
-	return { data_type, endian: endian === "<" ? "little" : "big" } as {
-		data_type: DataType;
+	return { dataType, endian: endian === "<" ? "little" : "big" } as {
+		dataType: DataType;
 		endian: "little" | "big";
 	};
 }
 
-export function v2_to_v3_array_metadata(
+export function v2ToV3ArrayMetadata(
 	meta: ArrayMetadataV2,
 	attributes: Record<string, unknown> = {},
 ): ArrayMetadata<DataType> {
 	let codecs: CodecMetadata[] = [];
-	let dtype = coerce_dtype(meta.dtype);
+	let dtype = coerceDtype(meta.dtype);
 	if (meta.order === "F") {
 		codecs.push({ name: "transpose", configuration: { order: "F" } });
 	}
@@ -218,15 +218,15 @@ export function v2_to_v3_array_metadata(
 		let { id, ...configuration } = meta.compressor;
 		codecs.push({ name: `numcodecs.${id}`, configuration });
 	}
-	let dimension_names: string[] | undefined;
+	let dimensionNames: string[] | undefined;
 	if (globalThis.Array.isArray(attributes._ARRAY_DIMENSIONS)) {
-		dimension_names = attributes._ARRAY_DIMENSIONS;
+		dimensionNames = attributes._ARRAY_DIMENSIONS;
 	}
 	return {
 		zarr_format: 3,
 		node_type: "array",
 		shape: meta.shape,
-		data_type: dtype.data_type,
+		data_type: dtype.dataType,
 		chunk_grid: {
 			name: "regular",
 			configuration: {
@@ -241,12 +241,12 @@ export function v2_to_v3_array_metadata(
 		},
 		codecs,
 		fill_value: meta.fill_value,
-		dimension_names,
+		dimension_names: dimensionNames,
 		attributes,
 	};
 }
 
-export function v2_to_v3_group_metadata(
+export function v2ToV3GroupMetadata(
 	_meta: unknown,
 	attributes: Record<string, unknown> = {},
 ): GroupMetadata {
@@ -280,7 +280,7 @@ export type NarrowDataType<
 					? ObjectType
 					: Extract<Query, Dtype>;
 
-export function is_dtype<Query extends DataTypeQuery>(
+export function isDtype<Query extends DataTypeQuery>(
 	dtype: DataType,
 	query: Query,
 ): dtype is NarrowDataType<DataType, Query> {
@@ -293,16 +293,16 @@ export function is_dtype<Query extends DataTypeQuery>(
 	) {
 		return dtype === query;
 	}
-	let is_boolean = dtype === "bool";
-	if (query === "boolean") return is_boolean;
-	let is_string =
+	let isBoolean = dtype === "bool";
+	if (query === "boolean") return isBoolean;
+	let isString =
 		dtype.startsWith("v2:U") || dtype.startsWith("v2:S") || dtype === "string";
-	if (query === "string") return is_string;
-	let is_bigint = dtype === "int64" || dtype === "uint64";
-	if (query === "bigint") return is_bigint;
-	let is_object = dtype === "v2:object";
-	if (query === "object") return is_object;
-	return !is_string && !is_bigint && !is_boolean && !is_object;
+	if (query === "string") return isString;
+	let isBigint = dtype === "int64" || dtype === "uint64";
+	if (query === "bigint") return isBigint;
+	let isObject = dtype === "v2:object";
+	if (query === "object") return isObject;
+	return !isString && !isBigint && !isBoolean && !isObject;
 }
 
 export type ShardingCodecMetadata = {
@@ -314,13 +314,13 @@ export type ShardingCodecMetadata = {
 	};
 };
 
-export function is_sharding_codec(
+export function isShardingCodec(
 	codec: CodecMetadata,
 ): codec is ShardingCodecMetadata {
 	return codec?.name === "sharding_indexed";
 }
 
-export function ensure_correct_scalar<D extends DataType>(
+export function ensureCorrectScalar<D extends DataType>(
 	metadata: ArrayMetadata<D>,
 ): Scalar<D> | null {
 	if (
@@ -332,11 +332,11 @@ export function ensure_correct_scalar<D extends DataType>(
 	}
 	// Zarr v3 represents IEEE 754 special float values as strings in JSON.
 	// Only applies to floating-point types.
-	let is_float =
+	let isFloat =
 		metadata.data_type === "float16" ||
 		metadata.data_type === "float32" ||
 		metadata.data_type === "float64";
-	if (typeof metadata.fill_value === "string" && is_float) {
+	if (typeof metadata.fill_value === "string" && isFloat) {
 		let mapping: Record<string, number> = {
 			NaN: NaN,
 			Infinity: Infinity,
@@ -371,7 +371,7 @@ type ErrorConstructor = new (...args: any[]) => Error;
  * try {
  *   await db.query();
  * } catch (err) {
- *   rethrow_unless(err, DatabaseError, NetworkError);
+ *   rethrowUnless(err, DatabaseError, NetworkError);
  *   err // DatabaseError | NetworkError
  * }
  * ```
@@ -389,7 +389,7 @@ export function isAbortable(opts: unknown): opts is { signal: AbortSignal } {
 	);
 }
 
-export function rethrow_unless<E extends ReadonlyArray<ErrorConstructor>>(
+export function rethrowUnless<E extends ReadonlyArray<ErrorConstructor>>(
 	error: unknown,
 	...errors: E
 ): asserts error is InstanceType<E[number]> {


### PR DESCRIPTION
The codebase inherited Python-style snake_case naming from zarr-python, which created confusion about what is a zarr metadata field versus an internal API. This change draws a clear boundary: zarr metadata types (`ArrayMetadata`, `GroupMetadata`, `CodecMetadata`, etc.) retain snake_case because they represent the on-disk JSON format, while all internal function names, variable names, and interface properties use idiomatic TypeScript camelCase.

The most visible breaking change is `CreateArrayOptions`, whose properties move to camelCase:

```ts
await zarr.create(store, {
  dtype: "float32",       // was data_type
  shape: [100, 100],
  chunkShape: [10, 10],   // was chunk_shape
  fillValue: 0,           // was fill_value
})
```

Internal exports consumed by `@zarrita/ndarray` are also renamed (`_zarrita_internal_getStrides`, `_zarrita_internal_sliceIndices`), and the `Setter` type properties become `setScalar`/`setFromChunk`.

Also closes #217 