### PR TITLE
Drop `Options` generic and thread `signal` directly

### DIFF
--- a/packages/@zarrita-ndarray/src/index.ts
+++ b/packages/@zarrita-ndarray/src/index.ts
@@ -49,7 +49,7 @@ export async function get<
 >(
 	arr: zarr.Array<D, Store>,
 	selection: Sel | null = null,
-	opts: zarr.GetOptions<Parameters<Store["get"]>[1]> = {},
+	opts: zarr.GetOptions = {},
 ): Promise<
 	null extends Sel[number]
 		? ndarray.NdArray<zarr.TypedArray<D>>

--- a/packages/@zarrita-storage/src/fetch.ts
+++ b/packages/@zarrita-storage/src/fetch.ts
@@ -131,7 +131,7 @@ interface FetchStoreOptions {
  * });
  * ```
  */
-class FetchStore implements AsyncReadable<RequestInit> {
+class FetchStore implements AsyncReadable {
 	#fetch: (request: Request) => Promise<Response>;
 	#overrides: RequestInit;
 	#useSuffixRequest: boolean;

--- a/packages/@zarrita-storage/src/fs.ts
+++ b/packages/@zarrita-storage/src/fs.ts
@@ -2,7 +2,12 @@ import { Buffer } from "node:buffer";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-import type { AbsolutePath, AsyncMutable, RangeQuery } from "./types.js";
+import type {
+	AbsolutePath,
+	AsyncMutable,
+	GetOptions,
+	RangeQuery,
+} from "./types.js";
 import { stripPrefix } from "./util.js";
 
 function isErrorNoEntry(err: unknown): err is { code: "ENOENT" } {
@@ -13,18 +18,26 @@ function isErrorNoEntry(err: unknown): err is { code: "ENOENT" } {
 class FileSystemStore implements AsyncMutable {
 	constructor(public root: string) {}
 
-	async get(key: AbsolutePath): Promise<Uint8Array | undefined> {
+	async get(
+		key: AbsolutePath,
+		opts: GetOptions = {},
+	): Promise<Uint8Array | undefined> {
+		opts.signal?.throwIfAborted();
 		let fp = path.join(this.root, stripPrefix(key));
-		return fs.promises.readFile(fp).catch((err: NodeJS.ErrnoException) => {
-			if (err.code === "ENOENT") return undefined;
-			throw err;
-		});
+		return fs.promises
+			.readFile(fp, { signal: opts.signal })
+			.catch((err: NodeJS.ErrnoException) => {
+				if (err.code === "ENOENT") return undefined;
+				throw err;
+			});
 	}
 
 	async getRange(
 		key: AbsolutePath,
 		range: RangeQuery,
+		opts: GetOptions = {},
 	): Promise<Uint8Array | undefined> {
+		opts.signal?.throwIfAborted();
 		let fp = path.join(this.root, stripPrefix(key));
 		let filehandle: fs.promises.FileHandle | undefined;
 		try {
@@ -38,10 +51,12 @@ class FileSystemStore implements AsyncMutable {
 					range.suffixLength,
 					stats.size - range.suffixLength,
 				);
+				opts.signal?.throwIfAborted();
 				return data;
 			}
 			let data = Buffer.alloc(range.length);
 			await filehandle.read(data, 0, range.length, range.offset);
+			opts.signal?.throwIfAborted();
 			return data;
 		} catch (err: unknown) {
 			// return undefined is no file or directory

--- a/packages/@zarrita-storage/src/ref.ts
+++ b/packages/@zarrita-storage/src/ref.ts
@@ -163,7 +163,7 @@ function parseReferencesJson(refsJson: unknown): Map<string, ResolvedEntry> {
  *
  * @experimental
  */
-class ReferenceStore implements AsyncReadable<RequestInit> {
+class ReferenceStore implements AsyncReadable {
 	#inner: FetchStore;
 
 	constructor(

--- a/packages/@zarrita-storage/src/types.ts
+++ b/packages/@zarrita-storage/src/types.ts
@@ -9,23 +9,25 @@ export type RangeQuery =
 			suffixLength: number;
 	  };
 
-export type Readable<GetOptions = unknown> =
-	| AsyncReadable<GetOptions>
-	| SyncReadable<GetOptions>;
-export interface AsyncReadable<Options = unknown> {
-	get(key: AbsolutePath, opts?: Options): Promise<Uint8Array | undefined>;
+export interface GetOptions {
+	signal?: AbortSignal;
+}
+
+export type Readable = AsyncReadable | SyncReadable;
+export interface AsyncReadable {
+	get(key: AbsolutePath, opts?: GetOptions): Promise<Uint8Array | undefined>;
 	getRange?(
 		key: AbsolutePath,
 		range: RangeQuery,
-		opts?: Options,
+		opts?: GetOptions,
 	): Promise<Uint8Array | undefined>;
 }
-export interface SyncReadable<Options = unknown> {
-	get(key: AbsolutePath, opts?: Options): Uint8Array | undefined;
+export interface SyncReadable {
+	get(key: AbsolutePath, opts?: GetOptions): Uint8Array | undefined;
 	getRange?(
 		key: AbsolutePath,
 		range: RangeQuery,
-		opts?: Options,
+		opts?: GetOptions,
 	): Uint8Array | undefined;
 }
 
@@ -37,10 +39,6 @@ export interface SyncWritable {
 	set(key: AbsolutePath, value: Uint8Array): void;
 }
 
-export type AsyncMutable<GetOptions = unknown> = AsyncReadable<GetOptions> &
-	AsyncWritable;
-export type SyncMutable<GetOptions = unknown> = SyncReadable<GetOptions> &
-	SyncWritable;
-export type Mutable<GetOptions = unknown> =
-	| AsyncMutable<GetOptions>
-	| SyncMutable<GetOptions>;
+export type AsyncMutable = AsyncReadable & AsyncWritable;
+export type SyncMutable = SyncReadable & SyncWritable;
+export type Mutable = AsyncMutable | SyncMutable;

--- a/packages/zarrita/__tests__/batched-fetch.test.ts
+++ b/packages/zarrita/__tests__/batched-fetch.test.ts
@@ -306,97 +306,44 @@ describe("withRangeBatching", () => {
 		});
 	});
 
-	describe("mergeOptions", () => {
-		it("uses first caller's options by default", async () => {
+	describe("signal merging", () => {
+		it("merges caller signals via AbortSignal.any across a batch", async () => {
 			let inner = fakeStore();
 			let store = withRangeBatching(inner);
 
+			let a = new AbortController();
+			let b = new AbortController();
 			await Promise.all([
 				store.getRange(
 					"/data/chunk",
 					{ offset: 0, length: 100 },
-					{ headers: { "x-req": "first" } },
+					{ signal: a.signal },
 				),
 				store.getRange(
 					"/data/chunk",
 					{ offset: 100, length: 100 },
-					{ headers: { "x-req": "second" } },
+					{ signal: b.signal },
 				),
 			]);
 
-			expect(inner.getRange.mock.calls[0][2]?.headers).toEqual({
-				"x-req": "first",
-			});
+			let passedSignal = inner.getRange.mock.calls[0][2]?.signal;
+			expect(passedSignal).toBeInstanceOf(AbortSignal);
+			// Aborting either upstream signal should propagate to the merged one.
+			a.abort(new Error("a aborted"));
+			expect(passedSignal?.aborted).toBe(true);
 		});
 
-		it("rejects pending requests and recovers when mergeOptions throws", async () => {
+		it("passes a single signal through unchanged", async () => {
 			let inner = fakeStore();
-			let shouldThrow = true;
-			let store = withRangeBatching(inner, {
-				mergeOptions: () => {
-					if (shouldThrow) throw new Error("bad merge");
-					return undefined;
-				},
-			});
+			let store = withRangeBatching(inner);
+			let ctl = new AbortController();
 
-			// First batch: mergeOptions throws, all requests should reject
-			let results = await Promise.allSettled([
-				store.getRange("/data/chunk", { offset: 0, length: 100 }),
-				store.getRange("/data/chunk", { offset: 100, length: 100 }),
-			]);
-			expect(results[0].status).toBe("rejected");
-			expect(results[1].status).toBe("rejected");
-			expect((results[0] as PromiseRejectedResult).reason.message).toBe(
-				"bad merge",
+			await store.getRange(
+				"/data/chunk",
+				{ offset: 0, length: 100 },
+				{ signal: ctl.signal },
 			);
-
-			// Second batch: store should not be deadlocked
-			shouldThrow = false;
-			let r = await store.getRange("/data/chunk", { offset: 0, length: 100 });
-			expect(r?.length).toBe(100);
-		});
-
-		it("applies mergeOptions reducer across batched callers", async () => {
-			interface TaggedOptions {
-				tags: string[];
-			}
-			let inner = {
-				get: vi.fn((_key: AbsolutePath, _opts?: TaggedOptions) =>
-					Promise.resolve<Uint8Array | undefined>(new Uint8Array(0)),
-				),
-				getRange: vi.fn(
-					(
-						_key: AbsolutePath,
-						range: RangeQuery,
-						_options?: TaggedOptions,
-					): Promise<Uint8Array | undefined> => {
-						if ("suffixLength" in range) {
-							return Promise.resolve(new Uint8Array(range.suffixLength));
-						}
-						return Promise.resolve(new Uint8Array(range.length));
-					},
-				),
-			};
-			let store = withRangeBatching(inner, {
-				mergeOptions: (batch) => ({
-					tags: batch.flatMap((o) => o?.tags ?? []),
-				}),
-			});
-
-			await Promise.all([
-				store.getRange(
-					"/data/chunk",
-					{ offset: 0, length: 100 },
-					{ tags: ["a"] },
-				),
-				store.getRange(
-					"/data/chunk",
-					{ offset: 100, length: 100 },
-					{ tags: ["b"] },
-				),
-			]);
-
-			expect(inner.getRange.mock.calls[0][2]?.tags).toEqual(["a", "b"]);
+			expect(inner.getRange.mock.calls[0][2]?.signal).toBe(ctl.signal);
 		});
 	});
 

--- a/packages/zarrita/__tests__/get-types.test.ts
+++ b/packages/zarrita/__tests__/get-types.test.ts
@@ -162,7 +162,6 @@ describe("Chunk type per union dtype", () => {
 		expectType(chunk.data).toMatchInlineSnapshot(
 			`
 			| string[]
-				| unknown[]
 				| Int8Array<ArrayBufferLike>
 				| Int16Array<ArrayBufferLike>
 				| Int32Array<ArrayBufferLike>
@@ -177,6 +176,7 @@ describe("Chunk type per union dtype", () => {
 				| zarr.BoolArray<ArrayBufferLike>
 				| zarr.UnicodeStringArray<ArrayBufferLike>
 				| zarr.ByteStringArray<ArrayBufferLike>
+				| unknown[]
 		`,
 		);
 	});

--- a/packages/zarrita/__tests__/middleware-types.test.ts
+++ b/packages/zarrita/__tests__/middleware-types.test.ts
@@ -10,20 +10,13 @@ describe("extendStore", () => {
 		expectType(store).toMatchInlineSnapshot(`Promise<zarr.FetchStore>`);
 	});
 
-	test("direct form in pipeline infers store options", () => {
+	test("direct form in pipeline", () => {
 		let store = zarr.extendStore(new zarr.FetchStore(""), (s) =>
-			zarr.withRangeBatching(s, {
-				mergeOptions: (batch) => {
-					expectType(batch).toMatchInlineSnapshot(
-						`ReadonlyArray<RequestInit | undefined>`,
-					);
-					return batch[0];
-				},
-			}),
+			zarr.withRangeBatching(s),
 		);
 		expectType(store).toMatchInlineSnapshot(`
 			Promise<
-				Required<AsyncReadable<RequestInit>> & {
+				Required<AsyncReadable> & {
 					stats: Readonly<zarr.RangeBatchingStats>;
 					url: string | URL;
 				}
@@ -36,12 +29,12 @@ describe("extendStore", () => {
 			return zarr.extendStore(
 				new zarr.FetchStore(""),
 				zarr.withConsolidation,
-				(s) => zarr.withRangeBatching(s, { mergeOptions: (batch) => batch[0] }),
+				(s) => zarr.withRangeBatching(s),
 			);
 		}
 		expectType(check).toMatchInlineSnapshot(`
 			() => Promise<
-				Required<AsyncReadable<RequestInit>> & {
+				Required<AsyncReadable> & {
 					stats: Readonly<zarr.RangeBatchingStats>;
 					url: string | URL;
 					contents: () => { path: AbsolutePath; kind: "array" | "group" }[];
@@ -68,7 +61,7 @@ describe("defineStoreMiddleware", () => {
 		let store = withCustom(new zarr.FetchStore(""), { flag: true });
 		expectType(store).toMatchInlineSnapshot(
 			`
-			Required<AsyncReadable<RequestInit>> & {
+			Required<AsyncReadable> & {
 				url: string | URL;
 				hello: () => string;
 			}
@@ -76,38 +69,7 @@ describe("defineStoreMiddleware", () => {
 		);
 	});
 
-	test("generic: store Options flows into opts parameter", () => {
-		interface ThingOptions<O> {
-			storeOptions?: O;
-			retries?: number;
-		}
-
-		let withThing = defineStoreMiddleware(
-			<O>(store: AsyncReadable<O>, opts: ThingOptions<O>) => {
-				return {
-					async get(key: AbsolutePath, options?: O) {
-						return store.get(key, options ?? opts.storeOptions);
-					},
-					retries: opts.retries ?? 3,
-				};
-			},
-		);
-
-		let store = withThing(new zarr.FetchStore(""), {
-			storeOptions: { signal: AbortSignal.timeout(1000) },
-			retries: 5,
-		});
-		expectType(store).toMatchInlineSnapshot(
-			`
-			Required<AsyncReadable<RequestInit>> & {
-				url: string | URL;
-				retries: number;
-			}
-		`,
-		);
-	});
-
-	test("chaining preserves Options through wrappers", () => {
+	test("chaining preserves store through wrappers", () => {
 		let withA = defineStoreMiddleware(
 			(store: AsyncReadable, _opts: { a: number }) => {
 				return {
@@ -134,7 +96,7 @@ describe("defineStoreMiddleware", () => {
 		);
 		let store = withB(withA(new zarr.FetchStore(""), { a: 1 }), { b: "x" });
 		expectType(store).toMatchInlineSnapshot(`
-			Required<AsyncReadable<RequestInit>> & {
+			Required<AsyncReadable> & {
 				url: string | URL;
 				methodB: () => string;
 				methodA: () => number;

--- a/packages/zarrita/__tests__/signal.test.ts
+++ b/packages/zarrita/__tests__/signal.test.ts
@@ -1,0 +1,112 @@
+import * as path from "node:path";
+import * as url from "node:url";
+import type {
+	AbsolutePath,
+	AsyncReadable,
+	GetOptions,
+	RangeQuery,
+} from "@zarrita/storage";
+import { describe, expect, it } from "vitest";
+import * as zarr from "../src/index.js";
+
+let __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+let fixturesRoot = path.resolve(__dirname, "../../../fixtures/v3/data.zarr");
+
+/** Wraps a store so every get/getRange call is observable. */
+function recordingStore<S extends AsyncReadable>(inner: S) {
+	let calls: Array<GetOptions | undefined> = [];
+	let wrapped: AsyncReadable = {
+		get(key, opts) {
+			calls.push(opts);
+			return inner.get(key, opts);
+		},
+	};
+	if (inner.getRange) {
+		wrapped.getRange = (
+			key: AbsolutePath,
+			range: RangeQuery,
+			opts?: GetOptions,
+		) => {
+			calls.push(opts);
+			return inner.getRange?.(key, range, opts) ?? Promise.resolve(undefined);
+		};
+	}
+	return { store: wrapped, calls };
+}
+
+describe("signal propagation through zarr.get", () => {
+	it("passes signal to store.get for a simple array", async () => {
+		let fsStore = new zarr.FileSystemStore(fixturesRoot);
+		let { store, calls } = recordingStore(fsStore);
+		let arr = await zarr.open.v3(
+			zarr.root(store).resolve("1d.contiguous.raw.i2"),
+			{
+				kind: "array",
+			},
+		);
+		let ctl = new AbortController();
+		await zarr.get(arr, null, { signal: ctl.signal });
+		expect(calls.length).toBeGreaterThan(0);
+		let seen = calls.find((c) => c?.signal === ctl.signal);
+		expect(seen).toBeDefined();
+	});
+
+	it("aborting signal rejects a pending zarr.get", async () => {
+		let fsStore = new zarr.FileSystemStore(fixturesRoot);
+		let arr = await zarr.open.v3(
+			zarr.root(fsStore).resolve("1d.contiguous.raw.i2"),
+			{ kind: "array" },
+		);
+		let ctl = new AbortController();
+		ctl.abort(new Error("aborted"));
+		await expect(zarr.get(arr, null, { signal: ctl.signal })).rejects.toThrow(
+			/abort/i,
+		);
+	});
+
+	it("propagates signal through a sharded chunk getter (#306)", async () => {
+		let fsStore = new zarr.FileSystemStore(fixturesRoot);
+		let { store, calls } = recordingStore(fsStore);
+		let arr = await zarr.open.v3(
+			zarr.root(store).resolve("1d.chunked.compressed.sharded.i2"),
+			{ kind: "array" },
+		);
+		let ctl = new AbortController();
+		await zarr.get(arr, null, { signal: ctl.signal });
+		// The shard index + shard chunk reads should both see our signal.
+		let rangeCalls = calls.filter((c) => c?.signal === ctl.signal);
+		expect(rangeCalls.length).toBeGreaterThan(0);
+	});
+
+	it("still accepts the deprecated `opts` shim", async () => {
+		let fsStore = new zarr.FileSystemStore(fixturesRoot);
+		let arr = await zarr.open.v3(
+			zarr.root(fsStore).resolve("1d.contiguous.raw.i2"),
+			{ kind: "array" },
+		);
+		let ctl = new AbortController();
+		ctl.abort(new Error("aborted"));
+		await expect(
+			zarr.get(arr, null, { opts: { signal: ctl.signal } }),
+		).rejects.toThrow(/abort/i);
+	});
+
+	it("merges `signal` and deprecated `opts.signal` via AbortSignal.any", async () => {
+		let fsStore = new zarr.FileSystemStore(fixturesRoot);
+		let arr = await zarr.open.v3(
+			zarr.root(fsStore).resolve("1d.contiguous.raw.i2"),
+			{ kind: "array" },
+		);
+		// Only the deprecated one is aborted; the resolved signal should
+		// still be aborted because of AbortSignal.any.
+		let live = new AbortController();
+		let aborted = new AbortController();
+		aborted.abort(new Error("deprecated aborted"));
+		await expect(
+			zarr.get(arr, null, {
+				signal: live.signal,
+				opts: { signal: aborted.signal },
+			}),
+		).rejects.toThrow(/abort/i);
+	});
+});

--- a/packages/zarrita/src/codecs/sharding.ts
+++ b/packages/zarrita/src/codecs/sharding.ts
@@ -1,4 +1,4 @@
-import type { Readable } from "@zarrita/storage";
+import type { GetOptions, Readable } from "@zarrita/storage";
 import { createCodecPipeline } from "../codecs.js";
 import { UnsupportedError } from "../errors.js";
 import type { Location } from "../hierarchy.js";
@@ -7,8 +7,8 @@ import type { ShardingCodecMetadata } from "../util.js";
 
 const MAX_BIG_UINT = 18446744073709551615n;
 
-export function createShardedChunkGetter<Store extends Readable>(
-	location: Location<Store>,
+export function createShardedChunkGetter(
+	location: Location<Readable>,
 	shardShape: number[],
 	encodeShardKey: (coord: number[]) => string,
 	shardingConfig: ShardingCodecMetadata["configuration"],
@@ -28,10 +28,7 @@ export function createShardedChunkGetter<Store extends Readable>(
 	let checksumSize = 4;
 	let indexSize = 16 * indexShape.reduce((a, b) => a * b, 1);
 	let cache: Record<string, Promise<Chunk<"uint64"> | null>> = {};
-	return async (
-		chunkCoord: number[],
-		options?: Parameters<Store["get"]>[1],
-	) => {
+	return async (chunkCoord: number[], options?: GetOptions) => {
 		let shardCoord = chunkCoord.map((d, i) => Math.floor(d / indexShape[i]));
 		let shardPath = location.resolve(encodeShardKey(shardCoord)).path;
 

--- a/packages/zarrita/src/hierarchy.ts
+++ b/packages/zarrita/src/hierarchy.ts
@@ -1,4 +1,4 @@
-import type { AbsolutePath, Readable } from "@zarrita/storage";
+import type { AbsolutePath, GetOptions, Readable } from "@zarrita/storage";
 import { createShardedChunkGetter } from "./codecs/sharding.js";
 import { createCodecPipeline } from "./codecs.js";
 import type {
@@ -78,10 +78,10 @@ export function getContext<T>(obj: { [CONTEXT_MARKER]: T }): T {
 	return obj[CONTEXT_MARKER];
 }
 
-function createContext<Store extends Readable, D extends DataType>(
+function createContext<D extends DataType>(
 	location: Location<Readable>,
 	metadata: ArrayMetadata<D>,
-): ArrayContext<Store, D> {
+): ArrayContext<D> {
 	let { configuration } = metadata.codecs.find(isShardingCodec) ?? {};
 	let sharedContext = {
 		encodeChunkKey: createChunkKeyEncoder(metadata.chunk_key_encoding),
@@ -136,7 +136,7 @@ function createContext<Store extends Readable, D extends DataType>(
 }
 
 /** For internal use only, and is subject to change. */
-interface ArrayContext<Store extends Readable, D extends DataType> {
+interface ArrayContext<D extends DataType> {
 	kind: "sharded" | "regular";
 	/** The codec pipeline for this array. */
 	codec: ReturnType<typeof createCodecPipeline<D>>;
@@ -151,7 +151,7 @@ interface ArrayContext<Store extends Readable, D extends DataType> {
 	/** A function to get the bytes for a given chunk. */
 	getChunkBytes(
 		chunkCoords: number[],
-		options?: Parameters<Store["get"]>[1],
+		options?: GetOptions,
 	): Promise<Uint8Array | undefined>;
 	/** The chunk shape for this array. */
 	chunkShape: number[];
@@ -163,7 +163,7 @@ export class Array<
 > extends Location<Store> {
 	readonly kind = "array";
 	#metadata: ArrayMetadata<Dtype>;
-	[CONTEXT_MARKER]: ArrayContext<Store, Dtype>;
+	[CONTEXT_MARKER]: ArrayContext<Dtype>;
 
 	constructor(
 		store: Store,
@@ -204,7 +204,7 @@ export class Array<
 
 	async getChunk(
 		chunkCoords: number[],
-		options?: Parameters<Store["get"]>[1],
+		options?: GetOptions,
 		opts?: { useSharedArrayBuffer?: boolean },
 	): Promise<Chunk<Dtype>> {
 		if (opts?.useSharedArrayBuffer) {

--- a/packages/zarrita/src/index.ts
+++ b/packages/zarrita/src/index.ts
@@ -48,7 +48,6 @@ export {
 	withMaybeConsolidation,
 	withMaybeConsolidation as tryWithConsolidated,
 } from "./middleware/consolidation.js";
-export type { GenericOptions } from "./middleware/define.js";
 export { defineStoreMiddleware } from "./middleware/define.js";
 export { extendStore } from "./middleware/extend-store.js";
 export type {

--- a/packages/zarrita/src/indexing/get.ts
+++ b/packages/zarrita/src/indexing/get.ts
@@ -5,7 +5,7 @@ import type { Chunk, DataType, Scalar, TypedArray } from "../metadata.js";
 import {
 	assertSharedArrayBufferAvailable,
 	createBuffer,
-	isAbortable,
+	resolveSignal,
 } from "../util.js";
 import { BasicIndexer } from "./indexer.js";
 import type {
@@ -32,7 +32,7 @@ export async function get<
 >(
 	arr: Array<D, Store>,
 	selection: null | Sel,
-	opts: GetOptions<Parameters<Store["get"]>[1]>,
+	opts: GetOptions,
 	setter: {
 		prepare: Prepare<D, Arr>;
 		setScalar: SetScalar<D, Arr>;
@@ -45,6 +45,7 @@ export async function get<
 		assertSharedArrayBufferAvailable();
 	}
 
+	let signal = resolveSignal(opts);
 	let context = getContext(arr);
 	let indexer = new BasicIndexer({
 		selection,
@@ -55,9 +56,11 @@ export async function get<
 	// Handle scalar arrays (shape=[]) directly, since the indexer yields nothing
 	// for zero-dimensional arrays.
 	if (arr.shape.length === 0) {
-		let { data } = await arr.getChunk([], opts.opts, {
-			useSharedArrayBuffer: opts.useSharedArrayBuffer,
-		});
+		let { data } = await arr.getChunk(
+			[],
+			{ signal },
+			{ useSharedArrayBuffer: opts.useSharedArrayBuffer },
+		);
 		// @ts-expect-error - TS can't narrow this conditional type
 		return unwrap(data, 0);
 	}
@@ -87,12 +90,12 @@ export async function get<
 	let queue = opts.createQueue?.() ?? createQueue();
 	for (const { chunkCoords, mapping } of indexer) {
 		queue.add(async () => {
-			if (isAbortable(opts.opts)) {
-				opts.opts.signal.throwIfAborted();
-			}
-			let { data, shape, stride } = await arr.getChunk(chunkCoords, opts.opts, {
-				useSharedArrayBuffer: opts.useSharedArrayBuffer,
-			});
+			signal?.throwIfAborted();
+			let { data, shape, stride } = await arr.getChunk(
+				chunkCoords,
+				{ signal },
+				{ useSharedArrayBuffer: opts.useSharedArrayBuffer },
+			);
 			let chunk = setter.prepare(data, shape, stride);
 			setter.setFromChunk(out, chunk, mapping);
 		});

--- a/packages/zarrita/src/indexing/ops.ts
+++ b/packages/zarrita/src/indexing/ops.ts
@@ -148,7 +148,7 @@ export async function get<
 >(
 	arr: Array<D, Store>,
 	selection: Sel | null = null,
-	opts: GetOptions<Parameters<Store["get"]>[1]> = {},
+	opts: GetOptions = {},
 ): Promise<
 	null extends Sel[number]
 		? Chunk<D>

--- a/packages/zarrita/src/indexing/set.ts
+++ b/packages/zarrita/src/indexing/set.ts
@@ -3,7 +3,7 @@ import type { Mutable } from "@zarrita/storage";
 import { InvalidSelectionError, UnsupportedError } from "../errors.js";
 import { type Array, getContext } from "../hierarchy.js";
 import type { Chunk, DataType, Scalar, TypedArray } from "../metadata.js";
-import { isAbortable } from "../util.js";
+import { resolveSignal } from "../util.js";
 import { BasicIndexer, type IndexerProjection } from "./indexer.js";
 import type {
 	Indices,
@@ -70,6 +70,7 @@ export async function set<Dtype extends DataType, Arr extends Chunk<Dtype>>(
 
 	const chunkSize = arr.chunks.reduce((a, b) => a * b, 1);
 	const queue = opts.createQueue ? opts.createQueue() : createQueue();
+	const signal = resolveSignal(opts);
 
 	// N.B., it is an important optimisation that we only visit chunks which overlap
 	// the selection. This minimises the number of iterations in the main for loop.
@@ -77,9 +78,7 @@ export async function set<Dtype extends DataType, Arr extends Chunk<Dtype>>(
 		const chunkSelection = mapping.map((i) => i.from);
 		const flipped = mapping.map(flipIndexerProjection);
 		queue.add(async () => {
-			if (isAbortable(opts.opts)) {
-				opts.opts.signal.throwIfAborted();
-			}
+			signal?.throwIfAborted();
 
 			// obtain key for chunk storage
 			const chunkPath = arr.resolve(context.encodeChunkKey(chunkCoords)).path;

--- a/packages/zarrita/src/indexing/types.ts
+++ b/packages/zarrita/src/indexing/types.ts
@@ -43,11 +43,18 @@ export type Setter<D extends DataType, Arr extends Chunk<D>> = {
 export type Options = {
 	createQueue?: () => ChunkQueue;
 	useSharedArrayBuffer?: boolean;
+	signal?: AbortSignal;
+	/**
+	 * @deprecated Pass `signal` directly on the options object.
+	 * Kept for one major version of back-compat; if both are set, the
+	 * signals are merged via `AbortSignal.any`.
+	 */
+	opts?: { signal?: AbortSignal };
 };
 
-export type GetOptions<O> = Options & { opts?: O };
+export type GetOptions = Options;
 
-export type SetOptions<O = unknown> = Options & { opts?: O };
+export type SetOptions = Options;
 
 // Compatible with https://github.com/sindresorhus/p-queue
 export type ChunkQueue = {

--- a/packages/zarrita/src/middleware/consolidation.ts
+++ b/packages/zarrita/src/middleware/consolidation.ts
@@ -1,4 +1,9 @@
-import type { AbsolutePath, AsyncReadable, Readable } from "@zarrita/storage";
+import type {
+	AbsolutePath,
+	AsyncReadable,
+	GetOptions,
+	Readable,
+} from "@zarrita/storage";
 import { InvalidMetadataError, NotFoundError } from "../errors.js";
 import type {
 	ArrayMetadata,
@@ -219,7 +224,7 @@ export const withConsolidation = defineStoreMiddleware(
 				return {
 					async get(
 						key: AbsolutePath,
-						options?: unknown,
+						options?: GetOptions,
 					): Promise<Uint8Array | undefined> {
 						if (knownMeta[key]) {
 							return jsonEncodeObject(knownMeta[key]);

--- a/packages/zarrita/src/middleware/define.ts
+++ b/packages/zarrita/src/middleware/define.ts
@@ -8,47 +8,23 @@ type Extensions<T> = {
 	[K in Extract<Exclude<keyof T, StoreKeys>, string>]: T[K];
 } & {};
 
-/**
- * Base interface for defining middleware options that depend on the store's
- * request options type. Extend this and override `options` using `this["_O"]`:
- *
- * ```ts
- * interface MyOpts extends GenericOptions {
- *   readonly options: { storeOptions?: this["_O"]; retries?: number };
- * }
- * ```
- */
-export interface GenericOptions {
-	readonly _O: unknown;
-	readonly options: unknown;
-}
-
-/** Apply a type lambda — substitutes `_O` with a concrete type. */
-type Apply<F extends GenericOptions, O> = (F & { readonly _O: O })["options"];
-
-/** Extract the Options type from a store. */
-// biome-ignore lint/suspicious/noExplicitAny: required for conditional type matching
-type InferStoreOpts<S> = S extends { get(key: any, opts?: infer O): any }
-	? O
-	: unknown;
-
-/** If factory returns a Promise, wrap the result in Promise; otherwise keep it sync. */
 type Prettify<T> = { [K in keyof T]: T[K] } & {};
 
-/** Collapse get/getRange into AsyncReadable<O>, show extras separately. */
-type CollapseStore<T> =
-	T extends AsyncReadable<infer O>
-		? // biome-ignore lint/suspicious/noExplicitAny: needed for getRange optionality check
-			(T extends { getRange: (...args: any[]) => any }
-				? Required<AsyncReadable<O>>
-				: AsyncReadable<O>) &
-				Prettify<Omit<T, keyof AsyncReadable>>
-		: T;
+/**
+ * Collapse store-typed keys onto `AsyncReadable`, hide them from the combined
+ * type, and show all extensions (from S and Ext) as a single merged object.
+ */
+type CollapseStore<T> = T extends AsyncReadable
+	? (T extends { getRange: (...args: never[]) => unknown }
+			? Required<AsyncReadable>
+			: AsyncReadable) &
+			Prettify<Omit<T, keyof AsyncReadable>>
+	: T;
 
-type WrapperResult<Ext, S> =
-	Ext extends Promise<infer Inner>
+type WrapperResult<R, S> =
+	R extends Promise<infer Inner>
 		? Promise<CollapseStore<S & Extensions<Inner>>>
-		: CollapseStore<S & Extensions<Ext>>;
+		: CollapseStore<S & Extensions<R>>;
 
 function createProxy(
 	store: object,
@@ -84,18 +60,16 @@ function createProxy(
 	});
 }
 
-function _apply(
-	factory: (store: AsyncReadable, opts: unknown) => unknown,
-	store: AsyncReadable,
-	opts: unknown,
-) {
-	let result = factory(store, opts);
-	if (result instanceof Promise) {
-		return result.then((overrides) =>
-			createProxy(store, overrides as Record<string | symbol, unknown>),
+type FactoryResult = Partial<AsyncReadable> & Record<string, unknown>;
+
+function assertFactoryResult(
+	value: unknown,
+): asserts value is Record<string | symbol, unknown> {
+	if (value == null || typeof value !== "object") {
+		throw new Error(
+			"Store middleware factory must return an object of overrides",
 		);
 	}
-	return createProxy(store, result as Record<string | symbol, unknown>);
 }
 
 /**
@@ -105,16 +79,8 @@ function _apply(
  * object of overrides and extensions. Methods not returned are automatically
  * delegated to the inner store via Proxy.
  *
- * Overrides of `get`/`getRange` work at runtime via the Proxy, but their types
- * are stripped from the return type so that the original store's Options generic
- * is preserved through chains of middleware.
- *
  * Supports both sync and async factories — if the factory returns a Promise,
  * the middleware returns a Promise too.
- *
- * ## Simple case
- *
- * When your options don't depend on the store's request options type:
  *
  * ```ts
  * import * as zarr from "zarrita";
@@ -128,63 +94,26 @@ function _apply(
  *   },
  * );
  * ```
- *
- * ## Generic case
- *
- * When your options need the store's request options type (e.g. for
- * `storeOptions` or `mergeOptions`), use {@linkcode GenericOptions}:
- *
- * ```ts
- * import * as zarr from "zarrita";
- *
- * interface MyOptsFor extends zarr.GenericOptions {
- *   readonly options: MyOptions<this["_O"]>;
- * }
- *
- * const withMyThing = zarr.defineStoreMiddleware.generic<MyOptsFor>()(
- *   (store, opts) => { ... },
- * );
- *
- * // At the call site, storeOptions is inferred from the store:
- * withMyThing(fetchStore, { storeOptions: { signal } });
- * //                                       ^? RequestInit
- * ```
  */
 export function defineStoreMiddleware<
-	// to correctly infer F's parameter types from the factory function.
-	F extends (
-		store: AsyncReadable,
-		// biome-ignore lint/suspicious/noExplicitAny: `any` for opts is required for TypeScript
-		opts?: any,
-		// biome-ignore lint/suspicious/noExplicitAny: `any` for opts is required for TypeScript
-	) => Partial<AsyncReadable> & Record<string, any>,
+	R extends FactoryResult | Promise<FactoryResult>,
+	Opts = void,
 >(
-	factory: F,
-): <S extends AsyncReadable>(
-	store: S,
-	opts?: Parameters<F>[1],
-) => WrapperResult<ReturnType<F>, S> {
-	// @ts-expect-error - TypeScript can't infer this
-	return (store: AsyncReadable, opts: unknown) => _apply(factory, store, opts);
-}
-
-/**
- * Define a store middleware whose options depend on the store's request options type.
- *
- * @see {@linkcode defineStoreMiddleware} for full documentation and examples.
- */
-defineStoreMiddleware.generic = function generic<
-	OptsLambda extends GenericOptions,
->() {
-	// biome-ignore lint/suspicious/noExplicitAny: `any` allows extra extension properties
-	return <Ext extends Partial<AsyncReadable> & Record<string, any>>(
-		factory: (store: AsyncReadable, opts: Apply<OptsLambda, unknown>) => Ext,
-	): (<S extends AsyncReadable>(
-		store: S,
-		opts?: NoInfer<Apply<OptsLambda, InferStoreOpts<S>>>,
-	) => WrapperResult<Ext, S>) => {
-		return ((store: AsyncReadable, opts: unknown) =>
-			// biome-ignore lint/suspicious/noExplicitAny: TS can't figure it out
-			_apply(factory, store, opts)) as any;
+	factory: (store: AsyncReadable, opts: Opts) => R,
+): <S extends AsyncReadable>(store: S, opts?: Opts) => WrapperResult<R, S>;
+export function defineStoreMiddleware(
+	factory: (store: AsyncReadable, opts: never) => unknown,
+): (store: AsyncReadable, opts?: unknown) => unknown {
+	return (store, opts) => {
+		// @ts-expect-error - factory's opts parameter is wider than `never` at runtime.
+		let result: unknown = factory(store, opts);
+		if (result instanceof Promise) {
+			return result.then((overrides) => {
+				assertFactoryResult(overrides);
+				return createProxy(store, overrides);
+			});
+		}
+		assertFactoryResult(result);
+		return createProxy(store, result);
 	};
-};
+}

--- a/packages/zarrita/src/middleware/range-batching.ts
+++ b/packages/zarrita/src/middleware/range-batching.ts
@@ -1,24 +1,34 @@
 import type {
 	AbsolutePath,
 	AsyncReadable,
+	GetOptions,
 	RangeQuery,
 	Readable,
 } from "@zarrita/storage";
 import { UnsupportedError } from "../errors.js";
-import { defineStoreMiddleware, type GenericOptions } from "./define.js";
+import { defineStoreMiddleware } from "./define.js";
 
-/** Narrow a Readable to AsyncReadable, throwing if getRange is missing. */
-function asAsync(store: Readable): AsyncReadable & {
-	getRange: NonNullable<AsyncReadable["getRange"]>;
-} {
+type RequiredGetRange = NonNullable<AsyncReadable["getRange"]>;
+
+/** Narrow a Readable to an AsyncReadable with a non-optional getRange. */
+function assertRangeCapable(
+	store: Readable,
+): asserts store is AsyncReadable & { getRange: RequiredGetRange } {
 	if (!store.getRange) {
 		throw new UnsupportedError(
 			"`zarr.withRangeBatching` requires a store with getRange",
 		);
 	}
-	return store as AsyncReadable & {
-		getRange: NonNullable<AsyncReadable["getRange"]>;
-	};
+}
+
+function mergeSignals(
+	signals: ReadonlyArray<AbortSignal | undefined>,
+): AbortSignal | undefined {
+	let present: AbortSignal[] = [];
+	for (let s of signals) if (s) present.push(s);
+	if (present.length === 0) return undefined;
+	if (present.length === 1) return present[0];
+	return AbortSignal.any(present);
 }
 
 /**
@@ -68,6 +78,7 @@ class LRUCache<V> {
 interface PendingRequest {
 	offset: number;
 	length: number;
+	signal?: AbortSignal;
 	resolve: (value: Uint8Array | undefined) => void;
 	reject: (reason: unknown) => void;
 }
@@ -85,17 +96,11 @@ export interface RangeBatchingStats {
 	batchedRequests: number;
 }
 
-export interface RangeBatchingOptions<O = unknown> {
+export interface RangeBatchingOptions {
 	/** Maximum number of entries in the LRU cache (default: 256). */
 	cacheSize?: number;
 	/** Byte gap threshold for merging adjacent ranges (default: 32768). */
 	coalesceSize?: number;
-	/**
-	 * Merge options from all callers in a batch into a single value passed to
-	 * the inner store. By default, the first caller's options win. Use this to
-	 * combine `AbortSignal`s, merge headers, etc.
-	 */
-	mergeOptions?: (batch: ReadonlyArray<O | undefined>) => O | undefined;
 }
 
 /**
@@ -158,171 +163,157 @@ function groupRequests(
  * let store = zarr.withRangeBatching(new zarr.FetchStore("https://example.com/data.zarr"));
  * ```
  */
-/** @internal Type lambda for {@linkcode RangeBatchingOptions}. */
-export interface RangeBatchingOptsFor extends GenericOptions {
-	readonly options: RangeBatchingOptions<this["_O"]>;
-}
+export const withRangeBatching = defineStoreMiddleware(
+	(_store, opts: RangeBatchingOptions = {}) => {
+		assertRangeCapable(_store);
+		let store = _store;
+		let boundGetRange = store.getRange.bind(store);
 
-export const withRangeBatching =
-	defineStoreMiddleware.generic<RangeBatchingOptsFor>()(
-		(_store, opts: RangeBatchingOptions<unknown> = {}) => {
-			let store = asAsync(_store);
-			let boundGetRange = store.getRange.bind(store);
+		let coalesceSize = opts.coalesceSize ?? DEFAULT_COALESCE_SIZE;
+		let cache = new LRUCache<Uint8Array | undefined>(opts.cacheSize ?? 256);
+		let inflight = new Map<string, Promise<Uint8Array | undefined>>();
 
-			let coalesceSize = opts.coalesceSize ?? DEFAULT_COALESCE_SIZE;
-			let cache = new LRUCache<Uint8Array | undefined>(opts.cacheSize ?? 256);
-			let inflight = new Map<string, Promise<Uint8Array | undefined>>();
-			let mergeOptionsFn = opts.mergeOptions;
+		let pending = new Map<AbsolutePath, PendingRequest[]>();
+		let scheduled = false;
 
-			let pending = new Map<AbsolutePath, PendingRequest[]>();
-			let scheduled = false;
-			let batchOptions: unknown[] = [];
+		let _stats: RangeBatchingStats = {
+			hits: 0,
+			misses: 0,
+			mergedRequests: 0,
+			batchedRequests: 0,
+		};
 
-			let _stats: RangeBatchingStats = {
-				hits: 0,
-				misses: 0,
-				mergedRequests: 0,
-				batchedRequests: 0,
-			};
+		async function flush(): Promise<void> {
+			let work = new Map(pending);
+			pending.clear();
+			scheduled = false;
 
-			async function flush(): Promise<void> {
-				let batch = batchOptions;
-				batchOptions = [];
-				let work = new Map(pending);
-				pending.clear();
-				scheduled = false;
-
-				let options: unknown;
-				try {
-					options = mergeOptionsFn ? mergeOptionsFn(batch) : batch[0];
-				} catch (err) {
-					for (let requests of work.values()) {
-						for (let req of requests) req.reject(err);
-					}
-					return;
-				}
-
-				let pathPromises: Promise<void>[] = [];
-				for (let [path, requests] of work) {
-					requests.sort((a, b) => a.offset - b.offset);
-					let groups = groupRequests(requests, coalesceSize);
-					_stats.mergedRequests += groups.length;
-					pathPromises.push(fetchGroups(path, groups, options));
-				}
-				await Promise.all(pathPromises);
+			let pathPromises: Promise<void>[] = [];
+			for (let [path, requests] of work) {
+				requests.sort((a, b) => a.offset - b.offset);
+				let groups = groupRequests(requests, coalesceSize);
+				_stats.mergedRequests += groups.length;
+				pathPromises.push(fetchGroups(path, groups));
 			}
+			await Promise.all(pathPromises);
+		}
 
-			async function fetchGroups(
-				path: AbsolutePath,
-				groups: RangeGroup[],
-				options?: unknown,
-			): Promise<void> {
-				await Promise.all(
-					groups.map(async (group) => {
-						try {
-							let data = await boundGetRange(
-								path,
-								{ offset: group.offset, length: group.length },
-								options,
+		async function fetchGroups(
+			path: AbsolutePath,
+			groups: RangeGroup[],
+		): Promise<void> {
+			await Promise.all(
+				groups.map(async (group) => {
+					let signal = mergeSignals(group.requests.map((r) => r.signal));
+					try {
+						let data = await boundGetRange(
+							path,
+							{ offset: group.offset, length: group.length },
+							{ signal },
+						);
+						if (data && data.length < group.length) {
+							throw new Error(
+								`Short read: expected ${group.length} bytes but received ${data.length}`,
 							);
-							if (data && data.length < group.length) {
-								throw new Error(
-									`Short read: expected ${group.length} bytes but received ${data.length}`,
-								);
-							}
-							for (let req of group.requests) {
-								let cacheKey = `${path}\0${req.offset}\0${req.length}`;
-								if (!data) {
-									cache.set(cacheKey, undefined);
-									req.resolve(undefined);
-									continue;
-								}
-								let start = req.offset - group.offset;
-								let slice = data.slice(start, start + req.length);
-								cache.set(cacheKey, slice);
-								req.resolve(slice);
-							}
-						} catch (err) {
-							for (let req of group.requests) {
-								req.reject(err);
-							}
 						}
-					}),
-				);
-			}
-
-			return {
-				get(
-					key: AbsolutePath,
-					options?: unknown,
-				): Promise<Uint8Array | undefined> {
-					return store.get(key, options);
-				},
-
-				getRange(
-					key: AbsolutePath,
-					range: RangeQuery,
-					options?: unknown,
-				): Promise<Uint8Array | undefined> {
-					// Suffix requests (shard index reads) bypass batching - file size
-					// is unknown until the response arrives.
-					if ("suffixLength" in range) {
-						let cacheKey = `${key}\0suffix\0${range.suffixLength}`;
-						if (cache.has(cacheKey)) {
-							_stats.hits++;
-							return Promise.resolve(cache.get(cacheKey));
+						for (let req of group.requests) {
+							let cacheKey = `${path}\0${req.offset}\0${req.length}`;
+							if (!data) {
+								cache.set(cacheKey, undefined);
+								req.resolve(undefined);
+								continue;
+							}
+							let start = req.offset - group.offset;
+							let slice = data.slice(start, start + req.length);
+							cache.set(cacheKey, slice);
+							req.resolve(slice);
 						}
-						// Deduplicate concurrent suffix requests
-						let existing = inflight.get(cacheKey);
-						if (existing) {
-							_stats.hits++;
-							return existing;
+					} catch (err) {
+						for (let req of group.requests) {
+							req.reject(err);
 						}
-						_stats.misses++;
-						let promise = boundGetRange(key, range, options)
-							.then((data) => {
-								cache.set(cacheKey, data);
-								inflight.delete(cacheKey);
-								return data;
-							})
-							.catch((err) => {
-								inflight.delete(cacheKey);
-								throw err;
-							});
-						inflight.set(cacheKey, promise);
-						return promise;
 					}
+				}),
+			);
+		}
 
-					let { offset, length } = range;
-					let cacheKey = `${key}\0${offset}\0${length}`;
+		return {
+			get(
+				key: AbsolutePath,
+				options?: GetOptions,
+			): Promise<Uint8Array | undefined> {
+				return store.get(key, options);
+			},
 
+			getRange(
+				key: AbsolutePath,
+				range: RangeQuery,
+				options?: GetOptions,
+			): Promise<Uint8Array | undefined> {
+				// Suffix requests (shard index reads) bypass batching - file size
+				// is unknown until the response arrives.
+				if ("suffixLength" in range) {
+					let cacheKey = `${key}\0suffix\0${range.suffixLength}`;
 					if (cache.has(cacheKey)) {
 						_stats.hits++;
 						return Promise.resolve(cache.get(cacheKey));
 					}
-
+					// Deduplicate concurrent suffix requests
+					let existing = inflight.get(cacheKey);
+					if (existing) {
+						_stats.hits++;
+						return existing;
+					}
 					_stats.misses++;
-					_stats.batchedRequests++;
+					let promise = boundGetRange(key, range, options)
+						.then((data) => {
+							cache.set(cacheKey, data);
+							inflight.delete(cacheKey);
+							return data;
+						})
+						.catch((err) => {
+							inflight.delete(cacheKey);
+							throw err;
+						});
+					inflight.set(cacheKey, promise);
+					return promise;
+				}
 
-					return new Promise((resolve, reject) => {
-						let reqs = pending.get(key);
-						if (!reqs) {
-							reqs = [];
-							pending.set(key, reqs);
-						}
-						reqs.push({ offset, length, resolve, reject });
+				let { offset, length } = range;
+				let cacheKey = `${key}\0${offset}\0${length}`;
 
-						batchOptions.push(options);
-						if (!scheduled) {
-							scheduled = true;
-							queueMicrotask(() => flush());
-						}
+				if (cache.has(cacheKey)) {
+					_stats.hits++;
+					return Promise.resolve(cache.get(cacheKey));
+				}
+
+				_stats.misses++;
+				_stats.batchedRequests++;
+
+				return new Promise((resolve, reject) => {
+					let reqs = pending.get(key);
+					if (!reqs) {
+						reqs = [];
+						pending.set(key, reqs);
+					}
+					reqs.push({
+						offset,
+						length,
+						signal: options?.signal,
+						resolve,
+						reject,
 					});
-				},
 
-				get stats(): Readonly<RangeBatchingStats> {
-					return { ..._stats };
-				},
-			};
-		},
-	);
+					if (!scheduled) {
+						scheduled = true;
+						queueMicrotask(() => flush());
+					}
+				});
+			},
+
+			get stats(): Readonly<RangeBatchingStats> {
+				return { ..._stats };
+			},
+		};
+	},
+);

--- a/packages/zarrita/src/open.ts
+++ b/packages/zarrita/src/open.ts
@@ -1,4 +1,4 @@
-import type { Readable } from "@zarrita/storage";
+import type { GetOptions, Readable } from "@zarrita/storage";
 import { InvalidMetadataError, NotFoundError } from "./errors.js";
 import { Array, Group, Location } from "./hierarchy.js";
 import type {
@@ -9,7 +9,6 @@ import type {
 } from "./metadata.js";
 import {
 	ensureCorrectScalar,
-	isAbortable,
 	jsonDecodeObject,
 	rethrowUnless,
 	v2ToV3ArrayMetadata,
@@ -37,7 +36,7 @@ function createVersionCounter() {
 
 async function loadAttrs(
 	location: Location<Readable>,
-	opts?: unknown,
+	opts?: GetOptions,
 ): Promise<Attributes> {
 	let metaBytes = await location.store.get(
 		location.resolve(".zattrs").path,
@@ -49,28 +48,32 @@ async function loadAttrs(
 
 function openV2<Store extends Readable>(
 	location: Location<Store> | Store,
-	options: { kind: "group"; attrs?: boolean; opts?: unknown },
+	options: { kind: "group"; attrs?: boolean; opts?: GetOptions },
 ): Promise<Group<Store>>;
 
 function openV2<Store extends Readable>(
 	location: Location<Store> | Store,
-	options: { kind: "array"; attrs?: boolean; opts?: unknown },
+	options: { kind: "array"; attrs?: boolean; opts?: GetOptions },
 ): Promise<Array<DataType, Store>>;
 
 function openV2<Store extends Readable>(
 	location: Location<Store> | Store,
-	options?: { kind?: "array" | "group"; attrs?: boolean; opts?: unknown },
+	options?: { kind?: "array" | "group"; attrs?: boolean; opts?: GetOptions },
 ): Promise<Array<DataType, Store> | Group<Store>>;
 
 async function openV2<Store extends Readable>(
 	location: Location<Store> | Store,
-	options: { kind?: "array" | "group"; attrs?: boolean; opts?: unknown } = {},
+	options: {
+		kind?: "array" | "group";
+		attrs?: boolean;
+		opts?: GetOptions;
+	} = {},
 ) {
 	let loc = "store" in location ? location : new Location(location);
 	let { opts } = options;
 	let attrs = {};
 	if (options.attrs ?? true) attrs = await loadAttrs(loc, opts);
-	if (isAbortable(opts)) opts.signal.throwIfAborted();
+	opts?.signal?.throwIfAborted();
 	if (options.kind === "array") return openArrayV2(loc, attrs, opts);
 	if (options.kind === "group") return openGroupV2(loc, attrs, opts);
 	return openArrayV2(loc, attrs, opts).catch((err) => {
@@ -82,7 +85,7 @@ async function openV2<Store extends Readable>(
 async function openArrayV2<Store extends Readable>(
 	location: Location<Store>,
 	attrs: Attributes,
-	opts?: unknown,
+	opts?: GetOptions,
 ) {
 	let { path } = location.resolve(".zarray");
 	let meta = await location.store.get(path, opts);
@@ -100,7 +103,7 @@ async function openArrayV2<Store extends Readable>(
 async function openGroupV2<Store extends Readable>(
 	location: Location<Store>,
 	attrs: Attributes,
-	opts?: unknown,
+	opts?: GetOptions,
 ) {
 	let { path } = location.resolve(".zgroup");
 	let meta = await location.store.get(path, opts);
@@ -117,7 +120,7 @@ async function openGroupV2<Store extends Readable>(
 
 async function _openV3<Store extends Readable>(
 	location: Location<Store>,
-	opts?: unknown,
+	opts?: GetOptions,
 ) {
 	let { store, path } = location.resolve("zarr.json");
 	let meta = await location.store.get(path, opts);
@@ -135,27 +138,27 @@ async function _openV3<Store extends Readable>(
 
 function openV3<Store extends Readable>(
 	location: Location<Store> | Store,
-	options: { kind: "group"; opts?: unknown },
+	options: { kind: "group"; opts?: GetOptions },
 ): Promise<Group<Store>>;
 
 function openV3<Store extends Readable>(
 	location: Location<Store> | Store,
-	options: { kind: "array"; opts?: unknown },
+	options: { kind: "array"; opts?: GetOptions },
 ): Promise<Array<DataType, Store>>;
 
 function openV3<Store extends Readable>(
 	location: Location<Store> | Store,
-	options?: { opts?: unknown },
+	options?: { opts?: GetOptions },
 ): Promise<Array<DataType, Store> | Group<Store>>;
 
 function openV3<Store extends Readable>(
 	location: Location<Store> | Store,
-	options?: { opts?: unknown },
+	options?: { opts?: GetOptions },
 ): Promise<Array<DataType, Store> | Group<Store>>;
 
 async function openV3<Store extends Readable>(
 	location: Location<Store>,
-	options: { kind?: "array" | "group"; opts?: unknown } = {},
+	options: { kind?: "array" | "group"; opts?: GetOptions } = {},
 ): Promise<Array<DataType, Store> | Group<Store>> {
 	let loc = "store" in location ? location : new Location(location);
 	let node = await _openV3(loc, options.opts);
@@ -172,17 +175,17 @@ async function openV3<Store extends Readable>(
 
 export function open<Store extends Readable>(
 	location: Location<Store> | Store,
-	options: { kind: "group"; attrs?: boolean; opts?: unknown },
+	options: { kind: "group"; attrs?: boolean; opts?: GetOptions },
 ): Promise<Group<Store>>;
 
 export function open<Store extends Readable>(
 	location: Location<Store> | Store,
-	options: { kind: "array"; attrs?: boolean; opts?: unknown },
+	options: { kind: "array"; attrs?: boolean; opts?: GetOptions },
 ): Promise<Array<DataType, Store>>;
 
 export async function open<Store extends Readable>(
 	location: Location<Store> | Store,
-	options: { kind?: "array" | "group"; attrs?: boolean; opts?: unknown },
+	options: { kind?: "array" | "group"; attrs?: boolean; opts?: GetOptions },
 ): Promise<Array<DataType, Store> | Group<Store>>;
 
 export function open<Store extends Readable>(
@@ -195,7 +198,11 @@ export function open<Store extends Readable>(
 
 export async function open<Store extends Readable>(
 	location: Location<Store> | Store,
-	options: { kind?: "array" | "group"; attrs?: boolean; opts?: unknown } = {},
+	options: {
+		kind?: "array" | "group";
+		attrs?: boolean;
+		opts?: GetOptions;
+	} = {},
 ): Promise<Array<DataType, Store> | Group<Store>> {
 	let store = "store" in location ? location.store : location;
 	let versionMax = VERSION_COUNTER.versionMax(store);

--- a/packages/zarrita/src/util.ts
+++ b/packages/zarrita/src/util.ts
@@ -388,13 +388,19 @@ type ErrorConstructor = new (...args: any[]) => Error;
  * @param errors - Expected error type(s)
  * @throws The original error if it doesn't match expected type(s)
  */
-export function isAbortable(opts: unknown): opts is { signal: AbortSignal } {
-	return (
-		opts != null &&
-		typeof opts === "object" &&
-		"signal" in opts &&
-		opts.signal instanceof AbortSignal
-	);
+/**
+ * Merge a first-class `signal` with the deprecated `opts.signal` shim.
+ * If both are set, the signals are combined via `AbortSignal.any` so that
+ * aborting either cancels the request.
+ */
+export function resolveSignal(opts: {
+	signal?: AbortSignal;
+	opts?: { signal?: AbortSignal };
+}): AbortSignal | undefined {
+	let a = opts.signal;
+	let b = opts.opts?.signal;
+	if (a && b) return AbortSignal.any([a, b]);
+	return a ?? b;
 }
 
 export function rethrowUnless<E extends ReadonlyArray<ErrorConstructor>>(


### PR DESCRIPTION
`AsyncReadable<Options>` existed so stores could receive arbitrary per-call state. Auth headers, presigning context, cancellation signals, even chunk-layer concerns like caching and prefetch priority (#296, vole-core's `wrapArray`).

It was a catch-all for extensions that had nowhere else to live, and the cost was a pile of type magic: higher-kinded-type encoding in the store middleware system (#384), threading generic types that didn't actually provide that much type safety. (TypeScript could often bail out to `any` when inference broke.)

Those extensions now have proper homes. Store middleware (#384) gives transport-layer concerns (auth, presigning, request transformation) a proper extension point, and the custom `fetch` option on `FetchStore` (#388) handles the per-store cases at the callsite. Chunk-layer concerns will move to `zarr.extendArray` in a follow-up.

What's left is `signal`, which now lives properly on the (non-generic) `AsyncReadable` interface and can be passed directly in `zarr.get` and `zarr.set` from the caller:

```ts
// Before
interface AsyncReadable<Options = unknown> {
  get(key: AbsolutePath, opts?: Options): Promise<Uint8Array | undefined>;
}
await zarr.get(arr, null, { opts: { signal: ctl.signal } });

// After
interface AsyncReadable {
  get(key: AbsolutePath, opts?: { signal?: AbortSignal }): Promise<Uint8Array | undefined>;
}
await zarr.get(arr, null, { signal: ctl.signal });
```

Batched caller signals in `withRangeBatching` are now merged with `AbortSignal.any` instead of a user-supplied `mergeOptions` reducer. The deprecated `opts?: { signal? }` shape still works for one major version and is folded into the new `signal` via `AbortSignal.any`.
