### PR TITLE
Rename middleware to extension

### DIFF
--- a/.changeset/store-extension-system.md
+++ b/.changeset/store-extension-system.md
@@ -2,13 +2,14 @@
 "zarrita": minor
 ---
 
-Introduce composable store middleware via `defineStoreMiddleware`
+Introduce composable store and array extensions via `defineStoreExtension` and `defineArrayExtension`
 
 **New APIs:**
 
-- `zarr.defineStoreMiddleware(factory)` — define a store middleware with automatic Proxy delegation. The factory receives an `AsyncReadable` store and options, returning overrides and extensions. Supports sync and async factories.
-- `zarr.defineStoreMiddleware.generic<OptsLambda>()(factory)` — for middleware whose options depend on the store's request options type (e.g., `mergeOptions`). Uses `GenericOptions` interface for higher-kinded type encoding.
-- `zarr.extendStore(store, ...middleware)` — compose middleware in a pipeline. Each middleware is `(store) => newStore`. Returns `Promise` to support async middleware like `withConsolidation`.
+- `zarr.defineStoreExtension(factory)` — define a store extension with automatic Proxy delegation. The factory receives an `AsyncReadable` store and options, returning overrides and extensions. Supports sync and async factories.
+- `zarr.defineArrayExtension(factory)` — define an array extension that intercepts `getChunk` on a `zarr.Array`. Same Proxy-delegation model.
+- `zarr.extendStore(store, ...extensions)` — compose store extensions in a pipeline. Each extension is `(store) => newStore`. Returns `Promise` to support async extensions like `withConsolidation`.
+- `zarr.extendArray(array, ...extensions)` — compose array extensions in a pipeline.
 
 **Renamed:**
 
@@ -33,12 +34,12 @@ let store = await zarr.extendStore(
 );
 ```
 
-**Defining custom middleware:**
+**Defining custom extensions:**
 
 ```ts
 import * as zarr from "zarrita";
 
-const withCaching = zarr.defineStoreMiddleware(
+const withCaching = zarr.defineStoreExtension(
   (store, opts: { maxSize?: number }) => {
     let cache = new Map();
     return {
@@ -55,4 +56,4 @@ const withCaching = zarr.defineStoreMiddleware(
 );
 ```
 
-`BatchedRangeStore` class has been removed in favor of `withRangeBatching` built on `zarr.defineStoreMiddleware`.
+`BatchedRangeStore` class has been removed in favor of `withRangeBatching` built on `zarr.defineStoreExtension`.

--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -34,7 +34,7 @@ export default defineConfig({
 					{ text: "Slicing and Indexing", link: "/slicing" },
 					{ text: "Supported Types", link: "/supported-types" },
 					{ text: "Cookbook", link: "/cookbook" },
-					{ text: "Middleware", link: "/store-middleware" },
+					{ text: "Extensions", link: "/store-extensions" },
 				],
 			},
 			{

--- a/docs/store-extensions.md
+++ b/docs/store-extensions.md
@@ -1,24 +1,24 @@
-# Middleware
+# Extensions
 
 **zarrita** has two symmetric extension points for composing behavior on top
-of a base store or array: **store middleware** and **array middleware**.
+of a base store or array: **store extensions** and **array extensions**.
 
 | Layer | Intercepts | Primitive | Composer |
 | --- | --- | --- | --- |
-| Transport | `store.get(key, range)` | `zarr.defineStoreMiddleware` | `zarr.extendStore` |
-| Data | `array.getChunk(coords)` | `zarr.defineArrayMiddleware` | `zarr.extendArray` |
+| Transport | `store.get(key, range)` | `zarr.defineStoreExtension` | `zarr.extendStore` |
+| Data | `array.getChunk(coords)` | `zarr.defineArrayExtension` | `zarr.extendArray` |
 
-Store middleware is for transport concerns (caching bytes, batching range
-requests, short-circuiting metadata, request transformation). Array middleware
-is for data concerns (caching decoded chunks, prefetch priority, observability).
+Store extensions are for transport concerns (caching bytes, batching range
+requests, short-circuiting metadata, request transformation). Array extensions
+are for data concerns (caching decoded chunks, prefetch priority, observability).
 If you're not sure which layer you need: if your code deals in paths and
-bytes, it's a store middleware; if it deals in chunk coordinates, it's an
-array middleware.
+bytes, it's a store extension; if it deals in chunk coordinates, it's an
+array extension.
 
-## Store middleware
+## Store extensions
 
-Wrap a store with `zarr.defineStoreMiddleware`, then compose with
-`zarr.extendStore`. **zarrita** ships with middleware for consolidated metadata
+Wrap a store with `zarr.defineStoreExtension`, then compose with
+`zarr.extendStore`. **zarrita** ships with extensions for consolidated metadata
 and range batching:
 
 ```ts
@@ -34,13 +34,13 @@ store.contents(); // from zarr.withConsolidation
 store.stats;      // from zarr.withRangeBatching
 ```
 
-Each middleware wraps the previous result. `zarr.extendStore` handles async
-middleware (like `zarr.withConsolidation`, which fetches metadata during
-initialization) automatically, and always returns a `Promise`. A middleware
+Each extension wraps the previous result. `zarr.extendStore` handles async
+extensions (like `zarr.withConsolidation`, which fetches metadata during
+initialization) automatically, and always returns a `Promise`. An extension
 with no required options can be passed uncalled; otherwise wrap it in an arrow
 so the options are applied to the argument.
 
-You can also call middleware directly:
+You can also call extensions directly:
 
 ```ts
 let consolidated = await zarr.withConsolidation(
@@ -58,7 +58,7 @@ inner store via `Proxy`.
 ```ts
 import * as zarr from "zarrita";
 
-const withCaching = zarr.defineStoreMiddleware(
+const withCaching = zarr.defineStoreExtension(
   (store, opts: { maxSize?: number } = {}) => {
     let cache = new Map<zarr.AbsolutePath, Uint8Array>();
     return {
@@ -77,17 +77,17 @@ const withCaching = zarr.defineStoreMiddleware(
 );
 
 let store = withCaching(new zarr.FetchStore("https://..."), { maxSize: 256 });
-store.clear(); // new method from the middleware
+store.clear(); // new method from the extension
 ```
 
 Only `get` and `getRange` are interceptable; any other keys on the factory
 result become extensions on the wrapped store.
 
-Middleware can be **sync or async**. If the factory returns a `Promise`, the
+Extensions can be **sync or async**. If the factory returns a `Promise`, the
 wrapper returns a `Promise` too:
 
 ```ts
-const withMetadata = zarr.defineStoreMiddleware(
+const withMetadata = zarr.defineStoreExtension(
   async (store, opts: { key: zarr.AbsolutePath }) => {
     let bytes = await store.get(opts.key);
     let meta = JSON.parse(new TextDecoder().decode(bytes));
@@ -101,16 +101,16 @@ let store = await withMetadata(rawStore, { key: "/meta.json" });
 store.metadata(); // loaded during initialization
 ```
 
-## Array middleware
+## Array extensions
 
-Array middleware is the symmetric extension point for **chunk-layer** concerns:
+Array extensions are the symmetric extension point for **chunk-layer** concerns:
 anything that wants to intercept `getChunk(coords)` without caring about paths
 or bytes. Think chunk caching, prefetch priority, or observability hooks.
 
 ```ts
 import * as zarr from "zarrita";
 
-const withChunkCache = zarr.defineArrayMiddleware(
+const withChunkCache = zarr.defineArrayExtension(
   (array, opts: { cache: Map<string, zarr.Chunk<zarr.DataType>> }) => ({
     async getChunk(coords, options) {
       let key = coords.join(",");
@@ -141,5 +141,5 @@ be written once and applied to any concrete `Array<D, S>`. At the call site
 the outer generics are preserved, so downstream `zarr.get(wrapped)` calls
 return the right specific type.
 
-Like `extendStore`, `extendArray` always returns a `Promise` so middleware can
+Like `extendStore`, `extendArray` always returns a `Promise` so extensions can
 perform async initialization.

--- a/packages/zarrita/__tests__/array-extension.test.ts
+++ b/packages/zarrita/__tests__/array-extension.test.ts
@@ -1,8 +1,8 @@
 import * as path from "node:path";
 import * as url from "node:url";
 import { describe, expect, it } from "vitest";
+import { defineArrayExtension } from "../src/extension/define-array.js";
 import * as zarr from "../src/index.js";
-import { defineArrayMiddleware } from "../src/middleware/define-array.js";
 
 let __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 let fixturesRoot = path.resolve(__dirname, "../../../fixtures/v3/data.zarr");
@@ -12,10 +12,10 @@ async function openFixture(name: string) {
 	return zarr.open.v3(zarr.root(store).resolve(name), { kind: "array" });
 }
 
-describe("defineArrayMiddleware", () => {
+describe("defineArrayExtension", () => {
 	it("intercepts getChunk", async () => {
 		let calls: number[][] = [];
-		let withTrace = defineArrayMiddleware((array) => ({
+		let withTrace = defineArrayExtension((array) => ({
 			async getChunk(coords, options) {
 				calls.push(coords);
 				return array.getChunk(coords, options);
@@ -29,7 +29,7 @@ describe("defineArrayMiddleware", () => {
 	});
 
 	it("pass-through getters still work (private field access)", async () => {
-		let withNoop = defineArrayMiddleware((_array) => ({}));
+		let withNoop = defineArrayExtension((_array) => ({}));
 		let arr = await openFixture("1d.chunked.i2");
 		let wrapped = withNoop(arr);
 		// These all read from `this.#metadata` via getters on Array.
@@ -40,7 +40,7 @@ describe("defineArrayMiddleware", () => {
 	});
 
 	it("extensions appear on the wrapped array", async () => {
-		let withCounter = defineArrayMiddleware((_array) => {
+		let withCounter = defineArrayExtension((_array) => {
 			let n = 0;
 			return {
 				bump() {
@@ -60,7 +60,7 @@ describe("defineArrayMiddleware", () => {
 
 	it("works with zarr.get through the interception chain", async () => {
 		let cache = new Map<string, zarr.Chunk<zarr.DataType>>();
-		let withCache = defineArrayMiddleware((array) => ({
+		let withCache = defineArrayExtension((array) => ({
 			async getChunk(coords, options) {
 				let key = coords.join(",");
 				let hit = cache.get(key);
@@ -81,22 +81,22 @@ describe("defineArrayMiddleware", () => {
 });
 
 describe("extendArray", () => {
-	it("no middleware returns the array as-is", async () => {
+	it("no extension returns the array as-is", async () => {
 		let arr = await openFixture("1d.chunked.i2");
 		let result = await zarr.extendArray(arr);
 		expect(result).toBe(arr);
 	});
 
-	it("composes multiple middlewares in order", async () => {
+	it("composes multiple extensions in order", async () => {
 		let order: string[] = [];
-		let withA = defineArrayMiddleware((_array) => ({
+		let withA = defineArrayExtension((_array) => ({
 			tagA: "a",
 			async getChunk(coords, options) {
 				order.push("a");
 				return _array.getChunk(coords, options);
 			},
 		}));
-		let withB = defineArrayMiddleware((_array) => ({
+		let withB = defineArrayExtension((_array) => ({
 			tagB: "b",
 			async getChunk(coords, options) {
 				order.push("b");

--- a/packages/zarrita/__tests__/batched-fetch.test.ts
+++ b/packages/zarrita/__tests__/batched-fetch.test.ts
@@ -1,6 +1,6 @@
 import type { AbsolutePath, RangeQuery } from "@zarrita/storage";
 import { describe, expect, it, vi } from "vitest";
-import { withRangeBatching } from "../src/middleware/range-batching.js";
+import { withRangeBatching } from "../src/extension/range-batching.js";
 
 /**
  * Create a fake store with controllable getRange.

--- a/packages/zarrita/__tests__/consolidated.test.ts
+++ b/packages/zarrita/__tests__/consolidated.test.ts
@@ -3,11 +3,11 @@ import * as url from "node:url";
 import { FileSystemStore } from "@zarrita/storage";
 import { assert, describe, expect, it } from "vitest";
 import { NotFoundError } from "../src/errors.js";
-import { Array as ZarrArray } from "../src/hierarchy.js";
 import {
 	withConsolidation,
 	withMaybeConsolidation,
-} from "../src/middleware/consolidation.js";
+} from "../src/extension/consolidation.js";
+import { Array as ZarrArray } from "../src/hierarchy.js";
 import { open } from "../src/open.js";
 
 let __dirname = path.dirname(url.fileURLToPath(import.meta.url));

--- a/packages/zarrita/__tests__/extension-types.test.ts
+++ b/packages/zarrita/__tests__/extension-types.test.ts
@@ -1,12 +1,12 @@
 import type { AbsolutePath, AsyncReadable } from "@zarrita/storage";
 import { expectType } from "tintype";
 import { describe, expect, test, vi } from "vitest";
+import { defineStoreExtension } from "../src/extension/define.js";
+import { defineArrayExtension } from "../src/extension/define-array.js";
 import * as zarr from "../src/index.js";
-import { defineStoreMiddleware } from "../src/middleware/define.js";
-import { defineArrayMiddleware } from "../src/middleware/define-array.js";
 
 describe("extendStore", () => {
-	test("no middleware returns store as-is", () => {
+	test("no extension returns store as-is", () => {
 		let store = zarr.extendStore(new zarr.FetchStore(""));
 		expectType(store).toMatchInlineSnapshot(`zarr.FetchStore`);
 	});
@@ -23,7 +23,7 @@ describe("extendStore", () => {
 		`);
 	});
 
-	test("no-config middleware can be passed uncalled", () => {
+	test("no-config extension can be passed uncalled", () => {
 		function check() {
 			return zarr.extendStore(
 				new zarr.FetchStore(""),
@@ -43,9 +43,9 @@ describe("extendStore", () => {
 	});
 });
 
-describe("defineStoreMiddleware", () => {
+describe("defineStoreExtension", () => {
 	test("simple: extensions appear, store methods preserved", () => {
-		let withCustom = defineStoreMiddleware(
+		let withCustom = defineStoreExtension(
 			(store: AsyncReadable, _opts: { flag: boolean }) => {
 				return {
 					async get(key: AbsolutePath) {
@@ -69,7 +69,7 @@ describe("defineStoreMiddleware", () => {
 	});
 
 	test("chaining preserves store through wrappers", () => {
-		let withA = defineStoreMiddleware(
+		let withA = defineStoreExtension(
 			(store: AsyncReadable, _opts: { a: number }) => {
 				return {
 					async get(key: AbsolutePath) {
@@ -81,7 +81,7 @@ describe("defineStoreMiddleware", () => {
 				};
 			},
 		);
-		let withB = defineStoreMiddleware(
+		let withB = defineStoreExtension(
 			(store: AsyncReadable, _opts: { b: string }) => {
 				return {
 					async get(key: AbsolutePath) {
@@ -102,9 +102,9 @@ describe("defineStoreMiddleware", () => {
 			}
 		`);
 	});
-	test("function called in middleware definition is only called once", async () => {
+	test("function called in extension definition is only called once", async () => {
 		const someInitializerFunction = vi.fn();
-		let withCustom = defineStoreMiddleware(
+		let withCustom = defineStoreExtension(
 			async (store: AsyncReadable, _opts: { flag: boolean }) => {
 				await someInitializerFunction();
 				return {
@@ -133,9 +133,9 @@ describe("defineStoreMiddleware", () => {
 	});
 });
 
-describe("defineArrayMiddleware", () => {
+describe("defineArrayExtension", () => {
 	test("extensions appear, concrete D/S are preserved", () => {
-		let withCounter = defineArrayMiddleware((_array) => ({
+		let withCounter = defineArrayExtension((_array) => ({
 			bump(): void {},
 			get count(): number {
 				return 0;

--- a/packages/zarrita/__tests__/signal.test.ts
+++ b/packages/zarrita/__tests__/signal.test.ts
@@ -128,7 +128,7 @@ describe("zarr.set cancels on signal", () => {
 });
 
 describe("signal propagation through extendStore pipeline", () => {
-	it("reaches the inner store through multiple middlewares", async () => {
+	it("reaches the inner store through multiple extensions", async () => {
 		let fsStore = new zarr.FileSystemStore(fixturesRoot);
 		let { store: recorder, calls } = recordingStore(fsStore);
 		let composed = await zarr.extendStore(recorder, (s) =>
@@ -141,7 +141,7 @@ describe("signal propagation through extendStore pipeline", () => {
 		let ctl = new AbortController();
 		await zarr.get(arr, null, { signal: ctl.signal });
 		// At least one of the inner-store calls carried our signal through
-		// the batching middleware.
+		// the batching extension.
 		let seen = calls.some((c) => c?.signal === ctl.signal);
 		expect(seen).toBe(true);
 	});

--- a/packages/zarrita/src/extension/consolidation.ts
+++ b/packages/zarrita/src/extension/consolidation.ts
@@ -20,7 +20,7 @@ import {
 	jsonEncodeObject,
 	rethrowUnless,
 } from "../util.js";
-import { defineStoreMiddleware } from "./define.js";
+import { defineStoreExtension } from "./define.js";
 
 type ConsolidatedMetadataV2 = {
 	metadata: Record<string, ArrayMetadataV2 | GroupMetadataV2>;
@@ -211,7 +211,7 @@ export type Listable<Store extends Readable> = Store & {
  * store.contents(); // [{ path: "/", kind: "group" }, ...]
  * ```
  */
-export const withConsolidation = defineStoreMiddleware(
+export const withConsolidation = defineStoreExtension(
 	async (store, opts: ConsolidationOptions = {}) => {
 		let formats = resolveFormats(store, opts.format);
 		let lastError: unknown;

--- a/packages/zarrita/src/extension/define-array.ts
+++ b/packages/zarrita/src/extension/define-array.ts
@@ -3,7 +3,7 @@ import type { Array } from "../hierarchy.js";
 import type { DataType } from "../metadata.js";
 import { assertFactoryResult, createProxy } from "./define.js";
 
-/** Array keys whose overrides are intercepted by the middleware. */
+/** Array keys whose overrides are intercepted by the extension. */
 type ArrayOverrideKeys = "getChunk";
 
 /** Strip array keys from extensions so Array's own surface isn't duplicated. */
@@ -24,7 +24,7 @@ type FactoryResult = Partial<
 	Record<string, unknown>;
 
 /**
- * Define a composable array middleware.
+ * Define a composable array extension.
  *
  * The factory receives the inner `Array` and user options, and returns an
  * object of overrides and extensions. In v1 only `getChunk` is interceptable —
@@ -39,7 +39,7 @@ type FactoryResult = Partial<
  * ```ts
  * import * as zarr from "zarrita";
  *
- * const withChunkCache = zarr.defineArrayMiddleware(
+ * const withChunkCache = zarr.defineArrayExtension(
  *   (array, opts: { cache: Map<string, zarr.Chunk<zarr.DataType>> }) => ({
  *     async getChunk(coords, options) {
  *       let key = coords.join(",");
@@ -53,7 +53,7 @@ type FactoryResult = Partial<
  * );
  * ```
  */
-export function defineArrayMiddleware<
+export function defineArrayExtension<
 	R extends FactoryResult | Promise<FactoryResult>,
 	Opts = void,
 >(
@@ -62,7 +62,7 @@ export function defineArrayMiddleware<
 	array: A,
 	opts?: Opts,
 ) => WrapperResult<R, A>;
-export function defineArrayMiddleware(
+export function defineArrayExtension(
 	factory: (array: Array<DataType, Readable>, opts: never) => unknown,
 ): (array: Array<DataType, Readable>, opts?: unknown) => unknown {
 	return (array, opts) => {

--- a/packages/zarrita/src/extension/define.ts
+++ b/packages/zarrita/src/extension/define.ts
@@ -76,24 +76,24 @@ export function assertFactoryResult(
 	value: unknown,
 ): asserts value is Record<string | symbol, unknown> {
 	if (value == null || typeof value !== "object") {
-		throw new Error("Middleware factory must return an object of overrides");
+		throw new Error("Extension factory must return an object of overrides");
 	}
 }
 
 /**
- * Define a composable store middleware.
+ * Define a composable store extension.
  *
  * The factory function receives the inner store and options, and returns an
  * object of overrides and extensions. Methods not returned are automatically
  * delegated to the inner store via Proxy.
  *
  * Supports both sync and async factories — if the factory returns a Promise,
- * the middleware returns a Promise too.
+ * the extension returns a Promise too.
  *
  * ```ts
  * import * as zarr from "zarrita";
  *
- * const withCaching = zarr.defineStoreMiddleware(
+ * const withCaching = zarr.defineStoreExtension(
  *   (store, opts: { maxSize: number }) => {
  *     return {
  *       async get(key, options) { ... },
@@ -103,13 +103,13 @@ export function assertFactoryResult(
  * );
  * ```
  */
-export function defineStoreMiddleware<
+export function defineStoreExtension<
 	R extends FactoryResult | Promise<FactoryResult>,
 	Opts = void,
 >(
 	factory: (store: AsyncReadable, opts: Opts) => R,
 ): <S extends AsyncReadable>(store: S, opts?: Opts) => WrapperResult<R, S>;
-export function defineStoreMiddleware(
+export function defineStoreExtension(
 	factory: (store: AsyncReadable, opts: never) => unknown,
 ): (store: AsyncReadable, opts?: unknown) => unknown {
 	return (store, opts) => {

--- a/packages/zarrita/src/extension/extend-array.ts
+++ b/packages/zarrita/src/extension/extend-array.ts
@@ -1,7 +1,7 @@
 import type { Readable } from "@zarrita/storage";
 import type { Array } from "../hierarchy.js";
 import type { DataType } from "../metadata.js";
-import { applyMiddlewares, type MaybeAsync } from "./extend.js";
+import { applyExtensions, type MaybeAsync } from "./extend.js";
 
 type AnyArray = Array<DataType, Readable>;
 
@@ -38,7 +38,7 @@ export function extendArray<A extends AnyArray, R1, R2, R3, R4, R5>(
 ): MaybeAsync<R5, [R1, R2, R3, R4, R5]>;
 export function extendArray(
 	array: AnyArray,
-	...middlewares: ((array: unknown) => unknown)[]
+	...extensions: ((array: unknown) => unknown)[]
 ): unknown {
-	return applyMiddlewares(array, middlewares);
+	return applyExtensions(array, extensions);
 }

--- a/packages/zarrita/src/extension/extend-store.ts
+++ b/packages/zarrita/src/extension/extend-store.ts
@@ -1,5 +1,5 @@
 import type { AsyncReadable } from "@zarrita/storage";
-import { applyMiddlewares, type MaybeAsync } from "./extend.js";
+import { applyExtensions, type MaybeAsync } from "./extend.js";
 
 export function extendStore<S extends AsyncReadable>(store: S): S;
 export function extendStore<S extends AsyncReadable, R1>(
@@ -34,7 +34,7 @@ export function extendStore<S extends AsyncReadable, R1, R2, R3, R4, R5>(
 ): MaybeAsync<R5, [R1, R2, R3, R4, R5]>;
 export function extendStore(
 	store: AsyncReadable,
-	...middlewares: ((store: unknown) => unknown)[]
+	...extensions: ((store: unknown) => unknown)[]
 ): unknown {
-	return applyMiddlewares(store, middlewares);
+	return applyExtensions(store, extensions);
 }

--- a/packages/zarrita/src/extension/extend.ts
+++ b/packages/zarrita/src/extension/extend.ts
@@ -1,19 +1,19 @@
 /**
- * Walk a list of middlewares, calling each synchronously until one returns a
- * `Promise`. From that point on, chain the remaining middlewares with `.then`
+ * Walk a list of extensions, calling each synchronously until one returns a
+ * `Promise`. From that point on, chain the remaining extensions with `.then`
  * so the caller only pays the cost of a Promise if any step actually needs
  * one. This is the shared runtime used by `extendStore` and `extendArray`.
  */
-export function applyMiddlewares(
+export function applyExtensions(
 	value: unknown,
-	middlewares: readonly ((value: unknown) => unknown)[],
+	extensions: readonly ((value: unknown) => unknown)[],
 ): unknown {
 	let result = value;
-	for (let m of middlewares) {
+	for (let ext of extensions) {
 		if (result instanceof Promise) {
-			result = result.then((v) => m(v));
+			result = result.then((v) => ext(v));
 		} else {
-			result = m(result);
+			result = ext(result);
 		}
 	}
 	return result;
@@ -27,7 +27,7 @@ export type AnyPromise<Rs extends readonly unknown[]> = [
 	: true;
 
 /**
- * Wrap `Final` in `Promise` iff any of the middleware results in `Rs` was a
+ * Wrap `Final` in `Promise` iff any of the extension results in `Rs` was a
  * Promise, otherwise return the unwrapped value type.
  */
 export type MaybeAsync<Final, Rs extends readonly unknown[]> =

--- a/packages/zarrita/src/extension/range-batching.ts
+++ b/packages/zarrita/src/extension/range-batching.ts
@@ -6,7 +6,7 @@ import type {
 	Readable,
 } from "@zarrita/storage";
 import { UnsupportedError } from "../errors.js";
-import { defineStoreMiddleware } from "./define.js";
+import { defineStoreExtension } from "./define.js";
 
 type RequiredGetRange = NonNullable<AsyncReadable["getRange"]>;
 
@@ -163,7 +163,7 @@ function groupRequests(
  * let store = zarr.withRangeBatching(new zarr.FetchStore("https://example.com/data.zarr"));
  * ```
  */
-export const withRangeBatching = defineStoreMiddleware(
+export const withRangeBatching = defineStoreExtension(
 	(_store, opts: RangeBatchingOptions = {}) => {
 		assertRangeCapable(_store);
 		let store = _store;

--- a/packages/zarrita/src/index.ts
+++ b/packages/zarrita/src/index.ts
@@ -14,6 +14,32 @@ export {
 	UnknownCodecError,
 	UnsupportedError,
 } from "./errors.js";
+/** @deprecated Use {@linkcode ConsolidationOptions} instead. */
+export type {
+	ConsolidatedFormat,
+	ConsolidationOptions,
+	ConsolidationOptions as WithConsolidatedOptions,
+	Listable,
+} from "./extension/consolidation.js";
+// deprecated re-exports
+/** @deprecated Use {@linkcode withConsolidation} instead. */
+/** @deprecated Use {@linkcode withMaybeConsolidation} instead. */
+export {
+	withConsolidation,
+	withConsolidation as withConsolidated,
+	withMaybeConsolidation,
+	withMaybeConsolidation as tryWithConsolidated,
+} from "./extension/consolidation.js";
+export { defineStoreExtension } from "./extension/define.js";
+export { defineArrayExtension } from "./extension/define-array.js";
+export { extendArray } from "./extension/extend-array.js";
+export { extendStore } from "./extension/extend-store.js";
+export type {
+	RangeBatchingOptions,
+	RangeBatchingStats,
+} from "./extension/range-batching.js";
+// extensions
+export { withRangeBatching } from "./extension/range-batching.js";
 export { Array, Group, Location, root } from "./hierarchy.js";
 // internal exports for @zarrita/ndarray
 export { get as _zarrita_internal_get } from "./indexing/get.js";
@@ -32,32 +58,6 @@ export {
 	sliceIndices as _zarrita_internal_sliceIndices,
 } from "./indexing/util.js";
 export type * from "./metadata.js";
-/** @deprecated Use {@linkcode ConsolidationOptions} instead. */
-export type {
-	ConsolidatedFormat,
-	ConsolidationOptions,
-	ConsolidationOptions as WithConsolidatedOptions,
-	Listable,
-} from "./middleware/consolidation.js";
-// deprecated re-exports
-/** @deprecated Use {@linkcode withConsolidation} instead. */
-/** @deprecated Use {@linkcode withMaybeConsolidation} instead. */
-export {
-	withConsolidation,
-	withConsolidation as withConsolidated,
-	withMaybeConsolidation,
-	withMaybeConsolidation as tryWithConsolidated,
-} from "./middleware/consolidation.js";
-export { defineStoreMiddleware } from "./middleware/define.js";
-export { defineArrayMiddleware } from "./middleware/define-array.js";
-export { extendArray } from "./middleware/extend-array.js";
-export { extendStore } from "./middleware/extend-store.js";
-export type {
-	RangeBatchingOptions,
-	RangeBatchingStats,
-} from "./middleware/range-batching.js";
-// middleware
-export { withRangeBatching } from "./middleware/range-batching.js";
 export { open } from "./open.js";
 export {
 	BoolArray,


### PR DESCRIPTION
Pure mechanical rename of the (unreleased) middleware system to extension terminology. No behavior changes.

- defineStoreMiddleware -> defineStoreExtension
- defineArrayMiddleware -> defineArrayExtension
- src/middleware/ -> src/extension/
- applyMiddlewares -> applyExtensions (internal)
- Rename tests, docs, and the unreleased changeset