### PR TITLE
Add v0.7 migration guide

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -46,6 +46,11 @@ export default defineConfig({
 					{ text: "@zarrita/ndarray", link: "/packages/ndarray" },
 				],
 			},
+			{
+				text: "Migration",
+				collapsed: false,
+				items: [{ text: "v0.7 (preview)", link: "/migration/v0.7" }],
+			},
 		],
 		socialLinks: [
 			{ icon: "github", link: "https://github.com/manzt/zarrita.js" },

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,5 +1,10 @@
 # Getting Started
 
+::: tip Upgrading from v0.6?
+v0.7.0 contains one breaking change and one deprecation. See the
+[v0.7 migration guide](/migration/v0.7) for details.
+:::
+
 **zarrita** supports a variety of environments, including the browser, Node.js,
 and Deno.
 

--- a/docs/migration/v0.7.md
+++ b/docs/migration/v0.7.md
@@ -1,0 +1,280 @@
+# Migrating to Zarrita v0.7.0
+
+**This release deliberately contains backwards-incompatible changes.**
+To avoid automatically picking up releases like this, you should either
+pin the exact version of `zarrita` in your `package.json` file
+(recommended) or use a version range that only accepts patch upgrades
+such as `~0.7.0`.
+
+There is one hard break and one deprecation in v0.7.0. Both touch
+parts of the API that had accumulated awkwardness over previous
+releases: snake_case options leaking out of [`zarr.create`](#zarr-create-options-are-camelcase),
+and [the `overrides` escape hatch on `FetchStore`](#fetchstore-s-overrides-option-is-deprecated-in-favor-of-fetch)
+forcing auth logic to leak into every call site. Neither was pleasant
+to use, and both were places where zarrita was asking you to work
+around the library instead of the library working for you.
+
+This release fixes both. The rest of the release is additive:
+cancellation with [`AbortSignal`](#cancellation-with-abortsignal),
+[named-dimension selection](#named-dimension-selection),
+[v3 consolidated metadata](#v3-consolidated-metadata-experimental),
+[request batching](#request-batching-with-withrangebatching),
+a first-class [`fillValue` getter](#also-new), and a handful of
+[bug fixes](#bug-fixes).
+
+## TL;DR
+
+- **Breaking**: [`zarr.create` options are now camelCase](#zarr-create-options-are-camelcase).
+- **Deprecated**: [`FetchStore`'s `overrides` option](#fetchstore-s-overrides-option-is-deprecated-in-favor-of-fetch);
+  use the new `fetch` option instead.
+- **New**: [custom `fetch`](#custom-fetch-on-fetchstore),
+  [`AbortSignal` cancellation](#cancellation-with-abortsignal),
+  [named-dimension selection (`sel`)](#named-dimension-selection),
+  [v3 consolidated metadata](#v3-consolidated-metadata-experimental),
+  [request batching](#request-batching-with-withrangebatching), and more.
+- **Fixes**: [NaN/Inf fill values, scalar `get`/`set`, boolean
+  narrowing, browser autodetect](#bug-fixes).
+
+## What's new
+
+### Custom `fetch` on `FetchStore`
+
+`FetchStore` now accepts a [WinterTC](https://wintertc.org/)-style
+`fetch` handler ([`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request)
+in, [`Response`](https://developer.mozilla.org/en-US/docs/Web/API/Response)
+out). This is the recommended way to cover the long tail of things
+you might need at the fetch level: auth, presigning, header
+injection, response remapping, caching, retries. Because it is a
+real function you configure once on the store, every outgoing
+request picks it up and the rest of your code does not have to
+know about it.
+
+**Attaching an auth token**:
+
+```ts
+const store = new FetchStore("https://example.com/data.zarr", {
+  async fetch(request) {
+    const token = await getAccessToken();
+    request.headers.set("Authorization", `Bearer ${token}`);
+    return fetch(request);
+  },
+});
+```
+
+**Presigning a URL** (for example, against an S3 bucket that
+requires signed URLs):
+
+```ts
+const store = new FetchStore("https://my-bucket.s3.amazonaws.com/data.zarr", {
+  async fetch(request) {
+    const signedUrl = await presign(request.url);
+    return fetch(new Request(signedUrl, request));
+  },
+});
+```
+
+**Remapping response status codes** (useful when a backend returns
+`403` for missing chunks where zarrita expects `404`):
+
+```ts
+const store = new FetchStore("https://my-bucket.s3.amazonaws.com/data.zarr", {
+  async fetch(request) {
+    const response = await fetch(request);
+    if (response.status === 403) {
+      return new Response(null, { status: 404 });
+    }
+    return response;
+  },
+});
+```
+
+See [the deprecation section below](#fetchstore-s-overrides-option-is-deprecated-in-favor-of-fetch)
+for the full migration story from `overrides`.
+
+### Cancellation with `AbortSignal`
+
+`open`, `get`, and `set` now accept an [`AbortSignal`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal).
+Signals are forwarded to the underlying store and checked between
+async steps so in-flight work can be cancelled cleanly.
+
+```ts
+const controller = new AbortController();
+await zarr.get(arr, [null], { opts: { signal: controller.signal } });
+```
+
+### Named-dimension selection
+
+`Array` now exposes a `dimensionNames` getter (v3 metadata, or
+`_ARRAY_DIMENSIONS` on v2), and the new `sel` helper converts a
+record of dimension names into a positional selection array:
+
+```ts
+// arr.dimensionNames -> ["time", "lat", "lon"]
+let selection = zarr.sel(arr, { lat: zarr.slice(100, 200), time: 0 });
+let result = await zarr.get(arr, selection);
+```
+
+### v3 consolidated metadata (experimental)
+
+`withConsolidated` now supports Zarr v3, reading `consolidated_metadata`
+from the root `zarr.json` to match [zarr-python](https://github.com/zarr-developers/zarr-python).
+A new `format` option controls which format(s) to try, accepting a
+single string or an array for fallback ordering:
+
+```ts
+await withConsolidated(store);                           // auto-detect
+await withConsolidated(store, { format: ["v3", "v2"] }); // v3, fall back to v2
+```
+
+Note: v3 consolidated metadata is [not yet part of the official Zarr v3 spec](https://github.com/zarr-developers/zarr-specs/issues/309)
+and should be considered experimental.
+
+### Request batching with `withRangeBatching`
+
+Wrap any store to coalesce concurrent range reads into fewer HTTP
+requests, a significant win for many-small-chunk workloads. Use
+`mergeOptions` to combine per-caller options (for example,
+[`AbortSignal.any`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/any_static))
+across a batch.
+
+### Also new
+
+- **`fillValue` getter** on `Array`, with proper handling of
+  `NaN`/`Infinity`/`-Infinity` across v2 and v3.
+- **`dimensionNames` in `create`**, and exposed on the array itself.
+- **`numcodecs.*` namespace** for the v2 codec registry, matching
+  [zarr-python's convention](https://numcodecs.readthedocs.io/).
+  Built-in `numcodecs.shuffle` and `numcodecs.delta` ship out of
+  the box (pure JS, no WASM). Custom v2 codecs register under the
+  same prefix.
+- **`bigint` in `slice()`** for addressing large dimensions.
+- **`attrs` option in top-level `open()`** to skip `.zattrs` loading
+  for v2 stores.
+- **Source maps to TypeScript** (`declarationMap`) so "go to
+  definition" resolves to `.ts` source instead of `.d.ts`.
+
+## Breaking change
+
+### `zarr.create` options are camelCase
+
+The rest of zarrita's public API is camelCase (`FetchStore`,
+`withConsolidated`, `dimensionNames`, and so on), but `zarr.create`
+had historically taken its options in snake_case because the option
+names were passed through more or less directly to the on-disk Zarr
+metadata, which itself is snake_case. This meant that any code that
+both read and wrote arrays ended up mixing cases, and anyone new to
+the library had to remember which side of the library they were on
+before they knew what to type.
+
+With this release, `zarr.create` options are camelCase, and
+`data_type` is now called `dtype` to match the name zarrita uses
+everywhere else. Internally, zarrita still writes out the correct
+snake_case field names into the stored metadata, so there is no
+change to the on-disk format. This only affects the
+TypeScript/JavaScript API.
+
+```diff
+  await zarr.create(store, {
+-   data_type: "float32",
++   dtype: "float32",
+    shape: [100, 100],
+-   chunk_shape: [10, 10],
++   chunkShape: [10, 10],
+-   chunk_separator: "/",
++   chunkSeparator: "/",
+-   fill_value: 0,
++   fillValue: 0,
+-   dimension_names: ["y", "x"],
++   dimensionNames: ["y", "x"],
+  });
+```
+
+TypeScript will flag every callsite that needs updating. If you are
+calling `zarr.create` from untyped JavaScript, note that the old
+snake_case fields are silently ignored rather than rejected, so a
+missed rename will write an incomplete `zarr.json` to disk. We
+recommend running your write paths once against a throwaway store
+after upgrading to catch any stragglers.
+
+## Deprecation
+
+### `FetchStore`'s `overrides` option is deprecated in favor of `fetch`
+
+`FetchStore` has historically accepted an `overrides` option, which
+was a static [`RequestInit`](https://developer.mozilla.org/en-US/docs/Web/API/RequestInit)
+object that was merged into every outgoing HTTP request. This covered
+the easy case (a fixed header) but fell over the moment anything had
+to be computed per request. The most common example is an auth token
+that needs to be refreshed: because `overrides` is static, there was
+no way to hook a token refresh into the store itself, and the token
+had to be passed through `zarr.get`'s `opts` parameter at every call
+site.
+
+This meant that adding auth to a zarrita app required threading the
+auth concern through every place that touched the store:
+
+```ts
+// Before: auth logic threaded through every get
+const store = new FetchStore("https://example.com/data.zarr");
+const arr = await zarr.open(store);
+
+let chunk = await zarr.get(arr, null, {
+  opts: { headers: { Authorization: `Bearer ${await getAccessToken()}` } },
+});
+```
+
+With this release, `FetchStore` accepts a `fetch` option that takes
+a [WinterTC](https://wintertc.org/)-style fetch handler (a function
+from [`Request`](https://developer.mozilla.org/en-US/docs/Web/API/Request)
+to [`Promise<Response>`](https://developer.mozilla.org/en-US/docs/Web/API/Response)).
+Because it is a real function, it can do anything the platform's
+[`fetch`](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API)
+can do: refresh tokens, presign URLs, rewrite response status codes,
+add caching, swap out the underlying transport, and so on. And
+because it lives on the store, the rest of your code does not have
+to know about it.
+
+```ts
+// After: call sites don't need to know about auth
+const store = new FetchStore("https://example.com/data.zarr", {
+  async fetch(request) {
+    const token = await getAccessToken();
+    request.headers.set("Authorization", `Bearer ${token}`);
+    return fetch(request);
+  },
+});
+const arr = await zarr.open(store);
+
+let chunk = await zarr.get(arr);
+```
+
+`overrides` still works in v0.7.x and will be removed in a future
+major release. If you are using it today, we recommend moving to
+`fetch` when you upgrade. If all you were doing with `overrides` was
+setting a static header, the migration is one line:
+
+```ts
+// Before
+new FetchStore(url, { overrides: { headers: { "X-Api-Key": key } } });
+
+// After
+new FetchStore(url, {
+  fetch(request) {
+    request.headers.set("X-Api-Key", key);
+    return fetch(request);
+  },
+});
+```
+
+## Bug fixes
+
+- **Fill values**: `NaN`, `Infinity`, and `-Infinity` now round-trip
+  correctly per the Zarr v3 spec.
+- **Scalar arrays**: `get` and `set` now work for `shape=[]`.
+- **Version autodetect**: `zarr.open` no longer fails in browsers
+  when servers return non-JSON responses for v2 metadata keys.
+- **`NarrowDataType`** correctly narrows the `"boolean"` query to `Bool`.
+
+## Under the hood
+
+- `unzipit` upgraded from 1.4.3 to 2.0.0.

--- a/docs/migration/v0.7.md
+++ b/docs/migration/v0.7.md
@@ -17,6 +17,8 @@ around the library instead of the library working for you.
 This release fixes both. The rest of the release is additive:
 cancellation with [`AbortSignal`](#cancellation-with-abortsignal),
 [named-dimension selection](#named-dimension-selection),
+a new [composable extension system](#composable-store-and-array-extensions)
+that unifies store and array wrappers behind a single pattern,
 [v3 consolidated metadata](#v3-consolidated-metadata-experimental),
 [request batching](#request-batching-with-withrangebatching),
 a first-class [`fillValue` getter](#also-new), and a handful of
@@ -30,6 +32,8 @@ a first-class [`fillValue` getter](#also-new), and a handful of
 - **New**: [custom `fetch`](#custom-fetch-on-fetchstore),
   [`AbortSignal` cancellation](#cancellation-with-abortsignal),
   [named-dimension selection (`sel`)](#named-dimension-selection),
+  [composable store and array extensions](#composable-store-and-array-extensions)
+  (`defineStoreExtension`, `defineArrayExtension`),
   [v3 consolidated metadata](#v3-consolidated-metadata-experimental),
   [request batching](#request-batching-with-withrangebatching), and more.
 - **Fixes**: [NaN/Inf fill values, scalar `get`/`set`, boolean
@@ -99,7 +103,7 @@ async steps so in-flight work can be cancelled cleanly.
 
 ```ts
 const controller = new AbortController();
-await zarr.get(arr, [null], { opts: { signal: controller.signal } });
+await zarr.get(arr, [null], { signal: controller.signal });
 ```
 
 ### Named-dimension selection
@@ -114,16 +118,157 @@ let selection = zarr.sel(arr, { lat: zarr.slice(100, 200), time: 0 });
 let result = await zarr.get(arr, selection);
 ```
 
-### v3 consolidated metadata (experimental)
+### Composable store and array extensions
 
-`withConsolidated` now supports Zarr v3, reading `consolidated_metadata`
-from the root `zarr.json` to match [zarr-python](https://github.com/zarr-developers/zarr-python).
-A new `format` option controls which format(s) to try, accepting a
-single string or an array for fallback ordering:
+Before v0.7, anything that wanted to layer behavior on top of a store —
+byte caching, consolidated metadata, range batching, auth remapping,
+virtual-format adapters — had to subclass `FetchStore` or hand-roll an
+`AsyncReadable`. Chunk-level concerns (chunk caching, prefetch priority,
+observability) had nowhere to live at all, because there was no
+extension point on `Array` itself. People smuggled them through the
+now-removed `Options` generic or replaced `Array` with a bare `Proxy`.
+
+v0.7 introduces two symmetric, composable extension points — one for
+each concern — built from the same factory-plus-`Proxy` primitive:
+
+| Layer | Intercepts | Primitive | Composer |
+| --- | --- | --- | --- |
+| Transport | `store.get(key, range)` | `zarr.defineStoreExtension` | `zarr.extendStore` |
+| Data | `array.getChunk(coords)` | `zarr.defineArrayExtension` | `zarr.extendArray` |
+
+**Store extensions** are for transport concerns: anything that deals in
+paths and bytes. **Array extensions** are for data concerns: anything
+that deals in chunk coordinates. The factory receives the inner value
+(store or array) and user options, and returns an object of method
+overrides and any new fields to expose. Anything not returned is
+delegated to the inner value through a `Proxy`, so instance state —
+private fields on `FetchStore`, metadata getters on `Array` — keeps
+working through the wrapper. Both composers handle sync and async
+factories uniformly.
+
+Here is a small store extension that caches bytes, followed by a small
+array extension that caches decoded chunks. They wrap at different
+layers and serve different workloads: the byte cache short-circuits the
+transport, the chunk cache short-circuits decoding.
 
 ```ts
-await withConsolidated(store);                           // auto-detect
-await withConsolidated(store, { format: ["v3", "v2"] }); // v3, fall back to v2
+const withByteCache = zarr.defineStoreExtension(
+  (store, opts: { maxSize?: number } = {}) => {
+    let cache = new Map<zarr.AbsolutePath, Uint8Array>();
+    return {
+      async get(key, options) {
+        let hit = cache.get(key);
+        if (hit) return hit;
+        let bytes = await store.get(key, options);
+        if (bytes) cache.set(key, bytes);
+        return bytes;
+      },
+      clear() { cache.clear(); },
+    };
+  },
+);
+
+const withChunkCache = zarr.defineArrayExtension(
+  (array, opts: { cache: Map<string, zarr.Chunk<zarr.DataType>> }) => ({
+    async getChunk(coords, options) {
+      let key = coords.join(",");
+      let hit = opts.cache.get(key);
+      if (hit) return hit;
+      let chunk = await array.getChunk(coords, options);
+      opts.cache.set(key, chunk);
+      return chunk;
+    },
+  }),
+);
+```
+
+Compose extensions in a pipeline with `extendStore` / `extendArray`.
+Each step wraps the previous one, and any async factory (like
+`withConsolidation`, which fetches metadata during initialization) is
+handled automatically:
+
+```ts
+let store = await zarr.extendStore(
+  new zarr.FetchStore("https://example.com/data.zarr"),
+  zarr.withConsolidation,
+  (s) => zarr.withRangeBatching(s, { cacheSize: 512 }),
+  (s) => withByteCache(s),
+);
+```
+
+Both extensions that ship with v0.7 — `zarr.withConsolidation` (covered
+[below](#v3-consolidated-metadata-experimental)) and
+`zarr.withRangeBatching` ([also below](#request-batching-with-withrangebatching))
+— are built on `defineStoreExtension`. They are the first concrete
+store extensions, not one-offs. The full API reference lives in
+[the store extensions docs](/store-extensions).
+
+#### Auto-applying array extensions from a store
+
+A store extension can also declare an `arrayExtensions` field on its
+factory result. `zarr.open` reads that list from the composed store and
+wraps every `zarr.Array` it returns with those extensions — so
+downstream consumers don't need to call `zarr.extendArray` at each
+call site.
+
+This is the enabling primitive for **virtual-format adapters** —
+projects like
+[`hdf5-as-virtual-zarr`](https://github.com/keller-mark/hdf5-as-virtual-zarr.js),
+[`tiff-as-virtual-zarr`](https://github.com/keller-mark/tiff-as-virtual-zarr.js),
+and
+[`parquet-as-virtual-zarr`](https://github.com/keller-mark/parquet-as-virtual-zarr.js)
+that need to synthesize metadata at the transport layer and supply
+decoded chunks at the data layer from a single factory with shared
+closure state:
+
+```ts
+const hdf5VirtualZarr = zarr.defineStoreExtension(
+  (inner, opts: { root: string }) => {
+    let parsed = parseHdf5(opts.root); // shared between get and getChunk
+    return {
+      async get(key, options) {
+        if (isVirtualMetadataKey(key, parsed)) {
+          return synthesizeJson(key, parsed);
+        }
+        return inner.get(key, options);
+      },
+      arrayExtensions: [
+        zarr.defineArrayExtension((_inner) => ({
+          async getChunk(coords) { return parsed.readChunk(coords); },
+        })),
+      ],
+    };
+  },
+);
+
+let store = await zarr.extendStore(raw, (s) =>
+  hdf5VirtualZarr(s, { root: "/my_image" }),
+);
+
+// Downstream code doesn't know the adapter exists. It opens and reads.
+let arr = await zarr.open(store, { kind: "array", path: "/my_image" });
+await zarr.get(arr, [null, zarr.slice(0, 10)]);
+```
+
+When store extensions are stacked, each layer's `arrayExtensions` are
+merged inner-first, outer-last — symmetric with how the store
+extensions themselves compose. Groups don't need special handling:
+nested `zarr.open(group.resolve("child"))` still picks up the wrapping,
+because the store reference flows through and each Array-producing
+`open` call reads the list on its own.
+
+### v3 consolidated metadata (experimental)
+
+`zarr.withConsolidation` is a store extension (see
+[above](#composable-store-and-array-extensions)), and now supports Zarr
+v3, reading `consolidated_metadata` from the root `zarr.json` to match
+[zarr-python](https://github.com/zarr-developers/zarr-python). A new
+`format` option controls which format(s) to try, accepting a single
+string or an array for fallback ordering:
+
+```ts
+await withConsolidation(store);                           // auto-detect
+await withConsolidation(store, { format: ["v3", "v2"] }); // v3, fall back to v2
 ```
 
 Note: v3 consolidated metadata is [not yet part of the official Zarr v3 spec](https://github.com/zarr-developers/zarr-specs/issues/309)
@@ -131,11 +276,24 @@ and should be considered experimental.
 
 ### Request batching with `withRangeBatching`
 
-Wrap any store to coalesce concurrent range reads into fewer HTTP
-requests, a significant win for many-small-chunk workloads. Use
-`mergeOptions` to combine per-caller options (for example,
-[`AbortSignal.any`](https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal/any_static))
-across a batch.
+`zarr.withRangeBatching` is a store extension (see
+[above](#composable-store-and-array-extensions)) that wraps any store
+to coalesce concurrent range reads into fewer HTTP requests — a
+significant win for many-small-chunk workloads. Compose it with
+`extendStore` alongside other store extensions:
+
+```ts
+let store = await zarr.extendStore(
+  new zarr.FetchStore("https://example.com/data.zarr"),
+  (s) => zarr.withRangeBatching(s, {
+    // Collapse per-caller options across a batch. `AbortSignal.any`
+    // means the combined request is cancelled if any caller bails.
+    mergeOptions: (batch) => ({
+      signal: AbortSignal.any(batch.map((o) => o.signal).filter(Boolean)),
+    }),
+  }),
+);
+```
 
 ### Also new
 
@@ -158,7 +316,7 @@ across a batch.
 ### `zarr.create` options are camelCase
 
 The rest of zarrita's public API is camelCase (`FetchStore`,
-`withConsolidated`, `dimensionNames`, and so on), but `zarr.create`
+`withConsolidation`, `dimensionNames`, and so on), but `zarr.create`
 had historically taken its options in snake_case because the option
 names were passed through more or less directly to the on-disk Zarr
 metadata, which itself is snake_case. This meant that any code that


### PR DESCRIPTION
The guide covers the one breaking change (camelCase `zarr.create` options), the one deprecation (`FetchStore`'s `overrides` in favor of a custom `fetch` handler), the new additive features (AbortSignal cancellation, named-dimension selection, v3 consolidated metadata, request batching), and a short bug-fix section.