### PR TITLE
Refactor `ReferenceStore` to delegate to `FetchStore`

### DIFF
--- a/.changeset/refstore-fetchstore-delegation.md
+++ b/.changeset/refstore-fetchstore-delegation.md
@@ -1,0 +1,17 @@
+---
+"@zarrita/storage": minor
+---
+
+`ReferenceStore` now uses `FetchStore` internally and accepts the same `fetch` option. The default fetch handler translates `s3://`, `gs://`, and `gcs://` URIs to HTTPS, but you can provide your own to add auth or handle other protocols:
+
+```ts
+const store = await ReferenceStore.fromUrl("https://example.com/refs.json", {
+  async fetch(request) {
+    // translate s3:// and gs:// URIs to HTTPS
+    const url = ReferenceStore.resolveUri(request.url);
+    const req = new Request(url, request);
+    req.headers.set("Authorization", `Bearer ${await getToken()}`);
+    return fetch(req);
+  },
+});
+```

--- a/packages/@zarrita-storage/__tests__/ref.test.ts
+++ b/packages/@zarrita-storage/__tests__/ref.test.ts
@@ -1,21 +1,23 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, assert, describe, expect, it, vi } from "vitest";
 
 import ReferenceStore from "../src/ref.js";
+
+// zarr.json is 99 bytes of known text content served by vitest's API server
+let zarrJsonUrl = "http://localhost:51204/fixtures/v3/data.zarr/zarr.json";
 
 describe("ReferenceStore", () => {
 	afterEach(() => {
 		vi.restoreAllMocks();
 	});
 
-	it("store creation is not async", async () => {
+	it("creates store from async spec", async () => {
 		let spec = Promise.resolve({
 			version: 1,
 			refs: {
 				".zgroup": '{"zarr_format":2}',
-				".zattrs": '{"encoding-type":"anndat…oding-version":"0.1.0"}',
 			},
 		});
-		let store = ReferenceStore.fromSpec(spec);
+		let store = await ReferenceStore.fromSpec(spec);
 		let bytes = await store.get("/.zgroup");
 		expect(bytes).toBeInstanceOf(Uint8Array);
 		expect(JSON.parse(new TextDecoder().decode(bytes))).toMatchInlineSnapshot(`
@@ -24,21 +26,129 @@ describe("ReferenceStore", () => {
 			}
 		`);
 	});
-	it("store creation can still accept a non-promise", async () => {
-		let spec = {
+
+	it("creates store from sync spec", () => {
+		let store = ReferenceStore.fromSpec({
 			version: 1,
 			refs: {
 				".zgroup": '{"zarr_format":2}',
-				".zattrs": '{"encoding-type":"anndat…oding-version":"0.1.0"}',
 			},
-		};
-		let store = ReferenceStore.fromSpec(spec);
+		});
+		// sync spec returns ReferenceStore directly, not a Promise
+		assert(store instanceof ReferenceStore);
+	});
+
+	it("returns undefined for missing keys", async () => {
+		let store = ReferenceStore.fromSpec({
+			version: 1,
+			refs: { ".zgroup": '{"zarr_format":2}' },
+		});
+		assert(store instanceof ReferenceStore);
+		let bytes = await store.get("/missing");
+		expect(bytes).toBeUndefined();
+	});
+
+	it("reads inline string entries", async () => {
+		let store = ReferenceStore.fromSpec({
+			version: 1,
+			refs: {
+				".zgroup": '{"zarr_format":2}',
+			},
+		});
+		assert(store instanceof ReferenceStore);
 		let bytes = await store.get("/.zgroup");
-		expect(bytes).toBeInstanceOf(Uint8Array);
-		expect(JSON.parse(new TextDecoder().decode(bytes))).toMatchInlineSnapshot(`
+		assert(bytes instanceof Uint8Array);
+		expect(JSON.parse(new TextDecoder().decode(bytes))).toEqual({
+			zarr_format: 2,
+		});
+	});
+
+	it("decodes base64 entries", async () => {
+		let store = ReferenceStore.fromSpec({
+			version: 1,
+			refs: {
+				// "hello" in base64
+				"data.bin": "base64:aGVsbG8=",
+			},
+		});
+		assert(store instanceof ReferenceStore);
+		let bytes = await store.get("/data.bin");
+		assert(bytes instanceof Uint8Array);
+		expect(new TextDecoder().decode(bytes)).toBe("hello");
+	});
+
+	it("fetches remote references with [url, offset, length]", async () => {
+		// zarr.json starts with '{\n  "attributes": {},'
+		// first 22 bytes: '{\n  "attributes": {},'
+		let store = ReferenceStore.fromSpec({
+			version: 1,
+			refs: {
+				"meta.bin": [zarrJsonUrl, 0, 99],
+			},
+		});
+		assert(store instanceof ReferenceStore);
+		let bytes = await store.get("/meta.bin");
+		assert(bytes instanceof Uint8Array);
+		let text = new TextDecoder().decode(bytes);
+		expect(JSON.parse(text)).toEqual({
+			attributes: {},
+			zarr_format: 3,
+			consolidated_metadata: null,
+			node_type: "group",
+		});
+	});
+
+	it("composes range with remote reference offset", async () => {
+		// Reference points at the full 99-byte file.
+		// getRange with offset: 0, length: 20 should return first 20 bytes.
+		let store = ReferenceStore.fromSpec({
+			version: 1,
+			refs: {
+				"meta.bin": [zarrJsonUrl, 0, 99],
+			},
+		});
+		assert(store instanceof ReferenceStore);
+		let bytes = await store.getRange("/meta.bin", { offset: 0, length: 20 });
+		assert(bytes instanceof Uint8Array);
+		expect(bytes.length).toBe(20);
+		let text = new TextDecoder().decode(bytes);
+		expect(text).toMatchInlineSnapshot(`"{\n  "attributes": {}"`);
+	});
+
+	it("uses custom fetch for remote references", async () => {
+		let customFetch = vi.fn((request: Request) => fetch(request));
+		let store = ReferenceStore.fromSpec(
 			{
-			  "zarr_format": 2,
-			}
-		`);
+				version: 1,
+				refs: {
+					"meta.bin": [zarrJsonUrl, 0, 99],
+				},
+			},
+			{ fetch: customFetch },
+		);
+		assert(store instanceof ReferenceStore);
+		await store.get("/meta.bin");
+		expect(customFetch).toHaveBeenCalledOnce();
+		let request = customFetch.mock.calls[0][0];
+		assert(request instanceof Request);
+		expect(request.headers.get("Range")).toBe("bytes=0-98");
+	});
+
+	it("does not call custom fetch for inline entries", async () => {
+		let customFetch = vi.fn((request: Request) => fetch(request));
+		let store = ReferenceStore.fromSpec(
+			{
+				version: 1,
+				refs: {
+					".zgroup": '{"zarr_format":2}',
+					"data.bin": "base64:aGVsbG8=",
+				},
+			},
+			{ fetch: customFetch },
+		);
+		assert(store instanceof ReferenceStore);
+		await store.get("/.zgroup");
+		await store.get("/data.bin");
+		expect(customFetch).not.toHaveBeenCalled();
 	});
 });

--- a/packages/@zarrita-storage/src/ref.ts
+++ b/packages/@zarrita-storage/src/ref.ts
@@ -1,110 +1,259 @@
 import { parse } from "reference-spec-reader";
-import type { AbsolutePath, AsyncReadable } from "./types.js";
-import { fetchRange, mergeInit, stripPrefix, uri2href } from "./util.js";
+import type { FetchStoreOptions } from "./fetch.js";
+import FetchStore from "./fetch.js";
+import type { AbsolutePath, AsyncReadable, RangeQuery } from "./types.js";
+import { resolveUri } from "./util.js";
 
 /**
- * This is for the "binary" loader (custom code is ~2x faster than "atob") from esbuild.
+ * Decode base64 to bytes. Uses Uint8Array.fromBase64 when available (ES2025),
+ * falls back to a custom decoder from esbuild.
  * https://github.com/evanw/esbuild/blob/150a01844d47127c007c2b1973158d69c560ca21/internal/runtime/runtime.go#L185
  */
-let table = new Uint8Array(128);
-for (let i = 0; i < 64; i++) {
-	table[i < 26 ? i + 65 : i < 52 ? i + 71 : i < 62 ? i - 4 : i * 4 - 205] = i;
-}
-export function toBinary(base64: string): Uint8Array {
-	const n = base64.length;
-	const bytes = new Uint8Array(
-		// @ts-expect-error
-		(((n - (base64[n - 1] === "=") - (base64[n - 2] === "=")) * 3) / 4) | 0,
-	);
-	for (let i = 0, j = 0; i < n; ) {
-		const c0 = table[base64.charCodeAt(i++)];
-		const c1 = table[base64.charCodeAt(i++)];
-		const c2 = table[base64.charCodeAt(i++)];
-		const c3 = table[base64.charCodeAt(i++)];
-		bytes[j++] = (c0 << 2) | (c1 >> 4);
-		bytes[j++] = (c1 << 4) | (c2 >> 2);
-		bytes[j++] = (c2 << 6) | c3;
-	}
-	return bytes;
-}
+const toBinary: (base64: string) => Uint8Array<ArrayBuffer> =
+	typeof Uint8Array.fromBase64 === "function"
+		? (s: string) => Uint8Array.fromBase64(s)
+		: (() => {
+				let table = new Uint8Array(128);
+				for (let i = 0; i < 64; i++) {
+					table[
+						i < 26 ? i + 65 : i < 52 ? i + 71 : i < 62 ? i - 4 : i * 4 - 205
+					] = i;
+				}
+				return (base64: string) => {
+					const n = base64.length;
+					const bytes = new Uint8Array(
+						// @ts-expect-error
+						(((n - (base64[n - 1] === "=") - (base64[n - 2] === "=")) * 3) /
+							4) |
+							0,
+					);
+					for (let i = 0, j = 0; i < n; ) {
+						const c0 = table[base64.charCodeAt(i++)];
+						const c1 = table[base64.charCodeAt(i++)];
+						const c2 = table[base64.charCodeAt(i++)];
+						const c3 = table[base64.charCodeAt(i++)];
+						bytes[j++] = (c0 << 2) | (c1 >> 4);
+						bytes[j++] = (c1 << 4) | (c2 >> 2);
+						bytes[j++] = (c2 << 6) | c3;
+					}
+					return bytes;
+				};
+			})();
 
-type ReferenceEntry =
+/** A resolved reference entry — base64 strings are decoded upfront. */
+type ResolvedEntry =
+	| Uint8Array<ArrayBuffer>
 	| string
 	| [url: string | null]
 	| [url: string | null, offset: number, length: number];
 
 interface ReferenceStoreOptions {
 	target?: string | URL;
+	/**
+	 * A custom fetch handler, same as {@link FetchStoreOptions.fetch}.
+	 * Covers both the spec load (via {@link ReferenceStore.fromUrl}) and
+	 * all chunk fetches.
+	 */
+	fetch?: FetchStoreOptions["fetch"];
+	/**
+	 * @deprecated Prefer providing a custom {@link ReferenceStoreOptions.fetch}.
+	 */
 	overrides?: RequestInit;
 }
 
-/** @experimental */
+/**
+ * Compose a caller's Range header with a reference entry's byte window.
+ *
+ * The incoming range (from FetchStore's getRange) is relative to the key's
+ * logical data. The entry's offset/length is relative to the remote file.
+ */
+function composeRange(
+	range: string | null,
+	offset: number,
+	length: number,
+): string {
+	const end = offset + length;
+	let start: number;
+	let stop: number;
+
+	if (!range) {
+		start = offset;
+		stop = end - 1;
+	} else if (range.startsWith("bytes=-")) {
+		const n = Number.parseInt(range.slice(7), 10);
+		start = end - Math.min(n, length);
+		stop = end - 1;
+	} else {
+		const [s, e] = range.slice(6).split("-").map(Number);
+		start = offset + s;
+		stop = Math.min(offset + e, end - 1);
+	}
+
+	if (start < offset || start > stop) {
+		throw new Error(
+			`Range out of bounds: requested ${range} for entry at offset=${offset}, length=${length}`,
+		);
+	}
+
+	return `bytes=${start}-${stop}`;
+}
+
+/** Default fetch that translates `s3://` and `gc://` URIs to HTTPS. */
+function defaultFetch(request: Request): Promise<Response> {
+	const href = resolveUri(request.url);
+	if (href !== request.url) {
+		return fetch(new Request(href, request));
+	}
+	return fetch(request);
+}
+
+/**
+ * Decode base64 entries upfront into Uint8Array. Saves ~2.5x memory
+ * (base64 string as UTF-16 vs raw bytes) and avoids decoding on every access.
+ */
+function parseReferencesJson(refsJson: unknown): Map<string, ResolvedEntry> {
+	// @ts-expect-error - TS doesn't like the type of `parse`
+	const refs = parse(refsJson);
+	const resolved = new Map<string, ResolvedEntry>();
+	for (const [key, ref] of refs) {
+		if (typeof ref === "string" && ref.startsWith("base64:")) {
+			resolved.set(key, toBinary(ref.slice(7)));
+		} else {
+			resolved.set(key, ref);
+		}
+	}
+	return resolved;
+}
+
+/**
+ * A store backed by a
+ * [kerchunk reference spec](https://fsspec.github.io/kerchunk/spec.html),
+ * enabling random access to data in monolithic files (HDF5, TIFF, etc.)
+ * that have been mapped to Zarr.
+ *
+ * Uses {@link FetchStore} internally. The default fetch handler translates
+ * cloud-storage URIs (`s3://`, `gs://`, `gcs://`) to HTTPS via
+ * {@link ReferenceStore.resolveUri}. Inline entries (plain strings and
+ * base64) are served directly without making any network requests.
+ *
+ * @example Basic usage
+ * ```ts
+ * const store = await ReferenceStore.fromUrl("https://example.com/refs.json");
+ * const arr = await zarr.open(store);
+ * ```
+ *
+ * @example Custom fetch with auth
+ * ```ts
+ * const store = await ReferenceStore.fromUrl("https://example.com/refs.json", {
+ *   async fetch(request) {
+ *     const url = ReferenceStore.resolveUri(request.url);
+ *     const req = new Request(url, request);
+ *     req.headers.set("Authorization", `Bearer ${await getToken()}`);
+ *     return fetch(req);
+ *   },
+ * });
+ * ```
+ *
+ * @example Opt out of default URI translation
+ * ```ts
+ * const store = await ReferenceStore.fromUrl("https://example.com/refs.json", {
+ *   fetch: (request) => fetch(request),
+ * });
+ * ```
+ *
+ * @experimental
+ */
 class ReferenceStore implements AsyncReadable<RequestInit> {
-	#refs: Promise<Map<string, ReferenceEntry>>;
-	#opts: ReferenceStoreOptions;
-	#overrides: RequestInit;
+	#inner: FetchStore;
 
 	constructor(
-		refs: Promise<Map<string, ReferenceEntry>> | Map<string, ReferenceEntry>,
+		refs: Map<string, ResolvedEntry>,
 		opts: ReferenceStoreOptions = {},
 	) {
-		this.#refs = Promise.resolve(refs);
-		this.#opts = opts;
-		this.#overrides = opts.overrides || {};
+		const target = opts.target;
+		const fetchFn = opts.fetch ?? defaultFetch;
+
+		this.#inner = new FetchStore(target ?? "https://ref.invalid", {
+			overrides: opts.overrides,
+			async fetch(request) {
+				const key = new URL(request.url).pathname.slice(1);
+				const ref = refs.get(key);
+
+				if (!ref) {
+					return new Response(null, { status: 404 });
+				}
+
+				if (ref instanceof Uint8Array) {
+					return new Response(ref, { status: 200 });
+				}
+
+				if (typeof ref === "string") {
+					return new Response(ref);
+				}
+
+				const [url, offset, length] = ref;
+				const resolved = url ?? target;
+				if (!resolved) {
+					return new Response(null, { status: 404 });
+				}
+
+				const newRequest = new Request(String(resolved), request);
+				const range = composeRange(
+					request.headers.get("Range"),
+					offset ?? 0,
+					length ?? 0,
+				);
+				newRequest.headers.set("Range", range);
+				return fetchFn(newRequest);
+			},
+		});
 	}
 
-	async get(
+	get(key: AbsolutePath, opts?: RequestInit): Promise<Uint8Array | undefined> {
+		return this.#inner.get(key, opts);
+	}
+
+	getRange(
 		key: AbsolutePath,
-		opts: RequestInit = {},
+		range: RangeQuery,
+		opts?: RequestInit,
 	): Promise<Uint8Array | undefined> {
-		let ref = (await this.#refs).get(stripPrefix(key));
-
-		if (!ref) return;
-
-		if (typeof ref === "string") {
-			if (ref.startsWith("base64:")) {
-				return toBinary(ref.slice("base64:".length));
-			}
-			return new TextEncoder().encode(ref);
-		}
-
-		let [urlOrNull, offset, size] = ref;
-		let url = urlOrNull ?? this.#opts.target;
-		if (!url) {
-			throw Error(`No url for key ${key}, and no target url provided.`);
-		}
-
-		let res = await fetchRange(
-			uri2href(url),
-			offset,
-			size,
-			mergeInit(this.#overrides, opts),
-		);
-
-		if (res.status === 200 || res.status === 206) {
-			return new Uint8Array(await res.arrayBuffer());
-		}
-
-		throw new Error(
-			`Request unsuccessful for key ${key}. Response status: ${res.status}.`,
-		);
+		return this.#inner.getRange(key, range, opts);
 	}
 
+	/**
+	 * Translate `s3://` and `gc://` URIs to HTTPS URLs.
+	 * Useful when writing a custom `fetch` handler for reference stores
+	 * whose entries contain cloud-specific URIs.
+	 */
+	static resolveUri = resolveUri;
+
+	static fromSpec(
+		spec: Record<string, unknown>,
+		opts?: ReferenceStoreOptions,
+	): ReferenceStore;
+	static fromSpec(
+		spec: Promise<Record<string, unknown>>,
+		opts?: ReferenceStoreOptions,
+	): Promise<ReferenceStore>;
 	static fromSpec(
 		spec: Promise<Record<string, unknown>> | Record<string, unknown>,
 		opts?: ReferenceStoreOptions,
-	): ReferenceStore {
-		// @ts-expect-error - TS doesn't like the type of `parse`
-		let refs = Promise.resolve(spec).then((spec) => parse(spec));
-		return new ReferenceStore(refs, opts);
+	): ReferenceStore | Promise<ReferenceStore> {
+		if (spec instanceof Promise) {
+			return spec.then((s) => new ReferenceStore(parseReferencesJson(s), opts));
+		}
+		return new ReferenceStore(parseReferencesJson(spec), opts);
 	}
 
-	static fromUrl(
+	static async fromUrl(
 		url: string | URL,
-		opts?: ReferenceStoreOptions,
-	): ReferenceStore {
-		let spec = fetch(url, opts?.overrides).then((res) => res.json());
-		return ReferenceStore.fromSpec(spec, opts);
+		opts: ReferenceStoreOptions = {},
+	): Promise<ReferenceStore> {
+		const fetchFn = opts.fetch ?? defaultFetch;
+		const resp = await fetchFn(new Request(url));
+		const refs = parseReferencesJson(await resp.json());
+		return new ReferenceStore(refs, opts);
 	}
 }
 

--- a/packages/@zarrita-storage/src/util.ts
+++ b/packages/@zarrita-storage/src/util.ts
@@ -7,20 +7,27 @@ export function stripPrefix<Path extends AbsolutePath>(
 	return path.slice(1);
 }
 
-export function uri2href(url: string | URL) {
-	let [protocol, rest] = (typeof url === "string" ? url : url.href).split(
-		"://",
-	);
-	if (protocol === "https" || protocol === "http") {
-		return url;
+/** Maps cloud-storage URI protocols to their HTTPS hosts. */
+const PROTOCOL_HOSTS: Record<string, string> = {
+	"gs:": "storage.googleapis.com",
+	"gcs:": "storage.googleapis.com",
+	"s3:": "s3.amazonaws.com",
+};
+
+/**
+ * Translate cloud-storage URIs (`s3://`, `gs://`, `gcs://`) to HTTPS URLs.
+ * HTTP(S) URLs are returned as-is.
+ */
+export function resolveUri(url: string | URL): string {
+	const href = typeof url === "string" ? url : url.href;
+	const colon = href.indexOf("://");
+	if (colon === -1) return href;
+	const protocol = href.slice(0, colon + 1);
+	const host = PROTOCOL_HOSTS[protocol];
+	if (host) {
+		return `https://${host}/${href.slice(colon + 3)}`;
 	}
-	if (protocol === "gc") {
-		return `https://storage.googleapis.com/${rest}`;
-	}
-	if (protocol === "s3") {
-		return `https://s3.amazonaws.com/${rest}`;
-	}
-	throw Error(`Protocol not supported, got: ${JSON.stringify(protocol)}`);
+	return href;
 }
 
 export function fetchRange(


### PR DESCRIPTION
`ReferenceStore` now uses `FetchStore` internally with a custom fetch handler that resolves reference entries. The reference lookup, inline data handling, and remote range composition all happen inside the fetch handler, so `ReferenceStore` gets the same `fetch` option as `FetchStore` for free. Auth, presigning, and URI translation are configured once and cover both the spec load and all chunk fetches.

```ts
const store = await ReferenceStore.fromUrl("https://example.com/refs.json", {
  async fetch(request) {
    const url = ReferenceStore.resolveUri(request.url);
    const req = new Request(url, request);
    req.headers.set("Authorization", `Bearer ${await getToken()}`);
    return fetch(req);
  },
});
```

`getRange` is now supported via `composeRange`, which translates caller-relative byte ranges into absolute offsets within the remote file.