### PR TITLE
Document middleware extension points and tighten signal tests

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -34,7 +34,7 @@ export default defineConfig({
 					{ text: "Slicing and Indexing", link: "/slicing" },
 					{ text: "Supported Types", link: "/supported-types" },
 					{ text: "Cookbook", link: "/cookbook" },
-					{ text: "Store Middleware", link: "/store-middleware" },
+					{ text: "Middleware", link: "/store-middleware" },
 				],
 			},
 			{

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -188,20 +188,9 @@ let store = zarr.withRangeBatching(
 );
 ```
 
-By default the first caller's options (headers, signal, etc.) are forwarded to
-the inner store. If you need to combine options from all callers in a batch,
-pass a `mergeOptions` reducer:
-
-```js
-let store = zarr.withRangeBatching(
-  new zarr.FetchStore("https://localhost:8080/data.zarr"),
-  {
-    mergeOptions: (batch) => ({
-      signal: AbortSignal.any(batch.map((o) => o?.signal).filter(Boolean)),
-    }),
-  },
-);
-```
+When multiple callers each pass their own `AbortSignal` and their requests
+land in the same batch, the signals are merged via `AbortSignal.any`: the
+shared request aborts as soon as any one caller aborts.
 
 You can inspect batching statistics via `store.stats`:
 

--- a/docs/packages/storage.md
+++ b/docs/packages/storage.md
@@ -16,12 +16,16 @@ In **zarrita**, a **store** must implement the `Readable` or `AsyncReadable`
 interface,
 
 ```typescript
-interface Readable<Options> {
-	get(key: string, options?: Options): Unit8Array | undefined;
+interface GetOptions {
+	signal?: AbortSignal;
 }
 
-interface AsyncReadable<Options> {
-	get(key: string, options?: Options): Promise<Uint8Array | undefined>;
+interface Readable {
+	get(key: string, options?: GetOptions): Uint8Array | undefined;
+}
+
+interface AsyncReadable {
+	get(key: string, options?: GetOptions): Promise<Uint8Array | undefined>;
 }
 ```
 

--- a/docs/store-middleware.md
+++ b/docs/store-middleware.md
@@ -1,39 +1,46 @@
-# Store Middleware
+# Middleware
 
-Many of the stores in [`@zarrita/storage`](/packages/storage) (like
-[`FetchStore`](/packages/storage#fetchstore) and
-[`FileSystemStore`](/packages/storage#filesystemstore)) handle the raw
-byte-level connection with a data source.
+**zarrita** has two symmetric extension points for composing behavior on top
+of a base store or array: **store middleware** and **array middleware**.
 
-A common pattern is to _wrap_ a store in another store that adds behavior
-(e.g., caching responses, batching range requests, or serving pre-loaded
-metadata) while delegating everything else to the inner store.
+| Layer | Intercepts | Primitive | Composer |
+| --- | --- | --- | --- |
+| Transport | `store.get(key, range)` | `zarr.defineStoreMiddleware` | `zarr.extendStore` |
+| Data | `array.getChunk(coords)` | `zarr.defineArrayMiddleware` | `zarr.extendArray` |
 
-`zarr.defineStoreMiddleware` lets you define this kind of "middleware" that you can
-_compose_ with base stores using `zarr.extendStore`.
+Store middleware is for transport concerns (caching bytes, batching range
+requests, short-circuiting metadata, request transformation). Array middleware
+is for data concerns (caching decoded chunks, prefetch priority, observability).
+If you're not sure which layer you need: if your code deals in paths and
+bytes, it's a store middleware; if it deals in chunk coordinates, it's an
+array middleware.
 
-## Built-in middleware
+## Store middleware
 
-**zarrita** ships with middleware for consolidated metadata and range batching:
+Wrap a store with `zarr.defineStoreMiddleware`, then compose with
+`zarr.extendStore`. **zarrita** ships with middleware for consolidated metadata
+and range batching:
 
 ```ts
 import * as zarr from "zarrita";
 
 let store = await zarr.extendStore(
   new zarr.FetchStore("https://example.com/data.zarr"),
-  zarr.withConsolidation({ format: "v3" }),
-  zarr.withRangeBatching(),
+  zarr.withConsolidation,
+  (s) => zarr.withRangeBatching(s, { cacheSize: 512 }),
 );
 
 store.contents(); // from zarr.withConsolidation
 store.stats;      // from zarr.withRangeBatching
 ```
 
-Each middleware in the pipeline wraps the previous result. `zarr.extendStore`
-handles async middleware (like `zarr.withConsolidation`, which loads metadata)
-automatically. It always returns a `Promise`.
+Each middleware wraps the previous result. `zarr.extendStore` handles async
+middleware (like `zarr.withConsolidation`, which fetches metadata during
+initialization) automatically, and always returns a `Promise`. A middleware
+with no required options can be passed uncalled; otherwise wrap it in an arrow
+so the options are applied to the argument.
 
-You can also use middleware directly without `zarr.extendStore`:
+You can also call middleware directly:
 
 ```ts
 let consolidated = await zarr.withConsolidation(
@@ -42,21 +49,20 @@ let consolidated = await zarr.withConsolidation(
 );
 ```
 
-## Defining your own middleware
+### Defining your own
 
-Use `zarr.defineStoreMiddleware` to define custom middleware. The factory function receives
-the inner store and custom options, and returns an object with method overrides
-and/or new methods. Anything not returned is automatically delegated to the
+The factory receives the inner store and user options, and returns an object
+of method overrides and extensions. Anything not returned is delegated to the
 inner store via `Proxy`.
 
 ```ts
 import * as zarr from "zarrita";
 
 const withCaching = zarr.defineStoreMiddleware(
-  (store: zarr.AsyncReadable, opts: { maxSize?: number } = {}) => {
-    let cache = new Map<string, Uint8Array>();
+  (store, opts: { maxSize?: number } = {}) => {
+    let cache = new Map<zarr.AbsolutePath, Uint8Array>();
     return {
-      async get(key: zarr.AbsolutePath, options?: unknown) {
+      async get(key, options) {
         let hit = cache.get(key);
         if (hit) return hit;
         let result = await store.get(key, options);
@@ -74,27 +80,17 @@ let store = withCaching(new zarr.FetchStore("https://..."), { maxSize: 256 });
 store.clear(); // new method from the middleware
 ```
 
-The returned middleware supports a **dual API**: call it directly with `(store,
-opts)` or curry it with `(opts)` for use in `zarr.extendStore` pipelines:
-
-```ts
-// Direct
-let store = withCaching(new zarr.FetchStore("https://..."), { maxSize: 256 });
-
-// Curried (for zarr.extendStore)
-let store = await zarr.extendStore(
-  new zarr.FetchStore("https://..."),
-  withCaching({ maxSize: 256 }),
-);
-```
+Only `get` and `getRange` are interceptable; any other keys on the factory
+result become extensions on the wrapped store.
 
 Middleware can be **sync or async**. If the factory returns a `Promise`, the
 wrapper returns a `Promise` too:
 
 ```ts
 const withMetadata = zarr.defineStoreMiddleware(
-  async (store: zarr.AsyncReadable, opts: { key: string }) => {
-    let meta = JSON.parse(new TextDecoder().decode(await store.get(opts.key)));
+  async (store, opts: { key: zarr.AbsolutePath }) => {
+    let bytes = await store.get(opts.key);
+    let meta = JSON.parse(new TextDecoder().decode(bytes));
     return {
       metadata() { return meta; },
     };
@@ -105,73 +101,45 @@ let store = await withMetadata(rawStore, { key: "/meta.json" });
 store.metadata(); // loaded during initialization
 ```
 
-## Store options and generics
+## Array middleware
 
-Stores are generic over their request options type. For example,
-[`zarr.FetchStore`](/packages/storage#fetchstore) uses `RequestInit` so you can
-pass headers or an `AbortSignal` to individual requests. Most middleware
-doesn't need to know about this type, and `zarr.defineStoreMiddleware` preserves it
-automatically through the chain.
-
-Sometimes, though, middleware options _depend_ on the store's request options.
-For example, `zarr.withRangeBatching` has a `mergeOptions` callback that
-combines request options from concurrent callers, and its parameter type
-should match the store's options.
-
-This is an advanced typing feature purely for caller convenience. It ensures
-users get proper type inference and autocomplete on options that reference
-the store's request type. Use `zarr.defineStoreMiddleware.generic` with a
-`zarr.GenericOptions` interface that maps the store's options type into your
-middleware options:
+Array middleware is the symmetric extension point for **chunk-layer** concerns:
+anything that wants to intercept `getChunk(coords)` without caring about paths
+or bytes. Think chunk caching, prefetch priority, or observability hooks.
 
 ```ts
 import * as zarr from "zarrita";
 
-// 1. Define your options as a normal generic interface
-interface LoggingOptions<O> {
-  label?: string;
-  formatOptions?: (opts: O) => string;
-}
-
-// 2. Create the type lambda (one line that wires up the generic)
-interface LoggingOptsFor extends zarr.GenericOptions {
-  readonly options: LoggingOptions<this["_O"]>;
-}
-
-// 3. Define the middleware
-const withLogging = zarr.defineStoreMiddleware.generic<LoggingOptsFor>()(
-  (store, opts: LoggingOptions<unknown> = {}) => {
-    let label = opts.label ?? "store";
-    let format = opts.formatOptions ?? String;
-    return {
-      async get(key: zarr.AbsolutePath, options?: unknown) {
-        console.log(`[${label}] get ${key} ${format(options)}`);
-        return store.get(key, options);
-      },
-    };
-  },
+const withChunkCache = zarr.defineArrayMiddleware(
+  (array, opts: { cache: Map<string, zarr.Chunk<zarr.DataType>> }) => ({
+    async getChunk(coords, options) {
+      let key = coords.join(",");
+      let hit = opts.cache.get(key);
+      if (hit) return hit;
+      let chunk = await array.getChunk(coords, options);
+      opts.cache.set(key, chunk);
+      return chunk;
+    },
+  }),
 );
+
+let arr = await zarr.extendArray(
+  await zarr.open(store, { kind: "array" }),
+  (a) => withChunkCache(a, { cache: new Map() }),
+);
+
+await zarr.get(arr, null); // cache hits are served from the Map
 ```
 
-At the call site, `formatOptions` receives the store's options type:
+Only `getChunk` is interceptable in v1 — `shape`, `dtype`, `attrs`, `chunks`,
+`store`, and `path` are part of the array's identity and are always delegated
+to the inner array. Any other keys on the factory result become extensions on
+the wrapped array.
 
-```ts
-let store = withLogging(new zarr.FetchStore("https://..."), {
-  label: "my-store",
-  formatOptions: (opts) => {
-    //            ^^^^ typed as RequestInit
-    return opts.method ?? "GET";
-  },
-});
-```
+The factory sees `zarr.Array<DataType, Readable>` (the widest form) so it can
+be written once and applied to any concrete `Array<D, S>`. At the call site
+the outer generics are preserved, so downstream `zarr.get(wrapped)` calls
+return the right specific type.
 
-This is an advanced pattern. Most middleware won't need it. It exists so
-that _users_ of your middleware get proper type inference and autocomplete
-when their options reference the store's request type. If your options don't
-depend on the store type, use the simpler `zarr.defineStoreMiddleware` and skip the
-`zarr.GenericOptions` boilerplate entirely.
-
-Under the hood, `zarr.GenericOptions` uses TypeScript's `this` types to encode
-a [higher-kinded type](https://www.typescriptlang.org/docs/handbook/2/classes.html#this-types):
-`this["_O"]` refers to the store's request options, which gets substituted with
-the concrete type (e.g., `RequestInit`) at the call site.
+Like `extendStore`, `extendArray` always returns a `Promise` so middleware can
+perform async initialization.

--- a/packages/zarrita/__tests__/signal.test.ts
+++ b/packages/zarrita/__tests__/signal.test.ts
@@ -110,3 +110,39 @@ describe("signal propagation through zarr.get", () => {
 		).rejects.toThrow(/abort/i);
 	});
 });
+
+describe("zarr.set cancels on signal", () => {
+	it("aborting signal rejects a pending zarr.set", async () => {
+		let store = new Map<string, Uint8Array>();
+		let arr = await zarr.create(store, {
+			dtype: "int16",
+			shape: [4],
+			chunkShape: [2],
+		});
+		let ctl = new AbortController();
+		ctl.abort(new Error("aborted"));
+		await expect(
+			zarr.set(arr, null, 42, { signal: ctl.signal }),
+		).rejects.toThrow(/abort/i);
+	});
+});
+
+describe("signal propagation through extendStore pipeline", () => {
+	it("reaches the inner store through multiple middlewares", async () => {
+		let fsStore = new zarr.FileSystemStore(fixturesRoot);
+		let { store: recorder, calls } = recordingStore(fsStore);
+		let composed = await zarr.extendStore(recorder, (s) =>
+			zarr.withRangeBatching(s),
+		);
+		let arr = await zarr.open.v3(
+			zarr.root(composed).resolve("1d.chunked.compressed.sharded.i2"),
+			{ kind: "array" },
+		);
+		let ctl = new AbortController();
+		await zarr.get(arr, null, { signal: ctl.signal });
+		// At least one of the inner-store calls carried our signal through
+		// the batching middleware.
+		let seen = calls.some((c) => c?.signal === ctl.signal);
+		expect(seen).toBe(true);
+	});
+});


### PR DESCRIPTION
Brings the middleware docs in line with the API after steps #392, #384 . The guide now covers both transport and data extension points on one page, and the storage reference and cookbook shed examples that no longer reflect how the types or runtime behave.