### PR TITLE
Add custom `fetch` option to FetchStore

### DIFF
--- a/.changeset/fetch-store-custom-fetch.md
+++ b/.changeset/fetch-store-custom-fetch.md
@@ -1,0 +1,60 @@
+---
+"@zarrita/storage": minor
+---
+
+Add custom `fetch` option to `FetchStore`. Accepts a WinterTC-style fetch handler ([`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) in, [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) out) to cover the long tail of things users need at the fetch level. Deprecates `overrides`.
+
+Presigning a URL:
+
+```ts
+const store = new FetchStore("https://my-bucket.s3.amazonaws.com/data.zarr", {
+  async fetch(request) {
+    const newUrl = await presign(request.url);
+    return fetch(new Request(newUrl, request));
+  },
+});
+```
+
+Remapping response status codes:
+
+```ts
+const store = new FetchStore("https://my-bucket.s3.amazonaws.com/data.zarr", {
+  async fetch(request) {
+    const response = await fetch(request);
+    if (response.status === 403) {
+      return new Response(null, { status: 404 });
+    }
+    return response;
+  },
+});
+```
+
+#### Migrating from `overrides`
+
+`overrides` only supported static [`RequestInit`](https://developer.mozilla.org/en-US/docs/Web/API/RequestInit) properties. For anything dynamic (like refreshing a token), you had to thread it through every call site:
+
+```ts
+const store = new FetchStore("https://example.com/data.zarr");
+const arr = await zarr.open(store);
+
+// token logic leaks into every get call
+let chunk = await zarr.get(arr, null, {
+  opts: { headers: { Authorization: `Bearer ${await getAccessToken()}` } },
+});
+```
+
+With `fetch`, auth is configured once on the store and every request picks it up:
+
+```ts
+const store = new FetchStore("https://example.com/data.zarr", {
+  async fetch(request) {
+    const token = await getAccessToken();
+    request.headers.set("Authorization", `Bearer ${token}`);
+    return fetch(request);
+  },
+});
+const arr = await zarr.open(store);
+
+// call sites don't need to know about auth
+let chunk = await zarr.get(arr);
+```

--- a/docs/packages/storage.md
+++ b/docs/packages/storage.md
@@ -61,16 +61,80 @@ import { FetchStore } from "@zarrita/storage";
 const store = new FetchStore("http://localhost:8080/data.zarr");
 ```
 
-#### Default Fetch Options
+#### Response handling
 
-You can specify default fetch options using the `overrides` parameter when
-initializing the `FetchStore`. These act as base configurations for every fetch
-request:
+The store interprets HTTP responses as follows:
+
+| Status        | Meaning                                    |
+| ------------- | ------------------------------------------ |
+| **404**       | Missing key — returns `undefined`          |
+| **200 / 206** | Success — body is read as `Uint8Array`     |
+| **Any other** | Throws an error                            |
+
+If your backend returns different status codes for missing keys (e.g., S3
+returns **403** for missing keys on private buckets), you can remap them with a
+custom `fetch` (see below).
+
+#### Custom `fetch`
+
+You can provide a custom `fetch` function to intercept every request made by the
+store. It receives a standard
+[WinterTC fetch handler](https://github.com/nicolo-ribaudo/tc55-proposal-functions-api),
+similar to Cloudflare Workers, Deno.serve, and Bun.serve — a
+[`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) in, a
+[`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) out.
+
+This is the recommended way to add authentication, presign URLs, or transform
+requests.
+
+::: warning Important
+Sharding and partial reads rely on `Range` headers in the request. When
+transforming a request (e.g., changing the URL), always use
+`new Request(newUrl, originalRequest)` to preserve headers, abort signals, and
+other options passed via `store.get(key, init)`.
+:::
 
 ```javascript
-const fetchOptions = { headers: { Authorization: "XXXXX" } };
-const store = new FetchStore("http://localhost:8080/data.zarr", {
-	overrides: fetchOptions,
+const store = new FetchStore("https://my-bucket.s3.amazonaws.com/data.zarr", {
+	async fetch(request) {
+		const newUrl = await presign(request.url);
+		// Preserves headers, abort signal, and other options from store.get(key, init)
+		return fetch(new Request(newUrl, request));
+	},
+});
+```
+
+##### Adding authentication headers
+
+You can set headers on the request directly, which replaces the need for the
+deprecated `overrides` option. Since the handler runs on every request, you can
+also dynamically refresh credentials:
+
+```javascript
+const store = new FetchStore("https://example.com/data.zarr", {
+	async fetch(request) {
+		const token = await getAccessToken();
+		request.headers.set("Authorization", `Bearer ${token}`);
+		return fetch(request);
+	},
+});
+```
+
+##### Handling S3 403 responses
+
+S3 returns **403** (not 404) for missing keys on private buckets, which causes
+the store to throw. If you know that 403 means "not found" in your setup, remap
+it:
+
+```javascript
+const store = new FetchStore("https://my-bucket.s3.amazonaws.com/data.zarr", {
+	async fetch(request) {
+		const response = await fetch(request);
+		if (response.status === 403) {
+			return new Response(null, { status: 404 });
+		}
+		return response;
+	},
 });
 ```
 
@@ -88,8 +152,10 @@ const bytes = await store.get("/zarr.json", {
 });
 ```
 
-These options override the defaults for the store, except headers are merged
-(with the latter taking precedent).
+These per-request options are merged into the `Request` passed to your custom
+`fetch` (or the global `fetch` if none is provided). Headers are merged, with
+per-request headers taking precedence.
+
 
 ### FileSystemStore <Badge type="tip" text="Readable" /> <Badge type="tip" text="Writable" />
 

--- a/packages/@zarrita-storage/__tests__/fetch.test.ts
+++ b/packages/@zarrita-storage/__tests__/fetch.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, assert, describe, expect, it, vi } from "vitest";
 
 import FetchStore from "../src/fetch.js";
 
@@ -117,7 +117,10 @@ describe("FetchStore", () => {
 		let store = new FetchStore(href);
 		let spy = vi.spyOn(globalThis, "fetch");
 		await store.get("/zarr.json", { headers });
-		expect(spy).toHaveBeenCalledWith(`${href}/zarr.json`, { headers });
+		let request = spy.mock.calls[0][0];
+		assert(request instanceof Request);
+		expect(request.url).toBe(`${href}/zarr.json`);
+		expect(request.headers.get("x-test")).toBe("test");
 	});
 
 	it("forwards request options to fetch when configured globally", async () => {
@@ -125,7 +128,10 @@ describe("FetchStore", () => {
 		let store = new FetchStore(href, { overrides: { headers } });
 		let spy = vi.spyOn(globalThis, "fetch");
 		await store.get("/zarr.json");
-		expect(spy).toHaveBeenCalledWith(`${href}/zarr.json`, { headers });
+		let request = spy.mock.calls[0][0];
+		assert(request instanceof Request);
+		expect(request.url).toBe(`${href}/zarr.json`);
+		expect(request.headers.get("x-test")).toBe("test");
 	});
 
 	it("merges request options", async () => {
@@ -136,10 +142,12 @@ describe("FetchStore", () => {
 		let store = new FetchStore(href, { overrides });
 		let spy = vi.spyOn(globalThis, "fetch");
 		await store.get("/zarr.json", { headers: { "x-test": "override" } });
-		expect(spy).toHaveBeenCalledWith(`${href}/zarr.json`, {
-			headers: { "x-test": "override", "x-test2": "root" },
-			cache: "no-cache",
-		});
+		let request = spy.mock.calls[0][0];
+		assert(request instanceof Request);
+		expect(request.url).toBe(`${href}/zarr.json`);
+		expect(request.headers.get("x-test")).toBe("override");
+		expect(request.headers.get("x-test2")).toBe("root");
+		expect(request.cache).toBe("no-cache");
 	});
 
 	it("reads partial - suffixLength", async () => {
@@ -164,5 +172,109 @@ describe("FetchStore", () => {
 			  "consolida"
 		`,
 		);
+	});
+
+	describe("custom fetch", () => {
+		it("uses custom fetch for get requests", async () => {
+			let customFetch = vi.fn((request: Request) => fetch(request));
+			let store = new FetchStore(href, { fetch: customFetch });
+			let bytes = await store.get("/zarr.json");
+			expect(bytes).toBeInstanceOf(Uint8Array);
+			expect(customFetch).toHaveBeenCalledOnce();
+			let request = customFetch.mock.calls[0][0];
+			expect(request).toBeInstanceOf(Request);
+			expect(request.url).toBe(`${href}/zarr.json`);
+		});
+
+		it("uses custom fetch for getRange requests", async () => {
+			let customFetch = vi.fn((request: Request) => fetch(request));
+			let store = new FetchStore(href, { fetch: customFetch });
+			let bytes = await store.getRange("/zarr.json", {
+				offset: 4,
+				length: 50,
+			});
+			expect(bytes).toBeInstanceOf(Uint8Array);
+			expect(customFetch).toHaveBeenCalledOnce();
+			let request = customFetch.mock.calls[0][0];
+			expect(request.headers.get("Range")).toBe("bytes=4-53");
+		});
+
+		it("allows intercepting and modifying the request", async () => {
+			let store = new FetchStore(href, {
+				async fetch(request) {
+					// Add a custom header before sending
+					let modified = new Request(request, {
+						headers: {
+							...Object.fromEntries(request.headers),
+							"x-custom": "test",
+						},
+					});
+					return fetch(modified);
+				},
+			});
+			let bytes = await store.get("/zarr.json");
+			expect(bytes).toBeInstanceOf(Uint8Array);
+		});
+
+		it("allows remapping status codes", async () => {
+			let store = new FetchStore("http://localhost:51204/does-not-exist", {
+				async fetch(request) {
+					let response = await fetch(request);
+					// Remap any error to 404 (simulates S3 403 → 404 pattern)
+					if (!response.ok && response.status !== 404) {
+						return new Response(null, { status: 404 });
+					}
+					return response;
+				},
+			});
+			let bytes = await store.get("/zarr.json");
+			expect(bytes).toBeUndefined();
+		});
+
+		it("receives merged overrides in the request", async () => {
+			let customFetch = vi.fn((request: Request) => fetch(request));
+			let store = new FetchStore(href, {
+				fetch: customFetch,
+				overrides: { headers: { "x-base": "base" } },
+			});
+			await store.get("/zarr.json", {
+				headers: { "x-request": "request" },
+			});
+			let request = customFetch.mock.calls[0][0];
+			expect(request.headers.get("x-base")).toBe("base");
+			expect(request.headers.get("x-request")).toBe("request");
+		});
+
+		it("allows setting headers on the request directly", async () => {
+			let spy = vi.spyOn(globalThis, "fetch");
+			let store = new FetchStore(href, {
+				async fetch(request) {
+					request.headers.set("Authorization", "Bearer test-token");
+					return fetch(request);
+				},
+			});
+			await store.get("/zarr.json");
+			let request = spy.mock.calls[0][0];
+			assert(request instanceof Request);
+			expect(request.headers.get("Authorization")).toBe("Bearer test-token");
+		});
+
+		it("abort signal survives request transformation", async () => {
+			let controller = new AbortController();
+			let store = new FetchStore(href, {
+				async fetch(request) {
+					// Simulate presigning: clone request with a new URL
+					let transformed = new Request(request.url, request);
+					expect(transformed.signal).toBe(request.signal);
+					expect(transformed.signal.aborted).toBe(false);
+					controller.abort();
+					expect(transformed.signal.aborted).toBe(true);
+					throw transformed.signal.reason;
+				},
+			});
+			await expect(
+				store.get("/zarr.json", { signal: controller.signal }),
+			).rejects.toThrow();
+		});
 	});
 });

--- a/packages/@zarrita-storage/src/fetch.ts
+++ b/packages/@zarrita-storage/src/fetch.ts
@@ -1,5 +1,5 @@
 import type { AbsolutePath, AsyncReadable, RangeQuery } from "./types.js";
-import { fetchRange, mergeInit } from "./util.js";
+import { mergeInit } from "./util.js";
 
 function resolve(root: string | URL, path: AbsolutePath): URL {
 	const base = typeof root === "string" ? new URL(root) : root;
@@ -27,52 +27,126 @@ async function handleResponse(
 	);
 }
 
-async function fetchSuffix(
-	url: URL,
-	suffixLength: number,
-	init: RequestInit,
-	useSuffixRequest: boolean,
-): Promise<Response> {
-	if (useSuffixRequest) {
-		return fetch(url, {
-			...init,
-			headers: { ...init.headers, Range: `bytes=-${suffixLength}` },
-		});
-	}
-	let response = await fetch(url, { ...init, method: "HEAD" });
-	if (!response.ok) {
-		// will be picked up by handleResponse
-		return response;
-	}
-	let contentLength = response.headers.get("Content-Length");
-	let length = Number(contentLength);
-	return fetchRange(url, length - suffixLength, length, init);
+/** Options for configuring a {@link FetchStore}. */
+interface FetchStoreOptions {
+	/**
+	 * A custom fetch handler to intercept requests.
+	 *
+	 * Receives a standard {@link https://github.com/nicolo-ribaudo/tc55-proposal-functions-api | WinterTC fetch handler},
+	 * similar to Cloudflare Workers, Deno.serve, and Bun.serve.
+	 *
+	 * Receives a {@link Request} object and must return a {@link Response}.
+	 * The response is handled by the store as follows:
+	 *
+	 * - **404** — treated as a missing key (`undefined`)
+	 * - **200 / 206** — treated as success, body is read as bytes
+	 * - **Any other status** — throws an error
+	 *
+	 * Use this to add authentication, presign URLs, transform requests,
+	 * or remap error codes for backends that don't follow the conventions
+	 * above.
+	 *
+	 * **Important:** Sharding and partial reads rely on `Range` headers.
+	 * When transforming a request (e.g., changing the URL), use
+	 * `new Request(newUrl, originalRequest)` to preserve headers, abort
+	 * signals, and other options passed via `store.get(key, init)`.
+	 *
+	 * @example Presign URLs
+	 * ```ts
+	 * const store = new FetchStore("https://my-bucket.s3.amazonaws.com/data.zarr", {
+	 *   async fetch(request) {
+	 *     const newUrl = await presign(request.url);
+	 *     // Preserves headers, abort signal, and other options from store.get(key, init)
+	 *     return fetch(new Request(newUrl, request));
+	 *   },
+	 * });
+	 * ```
+	 *
+	 * @example Handle S3 403 as missing key
+	 *
+	 * S3 returns 403 (not 404) for missing keys on private buckets,
+	 * which causes the store to throw. If you know that 403 means
+	 * "not found" in your setup, remap it:
+	 *
+	 * ```ts
+	 * const store = new FetchStore("https://my-bucket.s3.amazonaws.com/data.zarr", {
+	 *   async fetch(request) {
+	 *     const response = await fetch(request);
+	 *     if (response.status === 403) {
+	 *       return new Response(null, { status: 404 });
+	 *     }
+	 *     return response;
+	 *   },
+	 * });
+	 * ```
+	 */
+	fetch?: (request: Request) => Promise<Response>;
+	/**
+	 * Default {@link RequestInit} options applied to every request.
+	 *
+	 * @deprecated Prefer implementing a custom {@link FetchStoreOptions.fetch}
+	 * to intercept and modify requests.
+	 */
+	overrides?: RequestInit;
+	/** Whether to use suffix-length range requests (e.g., `Range: bytes=-N`). */
+	useSuffixRequest?: boolean;
 }
 
 /**
- * Readonly store based in the [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
- * Must polyfill `fetch` for use in Node.js.
+ * Readonly store backed by the
+ * [Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API).
  *
- * ```typescript
- * import * as zarr from "zarrita";
+ * Works anywhere `fetch` is available: browsers, Node.js 18+, Deno, and Bun.
+ *
+ * ## Response handling
+ *
+ * The store interprets HTTP responses as follows:
+ *
+ * | Status | Meaning |
+ * | ------ | ------- |
+ * | **404** | Missing key — returns `undefined` |
+ * | **200 / 206** | Success — body is read as `Uint8Array` |
+ * | **Any other** | Throws an error |
+ *
+ * If you need to remap status codes (e.g., S3 returns 403 for missing keys
+ * on private buckets), provide a custom `fetch` implementation.
+ *
+ * @example Basic usage
+ * ```ts
+ * import { FetchStore } from "@zarrita/storage";
+ *
  * const store = new FetchStore("http://localhost:8080/data.zarr");
- * const arr = await zarr.get(store, { kind: "array" });
+ * ```
+ *
+ * @example Custom fetch with presigned URLs
+ * ```ts
+ * import { FetchStore } from "@zarrita/storage";
+ *
+ * const store = new FetchStore("https://my-bucket.s3.amazonaws.com/data.zarr", {
+ *   async fetch(request) {
+ *     const newUrl = await presign(request.url);
+ *     // Preserves Range headers, abort signal, etc.
+ *     return fetch(new Request(newUrl, request));
+ *   },
+ * });
  * ```
  */
 class FetchStore implements AsyncReadable<RequestInit> {
+	#fetch: (request: Request) => Promise<Response>;
 	#overrides: RequestInit;
 	#useSuffixRequest: boolean;
 
 	constructor(
 		public url: string | URL,
-		options: { overrides?: RequestInit; useSuffixRequest?: boolean } = {},
+		options: FetchStoreOptions = {},
 	) {
+		this.#fetch = options.fetch ?? ((request) => fetch(request));
 		this.#overrides = options.overrides ?? {};
 		this.#useSuffixRequest = options.useSuffixRequest ?? false;
 	}
 
-	#mergeInit(overrides: RequestInit) {
-		return mergeInit(this.#overrides, overrides);
+	#buildRequest(url: string | URL, init: RequestInit): Request {
+		return new Request(url, mergeInit(this.#overrides, init));
 	}
 
 	async get(
@@ -80,7 +154,8 @@ class FetchStore implements AsyncReadable<RequestInit> {
 		options: RequestInit = {},
 	): Promise<Uint8Array | undefined> {
 		let href = resolve(this.url, key).href;
-		let response = await fetch(href, this.#mergeInit(options));
+		let request = this.#buildRequest(href, options);
+		let response = await this.#fetch(request);
 		return handleResponse(response);
 	}
 
@@ -90,20 +165,56 @@ class FetchStore implements AsyncReadable<RequestInit> {
 		options: RequestInit = {},
 	): Promise<Uint8Array | undefined> {
 		let url = resolve(this.url, key);
-		let init = this.#mergeInit(options);
 		let response: Response;
 		if ("suffixLength" in range) {
-			response = await fetchSuffix(
-				url,
-				range.suffixLength,
-				init,
-				this.#useSuffixRequest,
-			);
+			response = await this.#fetchSuffix(url, range.suffixLength, options);
 		} else {
-			response = await fetchRange(url, range.offset, range.length, init);
+			let rangeInit: RequestInit = {
+				...options,
+				headers: {
+					...options.headers,
+					Range: `bytes=${range.offset}-${range.offset + range.length - 1}`,
+				},
+			};
+			let request = this.#buildRequest(url, rangeInit);
+			response = await this.#fetch(request);
 		}
 		return handleResponse(response);
 	}
+
+	async #fetchSuffix(
+		url: URL,
+		suffixLength: number,
+		options: RequestInit,
+	): Promise<Response> {
+		if (this.#useSuffixRequest) {
+			let init: RequestInit = {
+				...options,
+				headers: { ...options.headers, Range: `bytes=-${suffixLength}` },
+			};
+			return this.#fetch(this.#buildRequest(url, init));
+		}
+		let headRequest = this.#buildRequest(url, {
+			...options,
+			method: "HEAD",
+		});
+		let response = await this.#fetch(headRequest);
+		if (!response.ok) {
+			return response;
+		}
+		let contentLength = response.headers.get("Content-Length");
+		let length = Number(contentLength);
+		let offset = length - suffixLength;
+		let rangeInit: RequestInit = {
+			...options,
+			headers: {
+				...options.headers,
+				Range: `bytes=${offset}-${length - 1}`,
+			},
+		};
+		return this.#fetch(this.#buildRequest(url, rangeInit));
+	}
 }
 
+export type { FetchStoreOptions };
 export default FetchStore;

--- a/packages/@zarrita-storage/src/index.ts
+++ b/packages/@zarrita-storage/src/index.ts
@@ -1,3 +1,4 @@
+export type { FetchStoreOptions } from "./fetch.js";
 export { default as FetchStore } from "./fetch.js";
 export { default as FileSystemStore } from "./fs.js";
 export { default as ReferenceStore } from "./ref.js";


### PR DESCRIPTION
Closes #344, #325, #288.

`FetchStore` only exposed `overrides` for setting default [`RequestInit`](https://developer.mozilla.org/en-US/docs/Web/API/RequestInit) properties. There is a long tail of things users need at the fetch level (presigning, auth, status code remapping) that `overrides` can't express. These changes add a `fetch` option that receives a WinterTC-style fetch handler ([`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request) in, [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response) out) to cover all of them, and deprecate `overrides`.

Presigning a URL (#325):

```ts
const store = new FetchStore("https://my-bucket.s3.amazonaws.com/data.zarr", {
  async fetch(request) {
    const newUrl = await presign(request.url);
    return fetch(new Request(newUrl, request));
  },
});
```

Remapping response status codes (#288, #344):

```ts
const store = new FetchStore("https://my-bucket.s3.amazonaws.com/data.zarr", {
  async fetch(request) {
    const response = await fetch(request);
    if (response.status === 403) {
      return new Response(null, { status: 404 });
    }
    return response;
  },
});
```

Modifying headers (main use case for `overrides`):

```ts
const store = new FetchStore("https://example.com/data.zarr", {
  async fetch(request) {
    const token = await getAccessToken();
    request.headers.set("Authorization", `Bearer ${token}`);
    return fetch(request);
  },
});
```
