### PR TITLE
Restructure errors as a tagged taxonomy

### DIFF
--- a/.changeset/structured-errors.md
+++ b/.changeset/structured-errors.md
@@ -1,0 +1,30 @@
+---
+"zarrita": minor
+---
+
+Add structured errors with `isZarritaError` type guard
+
+Zarrita now throws a small set of tagged error types from a single internal hierarchy, replacing the ad-hoc mix of plain `Error`s and one-off custom classes (`NodeNotFoundError`, `JsonDecodeError`, `KeyError`, `IndexError`). The classes are exported alongside an `isZarritaError` runtime guard; module documentation steers callers toward the guard so `instanceof` checks aren't load-bearing.
+
+Six tags cover every distinct failure mode reachable from `zarr.open`, `zarr.get`, and `zarr.set`:
+
+- `NotFoundError` — store returned nothing, or `open({ kind })` found a different node kind (`found: "array" | "group"`).
+- `InvalidMetadataError` — JSON decode failure, unknown dtype, unknown chunk-key encoding, codec config rejected at load time.
+- `UnknownCodecError` — codec name not in the registry; carries the `codec` name so callers can register and retry.
+- `CodecPipelineError` — codec encode/decode threw at runtime; carries `direction`, `codec`, and the underlying `cause`.
+- `InvalidSelectionError` — bad rank, out-of-bounds, zero step, dimension-name mismatch, scalar-shape mismatch.
+- `UnsupportedError` — capability limit (sharded set, codec encode paths that aren't implemented, runtime missing `DataView.prototype.getFloat16`).
+
+```ts
+try {
+  await zarr.open(store, { kind: "array" });
+} catch (e) {
+  if (zarr.isZarritaError(e, "NotFoundError")) {
+    // e.path / e.found are available
+  } else if (zarr.isZarritaError(e, "UnknownCodecError")) {
+    // e.codec is the unregistered codec name
+  }
+}
+```
+
+`isZarritaError(e)` with no tag arguments narrows to any zarrita error.

--- a/packages/@zarrita-ndarray/__tests__/slice.test.ts
+++ b/packages/@zarrita-ndarray/__tests__/slice.test.ts
@@ -1,6 +1,6 @@
 import ndarray from "ndarray";
 import { describe, expect, it } from "vitest";
-import { create, IndexError, slice } from "zarrita";
+import { create, InvalidSelectionError, slice } from "zarrita";
 
 import { get, set } from "../src/index.js";
 
@@ -125,6 +125,6 @@ describe("builtin slice", async () => {
 
 	it("Does not support negative indices", async () => {
 		let sel = [0, slice(null, null, -2), slice(null, null, 3)];
-		await expect(get(arr, sel)).rejects.toThrowError(IndexError);
+		await expect(get(arr, sel)).rejects.toThrowError(InvalidSelectionError);
 	});
 });

--- a/packages/zarrita/__tests__/cast_value.test.ts
+++ b/packages/zarrita/__tests__/cast_value.test.ts
@@ -458,6 +458,7 @@ describe("CastValueCodec", () => {
 				{ dataType: "float64" },
 			);
 			const chunk = makeChunk(new Int32Array([1]));
+			// @ts-expect-error - encode is typed as (_: never) => never
 			expect(() => codec.encode(chunk)).toThrow();
 		});
 

--- a/packages/zarrita/__tests__/consolidated.test.ts
+++ b/packages/zarrita/__tests__/consolidated.test.ts
@@ -3,7 +3,7 @@ import * as url from "node:url";
 import { FileSystemStore } from "@zarrita/storage";
 import { assert, describe, expect, it } from "vitest";
 import { tryWithConsolidated, withConsolidated } from "../src/consolidated.js";
-import { NodeNotFoundError } from "../src/errors.js";
+import { NotFoundError } from "../src/errors.js";
 import { Array as ZarrArray } from "../src/hierarchy.js";
 import { open } from "../src/open.js";
 
@@ -105,9 +105,9 @@ describe("withConsolidated", () => {
 		);
 		let try_open = () =>
 			withConsolidated(new FileSystemStore(root), { format: "v2" });
-		await expect(try_open).rejects.toThrowError(NodeNotFoundError);
+		await expect(try_open).rejects.toThrowError(NotFoundError);
 		await expect(try_open).rejects.toThrowErrorMatchingInlineSnapshot(
-			"[NodeNotFoundError: Node not found: v2 consolidated metadata]",
+			"[NotFoundError: Not found: v2 consolidated metadata]",
 		);
 	});
 });
@@ -172,7 +172,7 @@ describe("withConsolidated (v3)", () => {
 		let root = path.join(__dirname, "../../../fixtures/v2/data.zarr");
 		let try_open = () =>
 			withConsolidated(new FileSystemStore(root), { format: "v3" });
-		await expect(try_open).rejects.toThrowError(NodeNotFoundError);
+		await expect(try_open).rejects.toThrowError(NotFoundError);
 	});
 });
 

--- a/packages/zarrita/__tests__/errors.test.ts
+++ b/packages/zarrita/__tests__/errors.test.ts
@@ -1,0 +1,120 @@
+import { expectType } from "tintype";
+import { describe, expect, test } from "vitest";
+import {
+	CodecPipelineError,
+	InvalidMetadataError,
+	InvalidSelectionError,
+	NotFoundError,
+	UnknownCodecError,
+	UnsupportedError,
+} from "../src/errors.js";
+import * as zarr from "../src/index.js";
+
+describe("isZarritaError", () => {
+	test("returns false for non-zarrita errors", () => {
+		expect(zarr.isZarritaError(new Error("nope"))).toBe(false);
+		expect(zarr.isZarritaError("string")).toBe(false);
+		expect(zarr.isZarritaError(null)).toBe(false);
+		expect(zarr.isZarritaError(undefined)).toBe(false);
+		expect(zarr.isZarritaError({ _tag: "NotFoundError" })).toBe(false);
+	});
+
+	test("returns true for any zarrita error when no tag given", () => {
+		expect(zarr.isZarritaError(new NotFoundError("v3 array"))).toBe(true);
+		expect(zarr.isZarritaError(new InvalidMetadataError("bad json"))).toBe(
+			true,
+		);
+		expect(zarr.isZarritaError(new UnknownCodecError("wat"))).toBe(true);
+		expect(
+			zarr.isZarritaError(
+				new CodecPipelineError({
+					direction: "decode",
+					codec: "blosc",
+					cause: new Error("boom"),
+				}),
+			),
+		).toBe(true);
+		expect(zarr.isZarritaError(new InvalidSelectionError("oob"))).toBe(true);
+		expect(zarr.isZarritaError(new UnsupportedError("sharded set"))).toBe(true);
+	});
+
+	test("filters by single tag", () => {
+		const err = new NotFoundError("v3 array", { path: "/foo" });
+		expect(zarr.isZarritaError(err, "NotFoundError")).toBe(true);
+		expect(zarr.isZarritaError(err, "InvalidSelectionError")).toBe(false);
+	});
+
+	test("filters by multiple tags", () => {
+		const err = new InvalidSelectionError("oob");
+		expect(
+			zarr.isZarritaError(err, "NotFoundError", "InvalidSelectionError"),
+		).toBe(true);
+		expect(
+			zarr.isZarritaError(err, "UnknownCodecError", "UnsupportedError"),
+		).toBe(false);
+	});
+
+	test("narrows to NotFoundError with typed path + found fields", () => {
+		const err: unknown = new NotFoundError("array at /foo", {
+			path: "/foo",
+			found: "group",
+		});
+		if (zarr.isZarritaError(err, "NotFoundError")) {
+			expectType<NotFoundError>(err);
+			expect(err.path).toBe("/foo");
+			expect(err.found).toBe("group");
+			expect(err._tag).toBe("NotFoundError");
+		} else {
+			throw new Error("expected narrowing to succeed");
+		}
+	});
+
+	test("narrows to UnknownCodecError with typed codec field", () => {
+		const err: unknown = new UnknownCodecError("exotic");
+		if (zarr.isZarritaError(err, "UnknownCodecError")) {
+			expectType<UnknownCodecError>(err);
+			expect(err.codec).toBe("exotic");
+		} else {
+			throw new Error("expected narrowing to succeed");
+		}
+	});
+
+	test("narrows to CodecPipelineError with typed direction + cause", () => {
+		const cause = new Error("gzip boom");
+		const err: unknown = new CodecPipelineError({
+			direction: "decode",
+			codec: "gzip",
+			cause,
+		});
+		if (zarr.isZarritaError(err, "CodecPipelineError")) {
+			expectType<CodecPipelineError>(err);
+			expect(err.direction).toBe("decode");
+			expect(err.codec).toBe("gzip");
+			expect(err.cause).toBe(cause);
+		} else {
+			throw new Error("expected narrowing to succeed");
+		}
+	});
+
+	test("narrows to UnsupportedError with feature field", () => {
+		const err: unknown = new UnsupportedError("sharded set");
+		if (zarr.isZarritaError(err, "UnsupportedError")) {
+			expectType<UnsupportedError>(err);
+			expect(err.feature).toBe("sharded set");
+		} else {
+			throw new Error("expected narrowing to succeed");
+		}
+	});
+
+	test("narrows to union when multiple tags given", () => {
+		const err: unknown = new InvalidSelectionError("oob");
+		if (zarr.isZarritaError(err, "InvalidSelectionError", "UnsupportedError")) {
+			expectType<InvalidSelectionError | UnsupportedError>(err);
+			expect(
+				err._tag === "InvalidSelectionError" || err._tag === "UnsupportedError",
+			).toBe(true);
+		} else {
+			throw new Error("expected narrowing to succeed");
+		}
+	});
+});

--- a/packages/zarrita/__tests__/indexing/slice.test.ts
+++ b/packages/zarrita/__tests__/indexing/slice.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from "vitest";
-
+import { InvalidSelectionError } from "../../src/errors.js";
 import * as zarr from "../../src/index.js";
 import { get, set, slice } from "../../src/index.js";
-import { IndexError } from "../../src/indexing/indexer.js";
 
 const DATA = {
 	// biome-ignore format: the array should not be formatted
@@ -125,6 +124,6 @@ describe("slice", async () => {
 
 	it("Does not support negative indices", async () => {
 		let sel = [0, slice(null, null, -2), slice(null, null, 3)];
-		await expect(get(arr, sel)).rejects.toThrowError(IndexError);
+		await expect(get(arr, sel)).rejects.toThrowError(InvalidSelectionError);
 	});
 });

--- a/packages/zarrita/__tests__/indexing/util.test.ts
+++ b/packages/zarrita/__tests__/indexing/util.test.ts
@@ -63,7 +63,7 @@ describe("slice", () => {
 
 	test("slice throws on bigint exceeding MAX_SAFE_INTEGER", () => {
 		let big = BigInt(Number.MAX_SAFE_INTEGER) + 1n;
-		expect(() => slice(big)).toThrowError(RangeError);
+		expect(() => slice(big)).toThrowError(/exceeds Number.MAX_SAFE_INTEGER/);
 	});
 });
 

--- a/packages/zarrita/__tests__/open.test.ts
+++ b/packages/zarrita/__tests__/open.test.ts
@@ -17,7 +17,7 @@ import {
 	vi,
 } from "vitest";
 
-import { NodeNotFoundError } from "../src/errors.js";
+import { NotFoundError } from "../src/errors.js";
 import { root } from "../src/hierarchy.js";
 import type {
 	ArrayMetadata,
@@ -574,9 +574,9 @@ describe("v2", () => {
 	it("throws when group is not found", async () => {
 		let try_open = () =>
 			open.v2(store.resolve("/not/a/group"), { kind: "group" });
-		await expect(try_open).rejects.toThrowError(NodeNotFoundError);
+		await expect(try_open).rejects.toThrowError(NotFoundError);
 		await expect(try_open).rejects.toThrowErrorMatchingInlineSnapshot(
-			"[NodeNotFoundError: Node not found: v2 group]",
+			"[NotFoundError: Not found: v2 group]",
 		);
 	});
 
@@ -995,9 +995,9 @@ describe("v3", async () => {
 	it("throws when group not found", async () => {
 		const try_open = () =>
 			open.v3(store.resolve("/not/a/group"), { kind: "group" });
-		await expect(try_open).rejects.toThrowError(NodeNotFoundError);
+		await expect(try_open).rejects.toThrowError(NotFoundError);
 		await expect(try_open).rejects.toThrowErrorMatchingInlineSnapshot(
-			"[NodeNotFoundError: Node not found: v3 array or group]",
+			"[NotFoundError: Not found: v3 array or group]",
 		);
 	});
 

--- a/packages/zarrita/__tests__/scale_offset.test.ts
+++ b/packages/zarrita/__tests__/scale_offset.test.ts
@@ -82,6 +82,7 @@ describe("ScaleOffsetCodec", () => {
 			{ dataType: "int32" },
 		);
 		const chunk = makeChunk(new Int32Array([1, 2, 3]));
+		// @ts-expect-error - encode is typed as (_: never) => never
 		expect(() => codec.encode(chunk)).toThrow();
 	});
 

--- a/packages/zarrita/src/batched-fetch.ts
+++ b/packages/zarrita/src/batched-fetch.ts
@@ -1,4 +1,5 @@
 import type { AbsolutePath, AsyncReadable, RangeQuery } from "@zarrita/storage";
+import { UnsupportedError } from "./errors.js";
 
 /**
  * Simple LRU cache using Map insertion order.
@@ -168,7 +169,9 @@ export class BatchedRangeStore<Options = unknown>
 		options?: BatchedRangeStoreOptions<Options>,
 	) {
 		if (!inner.getRange) {
-			throw new Error("BatchedRangeStore requires a store with getRange");
+			throw new UnsupportedError(
+				"BatchedRangeStore requires a store with getRange",
+			);
 		}
 		this.#inner = inner;
 		this.#innerGetRange = inner.getRange.bind(inner);

--- a/packages/zarrita/src/codecs.ts
+++ b/packages/zarrita/src/codecs.ts
@@ -11,8 +11,12 @@ import { ShuffleCodec } from "./codecs/shuffle.js";
 import { TransposeCodec } from "./codecs/transpose.js";
 import { VLenUTF8 } from "./codecs/vlen-utf8.js";
 import { ZlibCodec } from "./codecs/zlib.js";
+import {
+	CodecPipelineError,
+	InvalidMetadataError,
+	UnknownCodecError,
+} from "./errors.js";
 import type { Chunk, CodecMetadata, DataType, Scalar } from "./metadata.js";
-import { assert } from "./util.js";
 
 type ChunkMetadata<D extends DataType> = {
 	dataType: D;
@@ -83,26 +87,43 @@ export function createCodecPipeline<Dtype extends DataType>(
 		if (!codecsPromise) codecsPromise = loadCodecs(chunkMetadata);
 		return codecsPromise;
 	}
+	async function runStep<T>(
+		direction: "encode" | "decode",
+		codec: string,
+		fn: () => Promise<T> | T,
+	): Promise<T> {
+		try {
+			return await fn();
+		} catch (cause) {
+			throw new CodecPipelineError({ direction, codec, cause });
+		}
+	}
 	return {
 		async encode(chunk: Chunk<Dtype>): Promise<Uint8Array> {
 			let codecs = await getCodecs();
-			for (const codec of codecs.arrayToArray) {
-				chunk = await codec.encode(chunk);
+			for (const { name, codec } of codecs.arrayToArray) {
+				chunk = await runStep("encode", name, () => codec.encode(chunk));
 			}
-			let bytes = await codecs.arrayToBytes.encode(chunk);
-			for (const codec of codecs.bytesToBytes) {
-				bytes = await codec.encode(bytes);
+			let bytes = await runStep("encode", codecs.arrayToBytes.name, () =>
+				codecs.arrayToBytes.codec.encode(chunk),
+			);
+			for (const { name, codec } of codecs.bytesToBytes) {
+				bytes = await runStep("encode", name, () => codec.encode(bytes));
 			}
 			return bytes;
 		},
 		async decode(bytes: Uint8Array): Promise<Chunk<Dtype>> {
 			let codecs = await getCodecs();
 			for (let i = codecs.bytesToBytes.length - 1; i >= 0; i--) {
-				bytes = await codecs.bytesToBytes[i].decode(bytes);
+				const { name, codec } = codecs.bytesToBytes[i];
+				bytes = await runStep("decode", name, () => codec.decode(bytes));
 			}
-			let chunk = await codecs.arrayToBytes.decode(bytes);
+			let chunk = await runStep("decode", codecs.arrayToBytes.name, () =>
+				codecs.arrayToBytes.codec.decode(bytes),
+			);
 			for (let i = codecs.arrayToArray.length - 1; i >= 0; i--) {
-				chunk = await codecs.arrayToArray[i].decode(chunk);
+				const { name, codec } = codecs.arrayToArray[i];
+				chunk = await runStep("decode", name, () => codec.decode(chunk));
 			}
 			return chunk;
 		},
@@ -124,15 +145,19 @@ type BytesToBytesCodec = {
 	decode: (data: Uint8Array) => Promise<Uint8Array>;
 };
 
+type Named<T> = { name: string; codec: T };
+
 async function loadCodecs<D extends DataType>(chunkMeta: ChunkMetadata<D>) {
 	let promises = chunkMeta.codecs.map(async (meta) => {
 		let Codec = await registry.get(meta.name)?.();
-		assert(Codec, `Unknown codec: ${meta.name}`);
+		if (!Codec) {
+			throw new UnknownCodecError(meta.name);
+		}
 		return { Codec, meta };
 	});
-	let arrayToArray: ArrayToArrayCodec<D>[] = [];
-	let arrayToBytes: ArrayToBytesCodec<D> | undefined;
-	let bytesToBytes: BytesToBytesCodec[] = [];
+	let arrayToArray: Named<ArrayToArrayCodec<D>>[] = [];
+	let arrayToBytes: Named<ArrayToBytesCodec<D>> | undefined;
+	let bytesToBytes: Named<BytesToBytesCodec>[] = [];
 	// Track the "current" data type through the codec chain. Array-to-array
 	// codecs like cast_value may change the type, and subsequent codecs
 	// (especially bytes) need to see the updated type.
@@ -141,7 +166,10 @@ async function loadCodecs<D extends DataType>(chunkMeta: ChunkMetadata<D>) {
 		let codec = Codec.fromConfig(meta.configuration, currentMeta);
 		switch (codec.kind) {
 			case "array_to_array":
-				arrayToArray.push(codec as unknown as ArrayToArrayCodec<D>);
+				arrayToArray.push({
+					name: meta.name,
+					codec: codec as unknown as ArrayToArrayCodec<D>,
+				});
 				// Array-to-array codecs like cast_value may change the data type
 				// (and derived metadata like fill_value) between the array's
 				// declared type and what's stored on disk. We call getEncodedMeta
@@ -152,18 +180,31 @@ async function loadCodecs<D extends DataType>(chunkMeta: ChunkMetadata<D>) {
 				}
 				break;
 			case "array_to_bytes":
-				arrayToBytes = codec as unknown as ArrayToBytesCodec<D>;
+				arrayToBytes = {
+					name: meta.name,
+					codec: codec as unknown as ArrayToBytesCodec<D>,
+				};
 				break;
 			default:
-				bytesToBytes.push(codec as unknown as BytesToBytesCodec);
+				bytesToBytes.push({
+					name: meta.name,
+					codec: codec as unknown as BytesToBytesCodec,
+				});
 		}
 	}
 	if (!arrayToBytes) {
-		assert(
-			isTypedArrayLikeMeta(currentMeta),
-			`Cannot encode ${currentMeta.dataType} to bytes without a codec`,
-		);
-		arrayToBytes = BytesCodec.fromConfig({ endian: "little" }, currentMeta);
+		if (!isTypedArrayLikeMeta(currentMeta)) {
+			throw new InvalidMetadataError(
+				`Cannot encode ${currentMeta.dataType} to bytes without a codec`,
+			);
+		}
+		arrayToBytes = {
+			name: "bytes",
+			codec: BytesCodec.fromConfig(
+				{ endian: "little" },
+				currentMeta,
+			) as unknown as ArrayToBytesCodec<D>,
+		};
 	}
 	return {
 		arrayToArray,

--- a/packages/zarrita/src/codecs/_shared.ts
+++ b/packages/zarrita/src/codecs/_shared.ts
@@ -1,0 +1,7 @@
+import { UnsupportedError } from "../errors.js";
+
+export function unimplementedEncode(codecName: string): (_: never) => never {
+	return () => {
+		throw new UnsupportedError(`${codecName} encode`);
+	};
+}

--- a/packages/zarrita/src/codecs/bitround.ts
+++ b/packages/zarrita/src/codecs/bitround.ts
@@ -1,5 +1,6 @@
+import { InvalidMetadataError } from "../errors.js";
 import type { Chunk, Float32, Float64 } from "../metadata.js";
-import { assert } from "../util.js";
+import { unimplementedEncode } from "./_shared.js";
 
 /**
  * A codec for bit-rounding.
@@ -21,7 +22,9 @@ export class BitroundCodec<D extends Float64 | Float32> {
 	kind = "array_to_array";
 
 	constructor(configuration: { keepbits: number }, _meta: { dataType: D }) {
-		assert(configuration.keepbits >= 0, "keepbits must be zero or positive");
+		if (configuration.keepbits < 0) {
+			throw new InvalidMetadataError("keepbits must be zero or positive");
+		}
 	}
 
 	static fromConfig<D extends Float32 | Float64>(
@@ -31,15 +34,7 @@ export class BitroundCodec<D extends Float64 | Float32> {
 		return new BitroundCodec(configuration, meta);
 	}
 
-	/**
-	 * Encode a chunk of data with bit-rounding.
-	 * @param _arr - The chunk to encode
-	 */
-	encode(_arr: Chunk<D>): Chunk<D> {
-		throw new Error(
-			"`BitroundCodec.encode` is not implemented. Please open an issue at https://github.com/manzt/zarrita.js/issues.",
-		);
-	}
+	encode = unimplementedEncode("bitround");
 
 	/**
 	 * Decode a chunk of data (no-op).

--- a/packages/zarrita/src/codecs/cast_value.ts
+++ b/packages/zarrita/src/codecs/cast_value.ts
@@ -5,8 +5,10 @@ casting procedure to each element.
 The specification for this codec can be found at https://github.com/zarr-developers/zarr-extensions/tree/main/codecs/cast_value
 */
 
+import { InvalidMetadataError } from "../errors.js";
 import type { Chunk, Scalar } from "../metadata.js";
 import { getCtr } from "../util.js";
+import { unimplementedEncode } from "./_shared.js";
 import {
 	isBigintType,
 	isFloatType,
@@ -267,13 +269,13 @@ export class CastValueCodec<
 		const arrayType = meta.dataType;
 		const encodedType = config.data_type;
 		if (!SUPPORTED.has(arrayType)) {
-			throw new Error(
-				`CastValue codec does not support array data type: ${arrayType}`,
+			throw new InvalidMetadataError(
+				`cast_value codec does not support array data type: ${arrayType}`,
 			);
 		}
 		if (!SUPPORTED.has(encodedType)) {
-			throw new Error(
-				`CastValue codec does not support encoded data type: ${encodedType}`,
+			throw new InvalidMetadataError(
+				`cast_value codec does not support encoded data type: ${encodedType}`,
 			);
 		}
 		const rounding = config.rounding ?? "nearest-even";
@@ -299,9 +301,7 @@ export class CastValueCodec<
 		);
 	}
 
-	encode(_chunk: Chunk<ArrayDtype>): never {
-		throw new Error("CastValue encoding is not supported.");
-	}
+	encode = unimplementedEncode("cast_value");
 
 	decode(chunk: Chunk<EncodedDtype>): Chunk<ArrayDtype> {
 		const input = chunk.data;
@@ -343,8 +343,8 @@ function buildConverter<
 
 	if (srcIsFloat && dstIsFloat) {
 		if (rounding !== "nearest-even") {
-			throw new Error(
-				`CastValue float -> float only supports "nearest-even" rounding, got "${rounding}"`,
+			throw new InvalidMetadataError(
+				`cast_value float -> float only supports "nearest-even" rounding, got "${rounding}"`,
 			);
 		}
 		// TypedArray assignment handles nearest-even natively.

--- a/packages/zarrita/src/codecs/crc32c.ts
+++ b/packages/zarrita/src/codecs/crc32c.ts
@@ -1,11 +1,11 @@
+import { unimplementedEncode } from "./_shared.js";
+
 export class Crc32cCodec {
 	readonly kind = "bytes_to_bytes";
 	static fromConfig() {
 		return new Crc32cCodec();
 	}
-	encode(_: Uint8Array): Uint8Array {
-		throw new Error("Not implemented");
-	}
+	encode = unimplementedEncode("crc32c");
 	decode(arr: Uint8Array): Uint8Array {
 		return new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength - 4);
 	}

--- a/packages/zarrita/src/codecs/delta.ts
+++ b/packages/zarrita/src/codecs/delta.ts
@@ -1,3 +1,4 @@
+import { InvalidMetadataError } from "../errors.js";
 import type { BigintDataType, Chunk, NumberDataType } from "../metadata.js";
 import { getCtr } from "../util.js";
 
@@ -51,10 +52,11 @@ export class DeltaCodec<D extends DeltaCompatibleType> {
 		_config: unknown,
 		meta: { dataType: D },
 	): DeltaCodec<D> {
-		if (!SUPPORTED.has(meta.dataType))
-			throw new Error(
+		if (!SUPPORTED.has(meta.dataType)) {
+			throw new InvalidMetadataError(
 				`Delta codec does not support data type: ${meta.dataType}`,
 			);
+		}
 		return new DeltaCodec(getCtr(meta.dataType));
 	}
 

--- a/packages/zarrita/src/codecs/gzip.ts
+++ b/packages/zarrita/src/codecs/gzip.ts
@@ -1,4 +1,5 @@
 import { decompress } from "../util.js";
+import { unimplementedEncode } from "./_shared.js";
 
 interface GzipCodecConfig {
 	level: number;
@@ -11,11 +12,7 @@ export class GzipCodec {
 		return new GzipCodec();
 	}
 
-	encode(_bytes: Uint8Array): never {
-		throw new Error(
-			"Gzip encoding is not enabled by default. Please register a custom codec with `numcodecs/gzip`.",
-		);
-	}
+	encode = unimplementedEncode("gzip");
 
 	async decode(bytes: Uint8Array): Promise<Uint8Array> {
 		const buffer = await decompress(bytes, { format: "gzip" });

--- a/packages/zarrita/src/codecs/json-scalar.ts
+++ b/packages/zarrita/src/codecs/json-scalar.ts
@@ -9,6 +9,7 @@ The Zarr V3 spec encodes numeric scalars in JSON as either:
 See https://github.com/zarr-developers/zarr-specs/blob/main/docs/v3/data-types/index.rst#permitted-fill-values
 */
 
+import { InvalidMetadataError, UnsupportedError } from "../errors.js";
 import type { BigintDataType, NumberDataType, Scalar } from "../metadata.js";
 
 export type NumericDataType = NumberDataType | BigintDataType;
@@ -48,8 +49,8 @@ function hexToFloat(hex: string, byteWidth: number): number {
 	const view = new DataView(buf);
 	if (byteWidth === 2) {
 		if (typeof view.getFloat16 !== "function") {
-			throw new Error(
-				"Decoding a float16 hex-encoded scalar requires DataView.prototype.getFloat16, which is not available in this runtime.",
+			throw new UnsupportedError(
+				"float16 hex-encoded scalar decoding (requires DataView.prototype.getFloat16)",
 			);
 		}
 		view.setUint16(0, Number(int));
@@ -77,7 +78,7 @@ export function parseJsonScalar<D extends NumericDataType>(
 ): Scalar<D> {
 	if (isBigintType(dataType)) {
 		if (typeof value !== "number" || !Number.isInteger(value)) {
-			throw new Error(
+			throw new InvalidMetadataError(
 				`Expected an integer value for data type "${dataType}", got ${JSON.stringify(value)}`,
 			);
 		}
@@ -85,7 +86,7 @@ export function parseJsonScalar<D extends NumericDataType>(
 	}
 	if (typeof value === "number") {
 		if (!isFloatType(dataType) && !Number.isInteger(value)) {
-			throw new Error(
+			throw new InvalidMetadataError(
 				`Expected an integer value for data type "${dataType}", got ${value}`,
 			);
 		}
@@ -93,7 +94,7 @@ export function parseJsonScalar<D extends NumericDataType>(
 	}
 	// value is SpecialFloat | HexString — only valid for float types
 	if (!isFloatType(dataType)) {
-		throw new Error(
+		throw new InvalidMetadataError(
 			`String-encoded scalar "${value}" is not valid for non-float data type "${dataType}"`,
 		);
 	}

--- a/packages/zarrita/src/codecs/scale_offset.ts
+++ b/packages/zarrita/src/codecs/scale_offset.ts
@@ -8,8 +8,10 @@ of the array.
 The specification for this codec can be found at https://github.com/zarr-developers/zarr-extensions/tree/main/codecs/scale_offset
 */
 
+import { InvalidMetadataError } from "../errors.js";
 import type { Chunk, Scalar } from "../metadata.js";
 import { getCtr } from "../util.js";
+import { unimplementedEncode } from "./_shared.js";
 import {
 	type JsonScalar,
 	type NumericDataType,
@@ -41,7 +43,11 @@ export class ScaleOffsetCodec<D extends NumericDataType> {
 	#scale: Scalar<D>;
 	#offset: Scalar<D>;
 
-	constructor(scale: Scalar<D>, offset: Scalar<D>, ctr: ReturnType<typeof getCtr<D>>) {
+	constructor(
+		scale: Scalar<D>,
+		offset: Scalar<D>,
+		ctr: ReturnType<typeof getCtr<D>>,
+	) {
 		this.#scale = scale;
 		this.#offset = offset;
 		this.#ctr = ctr;
@@ -52,20 +58,18 @@ export class ScaleOffsetCodec<D extends NumericDataType> {
 		meta: { dataType: D },
 	): ScaleOffsetCodec<D> {
 		if (!SUPPORTED.has(meta.dataType)) {
-			throw new Error(
-				`ScaleOffset codec does not support data type: ${meta.dataType}`,
+			throw new InvalidMetadataError(
+				`scale_offset codec does not support data type: ${meta.dataType}`,
 			);
 		}
 		return new ScaleOffsetCodec(
 			parseJsonScalar(meta.dataType, config.scale ?? 1),
 			parseJsonScalar(meta.dataType, config.offset ?? 0),
-			getCtr(meta.dataType)
+			getCtr(meta.dataType),
 		);
 	}
 
-	encode(_chunk: Chunk<D>): never {
-		throw new Error("ScaleOffset encoding is not supported.");
-	}
+	encode = unimplementedEncode("scale_offset");
 
 	decode(chunk: Chunk<D>): Chunk<D> {
 		const src = chunk.data;

--- a/packages/zarrita/src/codecs/sharding.ts
+++ b/packages/zarrita/src/codecs/sharding.ts
@@ -1,8 +1,9 @@
 import type { Readable } from "@zarrita/storage";
 import { createCodecPipeline } from "../codecs.js";
+import { UnsupportedError } from "../errors.js";
 import type { Location } from "../hierarchy.js";
 import type { Chunk } from "../metadata.js";
-import { assert, type ShardingCodecMetadata } from "../util.js";
+import type { ShardingCodecMetadata } from "../util.js";
 
 const MAX_BIG_UINT = 18446744073709551615n;
 
@@ -12,7 +13,9 @@ export function createShardedChunkGetter<Store extends Readable>(
 	encodeShardKey: (coord: number[]) => string,
 	shardingConfig: ShardingCodecMetadata["configuration"],
 ) {
-	assert(location.store.getRange, "Store does not support range requests");
+	if (!location.store.getRange) {
+		throw new UnsupportedError("sharding requires a store with getRange");
+	}
 	let getRange = location.store.getRange.bind(location.store);
 	let indexShape = shardShape.map((d, i) => d / shardingConfig.chunk_shape[i]);
 	let indexCodec = createCodecPipeline({

--- a/packages/zarrita/src/codecs/vlen-utf8.ts
+++ b/packages/zarrita/src/codecs/vlen-utf8.ts
@@ -1,5 +1,6 @@
 import type { Chunk, String } from "../metadata.js";
 import { getStrides } from "../util.js";
+import { unimplementedEncode } from "./_shared.js";
 
 export class VLenUTF8 {
 	readonly kind = "array_to_bytes";
@@ -14,9 +15,7 @@ export class VLenUTF8 {
 		return new VLenUTF8(meta.shape);
 	}
 
-	encode(_chunk: Chunk<String>): Uint8Array {
-		throw new Error("Method not implemented.");
-	}
+	encode = unimplementedEncode("vlen-utf8");
 
 	decode(bytes: Uint8Array): Chunk<String> {
 		let decoder = new TextDecoder();

--- a/packages/zarrita/src/codecs/zlib.ts
+++ b/packages/zarrita/src/codecs/zlib.ts
@@ -1,4 +1,5 @@
 import { decompress } from "../util.js";
+import { unimplementedEncode } from "./_shared.js";
 
 interface ZlibCodecConfig {
 	level: number;
@@ -11,11 +12,7 @@ export class ZlibCodec {
 		return new ZlibCodec();
 	}
 
-	encode(_bytes: Uint8Array): never {
-		throw new Error(
-			"Zlib encoding is not enabled by default. Please register a codec with `numcodecs/zlib`.",
-		);
-	}
+	encode = unimplementedEncode("zlib");
 
 	async decode(bytes: Uint8Array): Promise<Uint8Array> {
 		const buffer = await decompress(bytes, { format: "deflate" });

--- a/packages/zarrita/src/consolidated.ts
+++ b/packages/zarrita/src/consolidated.ts
@@ -1,5 +1,5 @@
 import type { AbsolutePath, Readable } from "@zarrita/storage";
-import { KeyError, NodeNotFoundError } from "./errors.js";
+import { InvalidMetadataError, NotFoundError } from "./errors.js";
 import type {
 	ArrayMetadata,
 	ArrayMetadataV2,
@@ -122,15 +122,16 @@ async function loadConsolidatedV2(
 	let key = metadataKey ?? ".zmetadata";
 	let bytes = await store.get(`/${key}`);
 	if (!bytes) {
-		throw new NodeNotFoundError("v2 consolidated metadata", {
-			cause: new KeyError(`/${key}`),
+		throw new NotFoundError("v2 consolidated metadata", {
+			path: `/${key}`,
 		});
 	}
 	let meta: unknown = jsonDecodeObject(bytes);
 	if (!isConsolidatedV2(meta)) {
-		throw new NodeNotFoundError("v2 consolidated metadata", {
-			cause: new Error("Invalid or unsupported v2 consolidated format."),
-		});
+		throw new InvalidMetadataError(
+			"Invalid or unsupported v2 consolidated format",
+			{ path: `/${key}` },
+		);
 	}
 	let knownMeta: Record<AbsolutePath, Metadata> = {};
 	for (let [k, value] of Object.entries(meta.metadata)) {
@@ -144,17 +145,16 @@ async function loadConsolidatedV3(
 ): Promise<Record<AbsolutePath, Metadata>> {
 	let bytes = await store.get("/zarr.json");
 	if (!bytes) {
-		throw new NodeNotFoundError("v3 consolidated metadata", {
-			cause: new KeyError("/zarr.json"),
+		throw new NotFoundError("v3 consolidated metadata", {
+			path: "/zarr.json",
 		});
 	}
 	let rootMeta: unknown = jsonDecodeObject(bytes);
 	if (!isConsolidatedV3(rootMeta)) {
-		throw new NodeNotFoundError("v3 consolidated metadata", {
-			cause: new Error(
-				"Root zarr.json does not contain consolidated_metadata.",
-			),
-		});
+		throw new InvalidMetadataError(
+			"Root zarr.json does not contain consolidated_metadata",
+			{ path: "/zarr.json" },
+		);
 	}
 	let knownMeta: Record<AbsolutePath, Metadata> = {};
 	// Add root group metadata
@@ -271,7 +271,7 @@ export async function withConsolidated<Store extends Readable>(
 					: await loadConsolidatedV3(store);
 			return createListable(store, knownMeta);
 		} catch (err) {
-			rethrowUnless(err, NodeNotFoundError);
+			rethrowUnless(err, NotFoundError, InvalidMetadataError);
 			lastError = err;
 		}
 	}
@@ -296,7 +296,7 @@ export async function tryWithConsolidated<Store extends Readable>(
 	opts: WithConsolidatedOptions = {},
 ): Promise<Listable<Store> | Store> {
 	return withConsolidated(store, opts).catch((error: unknown) => {
-		rethrowUnless(error, NodeNotFoundError);
+		rethrowUnless(error, NotFoundError, InvalidMetadataError);
 		return store;
 	});
 }

--- a/packages/zarrita/src/errors.ts
+++ b/packages/zarrita/src/errors.ts
@@ -1,20 +1,171 @@
-export class NodeNotFoundError extends Error {
-	constructor(context: string, options: { cause?: Error } = {}) {
-		super(`Node not found: ${context}`, options);
-		this.name = "NodeNotFoundError";
+/**
+ * @module
+ *
+ * Structured error types thrown by zarrita. Use {@link isZarritaError} to
+ * detect and narrow errors at runtime — error classes are intentionally not
+ * exported from the package root, so `instanceof` checks on the concrete
+ * classes are not part of the public contract.
+ *
+ * @example
+ * ```ts
+ * import * as zarr from "zarrita";
+ *
+ * try {
+ *   const arr = await zarr.open(store, { kind: "array" });
+ *   await zarr.get(arr, [null, null]);
+ * } catch (err) {
+ *   if (zarr.isZarritaError(err, "NotFoundError")) {
+ *     // err.path / err.found are available
+ *   } else if (zarr.isZarritaError(err, "UnknownCodecError")) {
+ *     // err.codec is the unregistered codec name
+ *   } else if (zarr.isZarritaError(err)) {
+ *     // any zarrita-thrown error
+ *   } else {
+ *     throw err;
+ *   }
+ * }
+ * ```
+ */
+
+abstract class ZarritaError<T extends string> extends Error {
+	abstract readonly _tag: T;
+}
+
+/**
+ * The store returned nothing for a required key, or `open({ kind })` was
+ * asked for an array/group and the path holds the other kind.
+ */
+export class NotFoundError extends ZarritaError<"NotFoundError"> {
+	override readonly _tag = "NotFoundError" as const;
+	override readonly name = "NotFoundError";
+	readonly path: string | undefined;
+	readonly found: "array" | "group" | undefined;
+	constructor(
+		context: string,
+		options: {
+			path?: string;
+			found?: "array" | "group";
+			cause?: unknown;
+		} = {},
+	) {
+		super(`Not found: ${context}`, { cause: options.cause });
+		this.path = options.path;
+		this.found = options.found;
 	}
 }
 
-export class JsonDecodeError extends Error {
-	constructor(cause: unknown) {
-		super("Failed to decode JSON", { cause });
-		this.name = "JsonDecodeError";
+/**
+ * Metadata exists but isn't something zarrita can read: malformed JSON,
+ * unknown dtype or chunk-key encoding, or a codec rejected its config at
+ * load time.
+ */
+export class InvalidMetadataError extends ZarritaError<"InvalidMetadataError"> {
+	override readonly _tag = "InvalidMetadataError" as const;
+	override readonly name = "InvalidMetadataError";
+	readonly path: string | undefined;
+	constructor(
+		message: string,
+		options: { path?: string; cause?: unknown } = {},
+	) {
+		super(message, { cause: options.cause });
+		this.path = options.path;
 	}
 }
 
-export class KeyError extends Error {
-	constructor(path: string) {
-		super(`Missing key: ${path}`);
-		this.name = "KeyError";
+/**
+ * The metadata references a codec that isn't in the registry. Register the
+ * codec via `zarr.registry` and retry to recover.
+ */
+export class UnknownCodecError extends ZarritaError<"UnknownCodecError"> {
+	override readonly _tag = "UnknownCodecError" as const;
+	override readonly name = "UnknownCodecError";
+	readonly codec: string;
+	constructor(codec: string) {
+		super(`Unknown codec: ${codec}`);
+		this.codec = codec;
 	}
+}
+
+/**
+ * A codec threw while encoding or decoding chunk bytes. The originating
+ * codec error is preserved on `cause`; per-chunk failures can be retried
+ * or skipped without abandoning the surrounding read.
+ */
+export class CodecPipelineError extends ZarritaError<"CodecPipelineError"> {
+	override readonly _tag = "CodecPipelineError" as const;
+	override readonly name = "CodecPipelineError";
+	readonly direction: "encode" | "decode";
+	readonly codec: string | undefined;
+	readonly chunkPath: string | undefined;
+	constructor(options: {
+		direction: "encode" | "decode";
+		codec?: string;
+		chunkPath?: string;
+		cause: unknown;
+	}) {
+		const parts = [
+			`Failed to ${options.direction} chunk`,
+			options.codec && `via codec "${options.codec}"`,
+			options.chunkPath && `at ${options.chunkPath}`,
+		].filter(Boolean);
+		super(parts.join(" "), { cause: options.cause });
+		this.direction = options.direction;
+		this.codec = options.codec;
+		this.chunkPath = options.chunkPath;
+	}
+}
+
+/**
+ * The selection passed to `get` or `set` is invalid: wrong rank,
+ * out-of-bounds, zero step, unknown dimension name, or scalar-shape
+ * mismatch.
+ */
+export class InvalidSelectionError extends ZarritaError<"InvalidSelectionError"> {
+	override readonly _tag = "InvalidSelectionError" as const;
+	override readonly name = "InvalidSelectionError";
+}
+
+/**
+ * The requested operation hits a capability limit: write to a sharded
+ * array, encode with a codec that only implements decode, or rely on a
+ * runtime feature the host doesn't provide.
+ */
+export class UnsupportedError extends ZarritaError<"UnsupportedError"> {
+	override readonly _tag = "UnsupportedError" as const;
+	override readonly name = "UnsupportedError";
+	readonly feature: string;
+	constructor(feature: string) {
+		super(`Unsupported: ${feature}`);
+		this.feature = feature;
+	}
+}
+
+type AnyZarritaError =
+	| NotFoundError
+	| InvalidMetadataError
+	| UnknownCodecError
+	| CodecPipelineError
+	| InvalidSelectionError
+	| UnsupportedError;
+
+/**
+ * Runtime guard for zarrita-thrown errors. Without tags, narrows to any
+ * zarrita error; with one or more tags, narrows to the matching subset
+ * (including their typed fields).
+ *
+ * @example
+ * ```ts
+ * try { ... } catch (err) {
+ *   if (zarr.isZarritaError(err, "NotFoundError")) {
+ *     console.log(err.path);
+ *   }
+ * }
+ * ```
+ */
+export function isZarritaError<T extends AnyZarritaError["_tag"]>(
+	err: unknown,
+	...tags: T[]
+): err is Extract<AnyZarritaError, { _tag: T }> {
+	if (!(err instanceof ZarritaError)) return false;
+	return tags.length === 0 || (tags as string[]).includes(err._tag);
 }

--- a/packages/zarrita/src/index.ts
+++ b/packages/zarrita/src/index.ts
@@ -15,11 +15,18 @@ export type {
 } from "./consolidated.js";
 export { tryWithConsolidated, withConsolidated } from "./consolidated.js";
 export { create } from "./create.js";
-export { KeyError, NodeNotFoundError } from "./errors.js";
+export {
+	CodecPipelineError,
+	InvalidMetadataError,
+	InvalidSelectionError,
+	isZarritaError,
+	NotFoundError,
+	UnknownCodecError,
+	UnsupportedError,
+} from "./errors.js";
 export { Array, Group, Location, root } from "./hierarchy.js";
 // internal exports for @zarrita/ndarray
 export { get as _zarrita_internal_get } from "./indexing/get.js";
-export { IndexError } from "./indexing/indexer.js";
 export { get, set } from "./indexing/ops.js";
 export { set as _zarrita_internal_set } from "./indexing/set.js";
 export type {

--- a/packages/zarrita/src/indexing/indexer.ts
+++ b/packages/zarrita/src/indexing/indexer.ts
@@ -1,30 +1,24 @@
+import { InvalidSelectionError } from "../errors.js";
 import type { Indices, Slice } from "./types.js";
 import { product, range, slice, sliceIndices } from "./util.js";
-
-export class IndexError extends Error {
-	constructor(msg: string) {
-		super(msg);
-		this.name = "IndexError";
-	}
-}
 
 function errTooManyIndices(
 	selection: (number | Slice)[],
 	shape: readonly number[],
 ) {
-	throw new IndexError(
+	throw new InvalidSelectionError(
 		`too many indicies for array; expected ${shape.length}, got ${selection.length}`,
 	);
 }
 
 function errBoundscheck(dimLen: number) {
-	throw new IndexError(
+	throw new InvalidSelectionError(
 		`index out of bounds for dimension with length ${dimLen}`,
 	);
 }
 
 function errNegativeStep() {
-	throw new IndexError("only slices with step >= 1 are supported");
+	throw new InvalidSelectionError("only slices with step >= 1 are supported");
 }
 
 function checkSelectionLength(

--- a/packages/zarrita/src/indexing/set.ts
+++ b/packages/zarrita/src/indexing/set.ts
@@ -1,5 +1,6 @@
 import type { Mutable } from "@zarrita/storage";
 
+import { InvalidSelectionError, UnsupportedError } from "../errors.js";
 import { type Array, getContext } from "../hierarchy.js";
 import type { Chunk, DataType, Scalar, TypedArray } from "../metadata.js";
 import { isAbortable } from "../util.js";
@@ -32,7 +33,7 @@ export async function set<Dtype extends DataType, Arr extends Chunk<Dtype>>(
 ) {
 	const context = getContext(arr);
 	if (context.kind === "sharded") {
-		throw new Error("Set not supported for sharded arrays.");
+		throw new UnsupportedError("set on sharded arrays");
 	}
 	const indexer = new BasicIndexer({
 		selection,
@@ -45,7 +46,9 @@ export async function set<Dtype extends DataType, Arr extends Chunk<Dtype>>(
 	if (arr.shape.length === 0) {
 		const chunkData = new context.TypedArray(1);
 		if (typeof value === "object") {
-			throw new Error("Cannot set a scalar array with a non-scalar value.");
+			throw new InvalidSelectionError(
+				"Cannot set a scalar array with a non-scalar value.",
+			);
 		}
 		// @ts-expect-error - Value is a scalar
 		chunkData.fill(value);

--- a/packages/zarrita/src/indexing/util.ts
+++ b/packages/zarrita/src/indexing/util.ts
@@ -1,4 +1,5 @@
 import type { Readable } from "@zarrita/storage";
+import { InvalidSelectionError } from "../errors.js";
 import type { Array as ZarrArray } from "../hierarchy.js";
 import type { DataType } from "../metadata.js";
 import type { ChunkQueue, Indices, Slice } from "./types.js";
@@ -60,7 +61,7 @@ export function sliceIndices(
 	length: number,
 ): Indices {
 	if (step === 0) {
-		throw new Error("slice step cannot be zero");
+		throw new InvalidSelectionError("slice step cannot be zero");
 	}
 	step = step ?? 1;
 	const stepIsNegative = step < 0;
@@ -103,7 +104,7 @@ function toInt(value: bigint | number | null): number | null {
 	if (value == null) return null;
 	if (typeof value === "bigint") {
 		if (value > Number.MAX_SAFE_INTEGER || value < Number.MIN_SAFE_INTEGER) {
-			throw new RangeError(
+			throw new InvalidSelectionError(
 				`Cannot safely convert ${value} to a number. Value exceeds Number.MAX_SAFE_INTEGER.`,
 			);
 		}
@@ -142,11 +143,13 @@ export function sel<D extends DataType, Store extends Readable>(
 ): (Slice | number | null)[] {
 	let names = arr.dimensionNames;
 	if (!names) {
-		throw new Error("Array does not have dimension_names in its metadata.");
+		throw new InvalidSelectionError(
+			"Array does not have dimension_names in its metadata.",
+		);
 	}
 	for (let key of Object.keys(selection)) {
 		if (!names.includes(key)) {
-			throw new Error(
+			throw new InvalidSelectionError(
 				`Unknown dimension name: "${key}". Available dimensions: ${names.map((n) => `"${n}"`).join(", ")}`,
 			);
 		}

--- a/packages/zarrita/src/open.ts
+++ b/packages/zarrita/src/open.ts
@@ -1,5 +1,5 @@
 import type { Readable } from "@zarrita/storage";
-import { JsonDecodeError, KeyError, NodeNotFoundError } from "./errors.js";
+import { InvalidMetadataError, NotFoundError } from "./errors.js";
 import { Array, Group, Location } from "./hierarchy.js";
 import type {
 	ArrayMetadata,
@@ -74,7 +74,7 @@ async function openV2<Store extends Readable>(
 	if (options.kind === "array") return openArrayV2(loc, attrs, opts);
 	if (options.kind === "group") return openGroupV2(loc, attrs, opts);
 	return openArrayV2(loc, attrs, opts).catch((err) => {
-		rethrowUnless(err, NodeNotFoundError, JsonDecodeError);
+		rethrowUnless(err, NotFoundError, InvalidMetadataError);
 		return openGroupV2(loc, attrs, opts);
 	});
 }
@@ -87,9 +87,7 @@ async function openArrayV2<Store extends Readable>(
 	let { path } = location.resolve(".zarray");
 	let meta = await location.store.get(path, opts);
 	if (!meta) {
-		throw new NodeNotFoundError("v2 array", {
-			cause: new KeyError(path),
-		});
+		throw new NotFoundError("v2 array", { path });
 	}
 	VERSION_COUNTER.increment(location.store, "v2");
 	return new Array(
@@ -107,9 +105,7 @@ async function openGroupV2<Store extends Readable>(
 	let { path } = location.resolve(".zgroup");
 	let meta = await location.store.get(path, opts);
 	if (!meta) {
-		throw new NodeNotFoundError("v2 group", {
-			cause: new KeyError(path),
-		});
+		throw new NotFoundError("v2 group", { path });
 	}
 	VERSION_COUNTER.increment(location.store, "v2");
 	return new Group(
@@ -126,9 +122,7 @@ async function _openV3<Store extends Readable>(
 	let { store, path } = location.resolve("zarr.json");
 	let meta = await location.store.get(path, opts);
 	if (!meta) {
-		throw new NodeNotFoundError("v3 array or group", {
-			cause: new KeyError(path),
-		});
+		throw new NotFoundError("v3 array or group", { path });
 	}
 	let metaDoc: ArrayMetadata<DataType> | GroupMetadata = jsonDecodeObject(meta);
 	if (metaDoc.node_type === "array") {
@@ -169,8 +163,11 @@ async function openV3<Store extends Readable>(
 	if (options.kind === undefined) return node;
 	if (options.kind === "array" && node instanceof Array) return node;
 	if (options.kind === "group" && node instanceof Group) return node;
-	let kind = node instanceof Array ? "array" : "group";
-	throw new Error(`Expected node of kind ${options.kind}, found ${kind}.`);
+	let kind: "array" | "group" = node instanceof Array ? "array" : "group";
+	throw new NotFoundError(`${options.kind} at ${loc.path}`, {
+		path: loc.path,
+		found: kind,
+	});
 }
 
 export function open<Store extends Readable>(
@@ -208,7 +205,7 @@ export async function open<Store extends Readable>(
 	let openPrimary = versionMax === "v2" ? open.v2 : open.v3;
 	let openSecondary = versionMax === "v2" ? open.v3 : open.v2;
 	return openPrimary(location, options).catch((err) => {
-		rethrowUnless(err, NodeNotFoundError, JsonDecodeError);
+		rethrowUnless(err, NotFoundError, InvalidMetadataError);
 		return openSecondary(location, options);
 	});
 }

--- a/packages/zarrita/src/util.ts
+++ b/packages/zarrita/src/util.ts
@@ -1,4 +1,4 @@
-import { JsonDecodeError } from "./errors.js";
+import { InvalidMetadataError } from "./errors.js";
 import type {
 	ArrayMetadata,
 	ArrayMetadataV2,
@@ -62,7 +62,7 @@ export function jsonDecodeObject(bytes: Uint8Array) {
 	try {
 		return JSON.parse(str);
 	} catch (cause) {
-		throw new JsonDecodeError(cause);
+		throw new InvalidMetadataError("Failed to decode JSON", { cause });
 	}
 }
 
@@ -115,7 +115,11 @@ export function getCtr<D extends DataType>(
 			bool: BoolArray,
 		} as const
 	)[dataType];
-	assert(ctr, `Unknown or unsupported dataType: ${dataType}`);
+	if (!ctr) {
+		throw new InvalidMetadataError(
+			`Unknown or unsupported dataType: ${dataType}`,
+		);
+	}
 	return ctr;
 }
 
@@ -159,7 +163,7 @@ export function createChunkKeyEncoder({
 		const separator = configuration?.separator ?? ".";
 		return (chunkCoords) => chunkCoords.join(separator) || "0";
 	}
-	throw new Error(`Unknown chunk key encoding: ${name}`);
+	throw new InvalidMetadataError(`Unknown chunk key encoding: ${name}`);
 }
 
 function coerceDtype(
@@ -170,7 +174,9 @@ function coerceDtype(
 	}
 
 	let match = dtype.match(/^([<|>])(.*)$/);
-	assert(match, `Invalid dtype: ${dtype}`);
+	if (!match) {
+		throw new InvalidMetadataError(`Invalid dtype: ${dtype}`);
+	}
 
 	let [, endian, rest] = match;
 	let dataType =
@@ -189,7 +195,9 @@ function coerceDtype(
 			f8: "float64",
 		}[rest] ??
 		(rest.startsWith("S") || rest.startsWith("U") ? `v2:${rest}` : undefined);
-	assert(dataType, `Unsupported or unknown dtype: ${dtype}`);
+	if (!dataType) {
+		throw new InvalidMetadataError(`Unsupported or unknown dtype: ${dtype}`);
+	}
 	if (endian === "|") {
 		return { dataType } as { dataType: DataType };
 	}


### PR DESCRIPTION
Zarrita's failure modes were spread across plain `Error` throws and a handful of one-off custom classes. Callers couldn't reliably catch a category without parsing message strings, and each new throw site risked growing the public class surface in an ad-hoc way.

These changes collapse every distinct failure reachable from `zarr.open`, `zarr.get`, and `zarr.set` into six tagged subclasses sharing an internal `ZarritaError` base. The classes are exported alongside an `isZarritaError` runtime guard, but module-level docs steer consumers toward the guard so `instanceof` checks aren't load-bearing.

The categories map to actual code paths a caller hits:

```js
    NotFoundError          // store missing key, or open({ kind }) found other kind
    InvalidMetadataError   // bad JSON, unknown dtype, codec config rejected
    UnknownCodecError      // codec not in registry — actionable: register and retry
    CodecPipelineError     // codec encode/decode threw at runtime; wraps cause
    InvalidSelectionError  // bad rank, bounds, step, scalar shape
    UnsupportedError       // capability limit (sharded set, encode-only codecs)
```

```ts
try {
  await zarr.open(store, { kind: "array" });
} catch (e) {
  if (zarr.isZarritaError(e, "NotFoundError")) {
    e.path; e.found;  // typed fields
  } else if (zarr.isZarritaError(e, "UnknownCodecError")) {
    await registerCodec(e.codec);
  }
}
```