### PR TITLE
Add `zarr.defineArrayMiddleware` and `zarr.extendArray`

### DIFF
--- a/.changeset/add-abort-signal-support.md
+++ b/.changeset/add-abort-signal-support.md
@@ -2,13 +2,13 @@
 "zarrita": minor
 ---
 
-Add AbortSignal support to `open` and `set`. Store options containing a `signal` are forwarded to underlying `store.get` calls and checked between async steps for early cancellation.
+Add `AbortSignal` support to `open`, `get`, and `set`. The signal is forwarded to `store.get` calls and checked between async steps for early cancellation.
 
 ```ts
 const controller = new AbortController();
-const opts = { signal: controller.signal };
+const signal = controller.signal;
 
-await zarr.open(store, { kind: "array", opts });
-await zarr.get(arr, [null], { opts });
-await zarr.set(arr, [null], value, { opts });
+await zarr.open(store, { kind: "array", signal });
+await zarr.get(arr, [null], { signal });
+await zarr.set(arr, [null], value, { signal });
 ```

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -34,7 +34,7 @@ export default defineConfig({
 					{ text: "Slicing and Indexing", link: "/slicing" },
 					{ text: "Supported Types", link: "/supported-types" },
 					{ text: "Cookbook", link: "/cookbook" },
-					{ text: "Store Middleware", link: "/store-middleware" },
+					{ text: "Middleware", link: "/store-middleware" },
 				],
 			},
 			{

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -188,20 +188,9 @@ let store = zarr.withRangeBatching(
 );
 ```
 
-By default the first caller's options (headers, signal, etc.) are forwarded to
-the inner store. If you need to combine options from all callers in a batch,
-pass a `mergeOptions` reducer:
-
-```js
-let store = zarr.withRangeBatching(
-  new zarr.FetchStore("https://localhost:8080/data.zarr"),
-  {
-    mergeOptions: (batch) => ({
-      signal: AbortSignal.any(batch.map((o) => o?.signal).filter(Boolean)),
-    }),
-  },
-);
-```
+When multiple callers each pass their own `AbortSignal` and their requests
+land in the same batch, the signals are merged via `AbortSignal.any`: the
+shared request aborts as soon as any one caller aborts.
 
 You can inspect batching statistics via `store.stats`:
 

--- a/docs/packages/storage.md
+++ b/docs/packages/storage.md
@@ -16,12 +16,12 @@ In **zarrita**, a **store** must implement the `Readable` or `AsyncReadable`
 interface,
 
 ```typescript
-interface Readable<Options> {
-	get(key: string, options?: Options): Unit8Array | undefined;
+interface Readable {
+	get(key: string, options?: { signal?: AbortSignal }): Uint8Array | undefined;
 }
 
-interface AsyncReadable<Options> {
-	get(key: string, options?: Options): Promise<Uint8Array | undefined>;
+interface AsyncReadable {
+	get(key: string, options?: { signal?: AbortSignal }): Promise<Uint8Array | undefined>;
 }
 ```
 

--- a/docs/store-middleware.md
+++ b/docs/store-middleware.md
@@ -1,39 +1,46 @@
-# Store Middleware
+# Middleware
 
-Many of the stores in [`@zarrita/storage`](/packages/storage) (like
-[`FetchStore`](/packages/storage#fetchstore) and
-[`FileSystemStore`](/packages/storage#filesystemstore)) handle the raw
-byte-level connection with a data source.
+**zarrita** has two symmetric extension points for composing behavior on top
+of a base store or array: **store middleware** and **array middleware**.
 
-A common pattern is to _wrap_ a store in another store that adds behavior
-(e.g., caching responses, batching range requests, or serving pre-loaded
-metadata) while delegating everything else to the inner store.
+| Layer | Intercepts | Primitive | Composer |
+| --- | --- | --- | --- |
+| Transport | `store.get(key, range)` | `zarr.defineStoreMiddleware` | `zarr.extendStore` |
+| Data | `array.getChunk(coords)` | `zarr.defineArrayMiddleware` | `zarr.extendArray` |
 
-`zarr.defineStoreMiddleware` lets you define this kind of "middleware" that you can
-_compose_ with base stores using `zarr.extendStore`.
+Store middleware is for transport concerns (caching bytes, batching range
+requests, short-circuiting metadata, request transformation). Array middleware
+is for data concerns (caching decoded chunks, prefetch priority, observability).
+If you're not sure which layer you need: if your code deals in paths and
+bytes, it's a store middleware; if it deals in chunk coordinates, it's an
+array middleware.
 
-## Built-in middleware
+## Store middleware
 
-**zarrita** ships with middleware for consolidated metadata and range batching:
+Wrap a store with `zarr.defineStoreMiddleware`, then compose with
+`zarr.extendStore`. **zarrita** ships with middleware for consolidated metadata
+and range batching:
 
 ```ts
 import * as zarr from "zarrita";
 
 let store = await zarr.extendStore(
   new zarr.FetchStore("https://example.com/data.zarr"),
-  zarr.withConsolidation({ format: "v3" }),
-  zarr.withRangeBatching(),
+  zarr.withConsolidation,
+  (s) => zarr.withRangeBatching(s, { cacheSize: 512 }),
 );
 
 store.contents(); // from zarr.withConsolidation
 store.stats;      // from zarr.withRangeBatching
 ```
 
-Each middleware in the pipeline wraps the previous result. `zarr.extendStore`
-handles async middleware (like `zarr.withConsolidation`, which loads metadata)
-automatically. It always returns a `Promise`.
+Each middleware wraps the previous result. `zarr.extendStore` handles async
+middleware (like `zarr.withConsolidation`, which fetches metadata during
+initialization) automatically, and always returns a `Promise`. A middleware
+with no required options can be passed uncalled; otherwise wrap it in an arrow
+so the options are applied to the argument.
 
-You can also use middleware directly without `zarr.extendStore`:
+You can also call middleware directly:
 
 ```ts
 let consolidated = await zarr.withConsolidation(
@@ -42,21 +49,20 @@ let consolidated = await zarr.withConsolidation(
 );
 ```
 
-## Defining your own middleware
+### Defining your own
 
-Use `zarr.defineStoreMiddleware` to define custom middleware. The factory function receives
-the inner store and custom options, and returns an object with method overrides
-and/or new methods. Anything not returned is automatically delegated to the
+The factory receives the inner store and user options, and returns an object
+of method overrides and extensions. Anything not returned is delegated to the
 inner store via `Proxy`.
 
 ```ts
 import * as zarr from "zarrita";
 
 const withCaching = zarr.defineStoreMiddleware(
-  (store: zarr.AsyncReadable, opts: { maxSize?: number } = {}) => {
-    let cache = new Map<string, Uint8Array>();
+  (store, opts: { maxSize?: number } = {}) => {
+    let cache = new Map<zarr.AbsolutePath, Uint8Array>();
     return {
-      async get(key: zarr.AbsolutePath, options?: unknown) {
+      async get(key, options) {
         let hit = cache.get(key);
         if (hit) return hit;
         let result = await store.get(key, options);
@@ -74,27 +80,17 @@ let store = withCaching(new zarr.FetchStore("https://..."), { maxSize: 256 });
 store.clear(); // new method from the middleware
 ```
 
-The returned middleware supports a **dual API**: call it directly with `(store,
-opts)` or curry it with `(opts)` for use in `zarr.extendStore` pipelines:
-
-```ts
-// Direct
-let store = withCaching(new zarr.FetchStore("https://..."), { maxSize: 256 });
-
-// Curried (for zarr.extendStore)
-let store = await zarr.extendStore(
-  new zarr.FetchStore("https://..."),
-  withCaching({ maxSize: 256 }),
-);
-```
+Only `get` and `getRange` are interceptable; any other keys on the factory
+result become extensions on the wrapped store.
 
 Middleware can be **sync or async**. If the factory returns a `Promise`, the
 wrapper returns a `Promise` too:
 
 ```ts
 const withMetadata = zarr.defineStoreMiddleware(
-  async (store: zarr.AsyncReadable, opts: { key: string }) => {
-    let meta = JSON.parse(new TextDecoder().decode(await store.get(opts.key)));
+  async (store, opts: { key: zarr.AbsolutePath }) => {
+    let bytes = await store.get(opts.key);
+    let meta = JSON.parse(new TextDecoder().decode(bytes));
     return {
       metadata() { return meta; },
     };
@@ -105,73 +101,45 @@ let store = await withMetadata(rawStore, { key: "/meta.json" });
 store.metadata(); // loaded during initialization
 ```
 
-## Store options and generics
+## Array middleware
 
-Stores are generic over their request options type. For example,
-[`zarr.FetchStore`](/packages/storage#fetchstore) uses `RequestInit` so you can
-pass headers or an `AbortSignal` to individual requests. Most middleware
-doesn't need to know about this type, and `zarr.defineStoreMiddleware` preserves it
-automatically through the chain.
-
-Sometimes, though, middleware options _depend_ on the store's request options.
-For example, `zarr.withRangeBatching` has a `mergeOptions` callback that
-combines request options from concurrent callers, and its parameter type
-should match the store's options.
-
-This is an advanced typing feature purely for caller convenience. It ensures
-users get proper type inference and autocomplete on options that reference
-the store's request type. Use `zarr.defineStoreMiddleware.generic` with a
-`zarr.GenericOptions` interface that maps the store's options type into your
-middleware options:
+Array middleware is the symmetric extension point for **chunk-layer** concerns:
+anything that wants to intercept `getChunk(coords)` without caring about paths
+or bytes. Think chunk caching, prefetch priority, or observability hooks.
 
 ```ts
 import * as zarr from "zarrita";
 
-// 1. Define your options as a normal generic interface
-interface LoggingOptions<O> {
-  label?: string;
-  formatOptions?: (opts: O) => string;
-}
-
-// 2. Create the type lambda (one line that wires up the generic)
-interface LoggingOptsFor extends zarr.GenericOptions {
-  readonly options: LoggingOptions<this["_O"]>;
-}
-
-// 3. Define the middleware
-const withLogging = zarr.defineStoreMiddleware.generic<LoggingOptsFor>()(
-  (store, opts: LoggingOptions<unknown> = {}) => {
-    let label = opts.label ?? "store";
-    let format = opts.formatOptions ?? String;
-    return {
-      async get(key: zarr.AbsolutePath, options?: unknown) {
-        console.log(`[${label}] get ${key} ${format(options)}`);
-        return store.get(key, options);
-      },
-    };
-  },
+const withChunkCache = zarr.defineArrayMiddleware(
+  (array, opts: { cache: Map<string, zarr.Chunk<zarr.DataType>> }) => ({
+    async getChunk(coords, options) {
+      let key = coords.join(",");
+      let hit = opts.cache.get(key);
+      if (hit) return hit;
+      let chunk = await array.getChunk(coords, options);
+      opts.cache.set(key, chunk);
+      return chunk;
+    },
+  }),
 );
+
+let arr = await zarr.extendArray(
+  await zarr.open(store, { kind: "array" }),
+  (a) => withChunkCache(a, { cache: new Map() }),
+);
+
+await zarr.get(arr, null); // cache hits are served from the Map
 ```
 
-At the call site, `formatOptions` receives the store's options type:
+Only `getChunk` is interceptable in v1 — `shape`, `dtype`, `attrs`, `chunks`,
+`store`, and `path` are part of the array's identity and are always delegated
+to the inner array. Any other keys on the factory result become extensions on
+the wrapped array.
 
-```ts
-let store = withLogging(new zarr.FetchStore("https://..."), {
-  label: "my-store",
-  formatOptions: (opts) => {
-    //            ^^^^ typed as RequestInit
-    return opts.method ?? "GET";
-  },
-});
-```
+The factory sees `zarr.Array<DataType, Readable>` (the widest form) so it can
+be written once and applied to any concrete `Array<D, S>`. At the call site
+the outer generics are preserved, so downstream `zarr.get(wrapped)` calls
+return the right specific type.
 
-This is an advanced pattern. Most middleware won't need it. It exists so
-that _users_ of your middleware get proper type inference and autocomplete
-when their options reference the store's request type. If your options don't
-depend on the store type, use the simpler `zarr.defineStoreMiddleware` and skip the
-`zarr.GenericOptions` boilerplate entirely.
-
-Under the hood, `zarr.GenericOptions` uses TypeScript's `this` types to encode
-a [higher-kinded type](https://www.typescriptlang.org/docs/handbook/2/classes.html#this-types):
-`this["_O"]` refers to the store's request options, which gets substituted with
-the concrete type (e.g., `RequestInit`) at the call site.
+Like `extendStore`, `extendArray` always returns a `Promise` so middleware can
+perform async initialization.

--- a/packages/zarrita/__tests__/array-middleware.test.ts
+++ b/packages/zarrita/__tests__/array-middleware.test.ts
@@ -1,0 +1,118 @@
+import * as path from "node:path";
+import * as url from "node:url";
+import { describe, expect, it } from "vitest";
+import * as zarr from "../src/index.js";
+import { defineArrayMiddleware } from "../src/middleware/define-array.js";
+
+let __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+let fixturesRoot = path.resolve(__dirname, "../../../fixtures/v3/data.zarr");
+
+async function openFixture(name: string) {
+	let store = new zarr.FileSystemStore(fixturesRoot);
+	return zarr.open.v3(zarr.root(store).resolve(name), { kind: "array" });
+}
+
+describe("defineArrayMiddleware", () => {
+	it("intercepts getChunk", async () => {
+		let calls: number[][] = [];
+		let withTrace = defineArrayMiddleware((array) => ({
+			async getChunk(coords, options) {
+				calls.push(coords);
+				return array.getChunk(coords, options);
+			},
+		}));
+		let arr = await openFixture("1d.chunked.i2");
+		let wrapped = withTrace(arr);
+		let chunk = await wrapped.getChunk([0]);
+		expect(chunk.data).toBeInstanceOf(Int16Array);
+		expect(calls).toEqual([[0]]);
+	});
+
+	it("pass-through getters still work (private field access)", async () => {
+		let withNoop = defineArrayMiddleware((_array) => ({}));
+		let arr = await openFixture("1d.chunked.i2");
+		let wrapped = withNoop(arr);
+		// These all read from `this.#metadata` via getters on Array.
+		expect(wrapped.shape).toEqual(arr.shape);
+		expect(wrapped.dtype).toBe(arr.dtype);
+		expect(wrapped.chunks).toEqual(arr.chunks);
+		expect(wrapped.attrs).toEqual(arr.attrs);
+	});
+
+	it("extensions appear on the wrapped array", async () => {
+		let withCounter = defineArrayMiddleware((_array) => {
+			let n = 0;
+			return {
+				bump() {
+					n += 1;
+				},
+				get count(): number {
+					return n;
+				},
+			};
+		});
+		let arr = await openFixture("1d.chunked.i2");
+		let wrapped = withCounter(arr);
+		wrapped.bump();
+		wrapped.bump();
+		expect(wrapped.count).toBe(2);
+	});
+
+	it("works with zarr.get through the interception chain", async () => {
+		let cache = new Map<string, zarr.Chunk<zarr.DataType>>();
+		let withCache = defineArrayMiddleware((array) => ({
+			async getChunk(coords, options) {
+				let key = coords.join(",");
+				let hit = cache.get(key);
+				if (hit) return hit;
+				let chunk = await array.getChunk(coords, options);
+				cache.set(key, chunk);
+				return chunk;
+			},
+		}));
+		let arr = await openFixture("1d.chunked.i2");
+		let wrapped = withCache(arr);
+		let a = await zarr.get(wrapped);
+		let b = await zarr.get(wrapped);
+		expect(a.data).toStrictEqual(b.data);
+		// Second pass should hit the cache for each chunk.
+		expect(cache.size).toBeGreaterThan(0);
+	});
+});
+
+describe("extendArray", () => {
+	it("no middleware returns the array as-is", async () => {
+		let arr = await openFixture("1d.chunked.i2");
+		let result = await zarr.extendArray(arr);
+		expect(result).toBe(arr);
+	});
+
+	it("composes multiple middlewares in order", async () => {
+		let order: string[] = [];
+		let withA = defineArrayMiddleware((_array) => ({
+			tagA: "a",
+			async getChunk(coords, options) {
+				order.push("a");
+				return _array.getChunk(coords, options);
+			},
+		}));
+		let withB = defineArrayMiddleware((_array) => ({
+			tagB: "b",
+			async getChunk(coords, options) {
+				order.push("b");
+				return _array.getChunk(coords, options);
+			},
+		}));
+		let arr = await openFixture("1d.chunked.i2");
+		let wrapped = await zarr.extendArray(
+			arr,
+			(a) => withA(a),
+			(a) => withB(a),
+		);
+		expect(wrapped.tagA).toBe("a");
+		expect(wrapped.tagB).toBe("b");
+		await wrapped.getChunk([0]);
+		// Outer wrapper runs first; it calls through to inner.
+		expect(order).toEqual(["b", "a"]);
+	});
+});

--- a/packages/zarrita/__tests__/middleware-types.test.ts
+++ b/packages/zarrita/__tests__/middleware-types.test.ts
@@ -8,7 +8,7 @@ import { defineArrayMiddleware } from "../src/middleware/define-array.js";
 describe("extendStore", () => {
 	test("no middleware returns store as-is", () => {
 		let store = zarr.extendStore(new zarr.FetchStore(""));
-		expectType(store).toMatchInlineSnapshot(`Promise<zarr.FetchStore>`);
+		expectType(store).toMatchInlineSnapshot(`zarr.FetchStore`);
 	});
 
 	test("direct form in pipeline", () => {
@@ -16,12 +16,10 @@ describe("extendStore", () => {
 			zarr.withRangeBatching(s),
 		);
 		expectType(store).toMatchInlineSnapshot(`
-			Promise<
-				Required<AsyncReadable> & {
-					stats: Readonly<zarr.RangeBatchingStats>;
-					url: string | URL;
-				}
-			>
+			Required<AsyncReadable> & {
+				stats: Readonly<zarr.RangeBatchingStats>;
+				url: string | URL;
+			}
 		`);
 	});
 

--- a/packages/zarrita/__tests__/middleware-types.test.ts
+++ b/packages/zarrita/__tests__/middleware-types.test.ts
@@ -3,6 +3,7 @@ import { expectType } from "tintype";
 import { describe, expect, test, vi } from "vitest";
 import * as zarr from "../src/index.js";
 import { defineStoreMiddleware } from "../src/middleware/define.js";
+import { defineArrayMiddleware } from "../src/middleware/define-array.js";
 
 describe("extendStore", () => {
 	test("no middleware returns store as-is", () => {
@@ -131,5 +132,25 @@ describe("defineStoreMiddleware", () => {
 		} finally {
 			fetchSpy.mockRestore();
 		}
+	});
+});
+
+describe("defineArrayMiddleware", () => {
+	test("extensions appear, concrete D/S are preserved", () => {
+		let withCounter = defineArrayMiddleware((_array) => ({
+			bump(): void {},
+			get count(): number {
+				return 0;
+			},
+		}));
+		// Simulate a typed Array; the wrapper should preserve <"int16", FetchStore>.
+		function check(arr: zarr.Array<"int16", zarr.FetchStore>) {
+			return withCounter(arr);
+		}
+		expectType(check).toMatchInlineSnapshot(`
+			(
+				arr: zarr.Array<"int16", zarr.FetchStore>,
+			) => zarr.Array<"int16", zarr.FetchStore> & { bump: () => void; count: number }
+		`);
 	});
 });

--- a/packages/zarrita/__tests__/signal.test.ts
+++ b/packages/zarrita/__tests__/signal.test.ts
@@ -110,3 +110,39 @@ describe("signal propagation through zarr.get", () => {
 		).rejects.toThrow(/abort/i);
 	});
 });
+
+describe("zarr.set cancels on signal", () => {
+	it("aborting signal rejects a pending zarr.set", async () => {
+		let store = new Map<string, Uint8Array>();
+		let arr = await zarr.create(store, {
+			dtype: "int16",
+			shape: [4],
+			chunkShape: [2],
+		});
+		let ctl = new AbortController();
+		ctl.abort(new Error("aborted"));
+		await expect(
+			zarr.set(arr, null, 42, { signal: ctl.signal }),
+		).rejects.toThrow(/abort/i);
+	});
+});
+
+describe("signal propagation through extendStore pipeline", () => {
+	it("reaches the inner store through multiple middlewares", async () => {
+		let fsStore = new zarr.FileSystemStore(fixturesRoot);
+		let { store: recorder, calls } = recordingStore(fsStore);
+		let composed = await zarr.extendStore(recorder, (s) =>
+			zarr.withRangeBatching(s),
+		);
+		let arr = await zarr.open.v3(
+			zarr.root(composed).resolve("1d.chunked.compressed.sharded.i2"),
+			{ kind: "array" },
+		);
+		let ctl = new AbortController();
+		await zarr.get(arr, null, { signal: ctl.signal });
+		// At least one of the inner-store calls carried our signal through
+		// the batching middleware.
+		let seen = calls.some((c) => c?.signal === ctl.signal);
+		expect(seen).toBe(true);
+	});
+});

--- a/packages/zarrita/src/index.ts
+++ b/packages/zarrita/src/index.ts
@@ -49,6 +49,8 @@ export {
 	withMaybeConsolidation as tryWithConsolidated,
 } from "./middleware/consolidation.js";
 export { defineStoreMiddleware } from "./middleware/define.js";
+export { defineArrayMiddleware } from "./middleware/define-array.js";
+export { extendArray } from "./middleware/extend-array.js";
 export { extendStore } from "./middleware/extend-store.js";
 export type {
 	RangeBatchingOptions,

--- a/packages/zarrita/src/middleware/define-array.ts
+++ b/packages/zarrita/src/middleware/define-array.ts
@@ -1,0 +1,80 @@
+import type { Readable } from "@zarrita/storage";
+import type { Array } from "../hierarchy.js";
+import type { DataType } from "../metadata.js";
+import { assertFactoryResult, createProxy } from "./define.js";
+
+/** Array keys whose overrides are intercepted by the middleware. */
+type ArrayOverrideKeys = "getChunk";
+
+/** Strip array keys from extensions so Array's own surface isn't duplicated. */
+type Extensions<T> = {
+	[K in Extract<Exclude<keyof T, ArrayOverrideKeys>, string>]: T[K];
+} & {};
+
+type Prettify<T> = { [K in keyof T]: T[K] } & {};
+
+type WrapperResult<R, A> =
+	R extends Promise<infer Inner>
+		? Promise<A & Prettify<Extensions<Inner>>>
+		: A & Prettify<Extensions<R>>;
+
+type FactoryResult = Partial<
+	Pick<Array<DataType, Readable>, ArrayOverrideKeys>
+> &
+	Record<string, unknown>;
+
+/**
+ * Define a composable array middleware.
+ *
+ * The factory receives the inner `Array` and user options, and returns an
+ * object of overrides and extensions. In v1 only `getChunk` is interceptable —
+ * every other property (shape, dtype, attrs, path, store) is delegated to
+ * the inner array via `Proxy`.
+ *
+ * The factory sees `Array<DataType, Readable>` (the widest form) so it can
+ * be written once and applied to any concrete `Array<D, S>`. At the call
+ * site the outer generics are preserved, so downstream `zarr.get(...)`
+ * calls still return the right specific type.
+ *
+ * ```ts
+ * import * as zarr from "zarrita";
+ *
+ * const withChunkCache = zarr.defineArrayMiddleware(
+ *   (array, opts: { cache: Map<string, zarr.Chunk<zarr.DataType>> }) => ({
+ *     async getChunk(coords, options) {
+ *       let key = coords.join(",");
+ *       let hit = opts.cache.get(key);
+ *       if (hit) return hit;
+ *       let chunk = await array.getChunk(coords, options);
+ *       opts.cache.set(key, chunk);
+ *       return chunk;
+ *     },
+ *   }),
+ * );
+ * ```
+ */
+export function defineArrayMiddleware<
+	R extends FactoryResult | Promise<FactoryResult>,
+	Opts = void,
+>(
+	factory: (array: Array<DataType, Readable>, opts: Opts) => R,
+): <A extends Array<DataType, Readable>>(
+	array: A,
+	opts?: Opts,
+) => WrapperResult<R, A>;
+export function defineArrayMiddleware(
+	factory: (array: Array<DataType, Readable>, opts: never) => unknown,
+): (array: Array<DataType, Readable>, opts?: unknown) => unknown {
+	return (array, opts) => {
+		// @ts-expect-error - factory's opts parameter is wider than `never` at runtime.
+		let result: unknown = factory(array, opts);
+		if (result instanceof Promise) {
+			return result.then((overrides) => {
+				assertFactoryResult(overrides);
+				return createProxy(array, overrides);
+			});
+		}
+		assertFactoryResult(result);
+		return createProxy(array, result);
+	};
+}

--- a/packages/zarrita/src/middleware/define.ts
+++ b/packages/zarrita/src/middleware/define.ts
@@ -26,28 +26,38 @@ type WrapperResult<R, S> =
 		? Promise<CollapseStore<S & Extensions<Inner>>>
 		: CollapseStore<S & Extensions<R>>;
 
-function createProxy(
-	store: object,
+/**
+ * Build a Proxy that serves `overrides` for listed keys and delegates the
+ * rest to `target`. Getters and methods run with `this = target` so that
+ * class instances with private fields (e.g. `FetchStore.#fetch`,
+ * `Array.#metadata`) continue to work when accessed through the wrapper.
+ */
+export function createProxy<T extends object>(
+	target: T,
 	overrides: Record<string | symbol, unknown>,
-) {
-	return new Proxy(store, {
-		get(target, prop, receiver) {
-			if (prop in overrides) {
-				return overrides[prop];
+): T {
+	let boundCache = new Map<string | symbol, unknown>();
+	return new Proxy(target, {
+		get(t, prop) {
+			if (prop in overrides) return overrides[prop];
+			let cached = boundCache.get(prop);
+			if (cached !== undefined) return cached;
+			let value = Reflect.get(t, prop, t);
+			if (typeof value === "function") {
+				let bound = value.bind(t);
+				boundCache.set(prop, bound);
+				return bound;
 			}
-			return Reflect.get(target, prop, receiver);
+			return value;
 		},
-		has(target, prop) {
-			return prop in overrides || Reflect.has(target, prop);
+		has(t, prop) {
+			return prop in overrides || Reflect.has(t, prop);
 		},
-		ownKeys(target) {
-			let keys = new Set([
-				...Reflect.ownKeys(target),
-				...Object.keys(overrides),
-			]);
+		ownKeys(t) {
+			let keys = new Set([...Reflect.ownKeys(t), ...Object.keys(overrides)]);
 			return [...keys];
 		},
-		getOwnPropertyDescriptor(target, prop) {
+		getOwnPropertyDescriptor(t, prop) {
 			if (prop in overrides) {
 				return {
 					configurable: true,
@@ -55,20 +65,18 @@ function createProxy(
 					value: overrides[prop],
 				};
 			}
-			return Reflect.getOwnPropertyDescriptor(target, prop);
+			return Reflect.getOwnPropertyDescriptor(t, prop);
 		},
 	});
 }
 
 type FactoryResult = Partial<AsyncReadable> & Record<string, unknown>;
 
-function assertFactoryResult(
+export function assertFactoryResult(
 	value: unknown,
 ): asserts value is Record<string | symbol, unknown> {
 	if (value == null || typeof value !== "object") {
-		throw new Error(
-			"Store middleware factory must return an object of overrides",
-		);
+		throw new Error("Middleware factory must return an object of overrides");
 	}
 }
 

--- a/packages/zarrita/src/middleware/extend-array.ts
+++ b/packages/zarrita/src/middleware/extend-array.ts
@@ -1,32 +1,33 @@
 import type { Readable } from "@zarrita/storage";
 import type { Array } from "../hierarchy.js";
 import type { DataType } from "../metadata.js";
+import { applyMiddlewares, type MaybeAsync } from "./extend.js";
 
 type AnyArray = Array<DataType, Readable>;
 
-export function extendArray<A extends AnyArray>(array: A): Promise<A>;
+export function extendArray<A extends AnyArray>(array: A): A;
 export function extendArray<A extends AnyArray, R1>(
 	array: A,
 	m1: (array: A) => R1,
-): Promise<Awaited<R1>>;
+): MaybeAsync<R1, [R1]>;
 export function extendArray<A extends AnyArray, R1, R2>(
 	array: A,
 	m1: (array: A) => R1,
 	m2: (array: Awaited<R1>) => R2,
-): Promise<Awaited<R2>>;
+): MaybeAsync<R2, [R1, R2]>;
 export function extendArray<A extends AnyArray, R1, R2, R3>(
 	array: A,
 	m1: (array: A) => R1,
 	m2: (array: Awaited<R1>) => R2,
 	m3: (array: Awaited<R2>) => R3,
-): Promise<Awaited<R3>>;
+): MaybeAsync<R3, [R1, R2, R3]>;
 export function extendArray<A extends AnyArray, R1, R2, R3, R4>(
 	array: A,
 	m1: (array: A) => R1,
 	m2: (array: Awaited<R1>) => R2,
 	m3: (array: Awaited<R2>) => R3,
 	m4: (array: Awaited<R3>) => R4,
-): Promise<Awaited<R4>>;
+): MaybeAsync<R4, [R1, R2, R3, R4]>;
 export function extendArray<A extends AnyArray, R1, R2, R3, R4, R5>(
 	array: A,
 	m1: (array: A) => R1,
@@ -34,14 +35,10 @@ export function extendArray<A extends AnyArray, R1, R2, R3, R4, R5>(
 	m3: (array: Awaited<R2>) => R3,
 	m4: (array: Awaited<R3>) => R4,
 	m5: (array: Awaited<R4>) => R5,
-): Promise<Awaited<R5>>;
-export async function extendArray(
+): MaybeAsync<R5, [R1, R2, R3, R4, R5]>;
+export function extendArray(
 	array: AnyArray,
 	...middlewares: ((array: unknown) => unknown)[]
-): Promise<unknown> {
-	let result: unknown = array;
-	for (let m of middlewares) {
-		result = await m(result);
-	}
-	return result;
+): unknown {
+	return applyMiddlewares(array, middlewares);
 }

--- a/packages/zarrita/src/middleware/extend-array.ts
+++ b/packages/zarrita/src/middleware/extend-array.ts
@@ -1,0 +1,47 @@
+import type { Readable } from "@zarrita/storage";
+import type { Array } from "../hierarchy.js";
+import type { DataType } from "../metadata.js";
+
+type AnyArray = Array<DataType, Readable>;
+
+export function extendArray<A extends AnyArray>(array: A): Promise<A>;
+export function extendArray<A extends AnyArray, R1>(
+	array: A,
+	m1: (array: A) => R1,
+): Promise<Awaited<R1>>;
+export function extendArray<A extends AnyArray, R1, R2>(
+	array: A,
+	m1: (array: A) => R1,
+	m2: (array: Awaited<R1>) => R2,
+): Promise<Awaited<R2>>;
+export function extendArray<A extends AnyArray, R1, R2, R3>(
+	array: A,
+	m1: (array: A) => R1,
+	m2: (array: Awaited<R1>) => R2,
+	m3: (array: Awaited<R2>) => R3,
+): Promise<Awaited<R3>>;
+export function extendArray<A extends AnyArray, R1, R2, R3, R4>(
+	array: A,
+	m1: (array: A) => R1,
+	m2: (array: Awaited<R1>) => R2,
+	m3: (array: Awaited<R2>) => R3,
+	m4: (array: Awaited<R3>) => R4,
+): Promise<Awaited<R4>>;
+export function extendArray<A extends AnyArray, R1, R2, R3, R4, R5>(
+	array: A,
+	m1: (array: A) => R1,
+	m2: (array: Awaited<R1>) => R2,
+	m3: (array: Awaited<R2>) => R3,
+	m4: (array: Awaited<R3>) => R4,
+	m5: (array: Awaited<R4>) => R5,
+): Promise<Awaited<R5>>;
+export async function extendArray(
+	array: AnyArray,
+	...middlewares: ((array: unknown) => unknown)[]
+): Promise<unknown> {
+	let result: unknown = array;
+	for (let m of middlewares) {
+		result = await m(result);
+	}
+	return result;
+}

--- a/packages/zarrita/src/middleware/extend-store.ts
+++ b/packages/zarrita/src/middleware/extend-store.ts
@@ -1,43 +1,40 @@
 import type { AsyncReadable } from "@zarrita/storage";
+import { applyMiddlewares, type MaybeAsync } from "./extend.js";
 
-export function extendStore<S extends AsyncReadable>(store: S): Promise<S>;
-export function extendStore<S extends AsyncReadable, A>(
+export function extendStore<S extends AsyncReadable>(store: S): S;
+export function extendStore<S extends AsyncReadable, R1>(
 	store: S,
-	m1: (store: S) => A,
-): Promise<Awaited<A>>;
-export function extendStore<S extends AsyncReadable, A, B>(
+	m1: (store: S) => R1,
+): MaybeAsync<R1, [R1]>;
+export function extendStore<S extends AsyncReadable, R1, R2>(
 	store: S,
-	m1: (store: S) => A,
-	m2: (store: Awaited<A>) => B,
-): Promise<Awaited<B>>;
-export function extendStore<S extends AsyncReadable, A, B, C>(
+	m1: (store: S) => R1,
+	m2: (store: Awaited<R1>) => R2,
+): MaybeAsync<R2, [R1, R2]>;
+export function extendStore<S extends AsyncReadable, R1, R2, R3>(
 	store: S,
-	m1: (store: S) => A,
-	m2: (store: Awaited<A>) => B,
-	m3: (store: Awaited<B>) => C,
-): Promise<Awaited<C>>;
-export function extendStore<S extends AsyncReadable, A, B, C, D>(
+	m1: (store: S) => R1,
+	m2: (store: Awaited<R1>) => R2,
+	m3: (store: Awaited<R2>) => R3,
+): MaybeAsync<R3, [R1, R2, R3]>;
+export function extendStore<S extends AsyncReadable, R1, R2, R3, R4>(
 	store: S,
-	m1: (store: S) => A,
-	m2: (store: Awaited<A>) => B,
-	m3: (store: Awaited<B>) => C,
-	m4: (store: Awaited<C>) => D,
-): Promise<Awaited<D>>;
-export function extendStore<S extends AsyncReadable, A, B, C, D, E>(
+	m1: (store: S) => R1,
+	m2: (store: Awaited<R1>) => R2,
+	m3: (store: Awaited<R2>) => R3,
+	m4: (store: Awaited<R3>) => R4,
+): MaybeAsync<R4, [R1, R2, R3, R4]>;
+export function extendStore<S extends AsyncReadable, R1, R2, R3, R4, R5>(
 	store: S,
-	m1: (store: S) => A,
-	m2: (store: Awaited<A>) => B,
-	m3: (store: Awaited<B>) => C,
-	m4: (store: Awaited<C>) => D,
-	m5: (store: Awaited<D>) => E,
-): Promise<Awaited<E>>;
-export async function extendStore(
+	m1: (store: S) => R1,
+	m2: (store: Awaited<R1>) => R2,
+	m3: (store: Awaited<R2>) => R3,
+	m4: (store: Awaited<R3>) => R4,
+	m5: (store: Awaited<R4>) => R5,
+): MaybeAsync<R5, [R1, R2, R3, R4, R5]>;
+export function extendStore(
 	store: AsyncReadable,
 	...middlewares: ((store: unknown) => unknown)[]
-): Promise<unknown> {
-	let result: unknown = store;
-	for (let m of middlewares) {
-		result = await m(result);
-	}
-	return result;
+): unknown {
+	return applyMiddlewares(store, middlewares);
 }

--- a/packages/zarrita/src/middleware/extend.ts
+++ b/packages/zarrita/src/middleware/extend.ts
@@ -1,0 +1,34 @@
+/**
+ * Walk a list of middlewares, calling each synchronously until one returns a
+ * `Promise`. From that point on, chain the remaining middlewares with `.then`
+ * so the caller only pays the cost of a Promise if any step actually needs
+ * one. This is the shared runtime used by `extendStore` and `extendArray`.
+ */
+export function applyMiddlewares(
+	value: unknown,
+	middlewares: readonly ((value: unknown) => unknown)[],
+): unknown {
+	let result = value;
+	for (let m of middlewares) {
+		if (result instanceof Promise) {
+			result = result.then((v) => m(v));
+		} else {
+			result = m(result);
+		}
+	}
+	return result;
+}
+
+/** True if any type in the tuple is a Promise. */
+export type AnyPromise<Rs extends readonly unknown[]> = [
+	Extract<Rs[number], Promise<unknown>>,
+] extends [never]
+	? false
+	: true;
+
+/**
+ * Wrap `Final` in `Promise` iff any of the middleware results in `Rs` was a
+ * Promise, otherwise return the unwrapped value type.
+ */
+export type MaybeAsync<Final, Rs extends readonly unknown[]> =
+	AnyPromise<Rs> extends true ? Promise<Awaited<Final>> : Awaited<Final>;

--- a/packages/zarrita/src/open.ts
+++ b/packages/zarrita/src/open.ts
@@ -1,4 +1,4 @@
-import type { GetOptions, Readable } from "@zarrita/storage";
+import type { Readable } from "@zarrita/storage";
 import { InvalidMetadataError, NotFoundError } from "./errors.js";
 import { Array, Group, Location } from "./hierarchy.js";
 import type {
@@ -36,59 +36,60 @@ function createVersionCounter() {
 
 async function loadAttrs(
 	location: Location<Readable>,
-	opts?: GetOptions,
+	signal?: AbortSignal,
 ): Promise<Attributes> {
-	let metaBytes = await location.store.get(
-		location.resolve(".zattrs").path,
-		opts,
-	);
+	let metaBytes = await location.store.get(location.resolve(".zattrs").path, {
+		signal,
+	});
 	if (!metaBytes) return {};
 	return jsonDecodeObject(metaBytes);
 }
 
+type OpenV2Options = {
+	kind?: "array" | "group";
+	attrs?: boolean;
+	signal?: AbortSignal;
+};
+
 function openV2<Store extends Readable>(
 	location: Location<Store> | Store,
-	options: { kind: "group"; attrs?: boolean; opts?: GetOptions },
+	options: OpenV2Options & { kind: "group" },
 ): Promise<Group<Store>>;
 
 function openV2<Store extends Readable>(
 	location: Location<Store> | Store,
-	options: { kind: "array"; attrs?: boolean; opts?: GetOptions },
+	options: OpenV2Options & { kind: "array" },
 ): Promise<Array<DataType, Store>>;
 
 function openV2<Store extends Readable>(
 	location: Location<Store> | Store,
-	options?: { kind?: "array" | "group"; attrs?: boolean; opts?: GetOptions },
+	options?: OpenV2Options,
 ): Promise<Array<DataType, Store> | Group<Store>>;
 
 async function openV2<Store extends Readable>(
 	location: Location<Store> | Store,
-	options: {
-		kind?: "array" | "group";
-		attrs?: boolean;
-		opts?: GetOptions;
-	} = {},
+	options: OpenV2Options = {},
 ) {
 	let loc = "store" in location ? location : new Location(location);
-	let { opts } = options;
+	let { signal } = options;
 	let attrs = {};
-	if (options.attrs ?? true) attrs = await loadAttrs(loc, opts);
-	opts?.signal?.throwIfAborted();
-	if (options.kind === "array") return openArrayV2(loc, attrs, opts);
-	if (options.kind === "group") return openGroupV2(loc, attrs, opts);
-	return openArrayV2(loc, attrs, opts).catch((err) => {
+	if (options.attrs ?? true) attrs = await loadAttrs(loc, signal);
+	signal?.throwIfAborted();
+	if (options.kind === "array") return openArrayV2(loc, attrs, signal);
+	if (options.kind === "group") return openGroupV2(loc, attrs, signal);
+	return openArrayV2(loc, attrs, signal).catch((err) => {
 		rethrowUnless(err, NotFoundError, InvalidMetadataError);
-		return openGroupV2(loc, attrs, opts);
+		return openGroupV2(loc, attrs, signal);
 	});
 }
 
 async function openArrayV2<Store extends Readable>(
 	location: Location<Store>,
 	attrs: Attributes,
-	opts?: GetOptions,
+	signal?: AbortSignal,
 ) {
 	let { path } = location.resolve(".zarray");
-	let meta = await location.store.get(path, opts);
+	let meta = await location.store.get(path, { signal });
 	if (!meta) {
 		throw new NotFoundError("v2 array", { path });
 	}
@@ -103,10 +104,10 @@ async function openArrayV2<Store extends Readable>(
 async function openGroupV2<Store extends Readable>(
 	location: Location<Store>,
 	attrs: Attributes,
-	opts?: GetOptions,
+	signal?: AbortSignal,
 ) {
 	let { path } = location.resolve(".zgroup");
-	let meta = await location.store.get(path, opts);
+	let meta = await location.store.get(path, { signal });
 	if (!meta) {
 		throw new NotFoundError("v2 group", { path });
 	}
@@ -120,10 +121,10 @@ async function openGroupV2<Store extends Readable>(
 
 async function _openV3<Store extends Readable>(
 	location: Location<Store>,
-	opts?: GetOptions,
+	signal?: AbortSignal,
 ) {
 	let { store, path } = location.resolve("zarr.json");
-	let meta = await location.store.get(path, opts);
+	let meta = await location.store.get(path, { signal });
 	if (!meta) {
 		throw new NotFoundError("v3 array or group", { path });
 	}
@@ -136,32 +137,32 @@ async function _openV3<Store extends Readable>(
 		: new Group(store, location.path, metaDoc);
 }
 
+type OpenV3Options = {
+	kind?: "array" | "group";
+	signal?: AbortSignal;
+};
+
 function openV3<Store extends Readable>(
 	location: Location<Store> | Store,
-	options: { kind: "group"; opts?: GetOptions },
+	options: OpenV3Options & { kind: "group" },
 ): Promise<Group<Store>>;
 
 function openV3<Store extends Readable>(
 	location: Location<Store> | Store,
-	options: { kind: "array"; opts?: GetOptions },
+	options: OpenV3Options & { kind: "array" },
 ): Promise<Array<DataType, Store>>;
 
 function openV3<Store extends Readable>(
 	location: Location<Store> | Store,
-	options?: { opts?: GetOptions },
-): Promise<Array<DataType, Store> | Group<Store>>;
-
-function openV3<Store extends Readable>(
-	location: Location<Store> | Store,
-	options?: { opts?: GetOptions },
+	options?: OpenV3Options,
 ): Promise<Array<DataType, Store> | Group<Store>>;
 
 async function openV3<Store extends Readable>(
 	location: Location<Store>,
-	options: { kind?: "array" | "group"; opts?: GetOptions } = {},
+	options: OpenV3Options = {},
 ): Promise<Array<DataType, Store> | Group<Store>> {
 	let loc = "store" in location ? location : new Location(location);
-	let node = await _openV3(loc, options.opts);
+	let node = await _openV3(loc, options.signal);
 	VERSION_COUNTER.increment(loc.store, "v3");
 	if (options.kind === undefined) return node;
 	if (options.kind === "array" && node instanceof Array) return node;
@@ -173,36 +174,30 @@ async function openV3<Store extends Readable>(
 	});
 }
 
+type OpenOptions = {
+	kind?: "array" | "group";
+	attrs?: boolean;
+	signal?: AbortSignal;
+};
+
 export function open<Store extends Readable>(
 	location: Location<Store> | Store,
-	options: { kind: "group"; attrs?: boolean; opts?: GetOptions },
+	options: OpenOptions & { kind: "group" },
 ): Promise<Group<Store>>;
 
 export function open<Store extends Readable>(
 	location: Location<Store> | Store,
-	options: { kind: "array"; attrs?: boolean; opts?: GetOptions },
+	options: OpenOptions & { kind: "array" },
 ): Promise<Array<DataType, Store>>;
 
-export async function open<Store extends Readable>(
-	location: Location<Store> | Store,
-	options: { kind?: "array" | "group"; attrs?: boolean; opts?: GetOptions },
-): Promise<Array<DataType, Store> | Group<Store>>;
-
 export function open<Store extends Readable>(
 	location: Location<Store> | Store,
-): Promise<Array<DataType, Store> | Group<Store>>;
-
-export function open<Store extends Readable>(
-	location: Location<Store> | Store,
+	options?: OpenOptions,
 ): Promise<Array<DataType, Store> | Group<Store>>;
 
 export async function open<Store extends Readable>(
 	location: Location<Store> | Store,
-	options: {
-		kind?: "array" | "group";
-		attrs?: boolean;
-		opts?: GetOptions;
-	} = {},
+	options: OpenOptions = {},
 ): Promise<Array<DataType, Store> | Group<Store>> {
 	let store = "store" in location ? location.store : location;
 	let versionMax = VERSION_COUNTER.versionMax(store);


### PR DESCRIPTION
The data-layer counterpart to `zarr.defineStoreMiddleware` / `zarr.extendStore` (#384). Array middleware intercepts `getChunk(coords)`; everything else on the Array (shape, dtype, attrs, path, store) is delegated via `Proxy` to the inner instance.

In v1 only `getChunk` is interceptable — additional fields on the factory result appear as extensions on the wrapped array, so you can bolt on caches, counters, or observability hooks without reaching into the class.

The shared `createProxy` in `define.ts` had a latent bug: it forwarded property access with `receiver = proxy`, which meant getters and methods ran with `this = proxy` and choked on class private fields (`Array.#metadata`, `FetchStore.#fetch`). Fixed by running getters against the target directly and binding methods to the target. Store middleware benefits too.

No built-in chunk middleware ships with this change; `withChunkCache` and similar can be layered on as follow-ups or built by users.

```ts
const withChunkCache = zarr.defineArrayMiddleware(
  (array, opts: { cache: Map<string, zarr.Chunk<zarr.DataType>> }) => ({
    async getChunk(coords, options) {
      let key = coords.join(",");
      let hit = opts.cache.get(key);
      if (hit) return hit;
      let chunk = await array.getChunk(coords, options);
      opts.cache.set(key, chunk);
      return chunk;
    },
  }),
);

let wrapped = await zarr.extendArray(
  await zarr.open(store, { kind: "array" }),
  (a) => withChunkCache(a, { cache: new Map() }),
);
```