### PR TITLE
Auto-apply array extensions carried by a store

### DIFF
--- a/.changeset/auto-apply-array-extensions.md
+++ b/.changeset/auto-apply-array-extensions.md
@@ -1,0 +1,38 @@
+---
+"zarrita": minor
+---
+
+Auto-apply array extensions carried by a store
+
+A store extension factory may now declare an `arrayExtensions` field on its
+returned overrides. `defineStoreExtension` merges each layer's list with the
+inner store's (inner-first, outer-last), and `zarr.open` applies the resulting
+list to every `zarr.Array` it returns — so downstream consumers don't need to
+call `zarr.extendArray` at each call site.
+
+This is the primitive for virtual-format adapters (hdf5-as-virtual-zarr,
+tiff-as-virtual-zarr, parquet-as-virtual-zarr) that pair a transport-layer
+store extension (synthesizing metadata keys) with a data-layer array extension
+(supplying decoded chunks) from a single factory with shared closure state:
+
+```ts
+const hdf5VirtualZarr = zarr.defineStoreExtension((inner, opts: { root: string }) => {
+  let parsed = parseHdf5(opts.root);
+  return {
+    async get(key, options) {
+      if (isVirtualMetadataKey(key, parsed)) return synthesizeJson(key, parsed);
+      return inner.get(key, options);
+    },
+    arrayExtensions: [
+      zarr.defineArrayExtension((_inner) => ({
+        async getChunk(coords) { return parsed.readChunk(coords); },
+      })),
+    ],
+  };
+});
+
+let store = await zarr.extendStore(raw, (s) => hdf5VirtualZarr(s, { root: "/img" }));
+let arr = await zarr.open(store, { kind: "array", path: "/img" }); // auto-wrapped
+```
+
+Also exports a new public type `zarr.ArrayExtension` for authoring these lists.

--- a/docs/store-extensions.md
+++ b/docs/store-extensions.md
@@ -143,3 +143,62 @@ return the right specific type.
 
 Like `extendStore`, `extendArray` always returns a `Promise` so extensions can
 perform async initialization.
+
+## Auto-applying array extensions from a store
+
+A store extension can declare an `arrayExtensions` field on its factory
+result. `zarr.open` reads that list from the composed store and wraps every
+`zarr.Array` it returns with those extensions — so downstream consumers
+don't need to remember to call `zarr.extendArray` at each call site.
+
+This is the primitive for **virtual-format adapters** (hdf5-as-virtual-zarr,
+tiff-as-virtual-zarr, parquet-as-virtual-zarr): a single factory parses the
+source once, synthesizes metadata at the transport layer, and hands decoded
+chunks at the data layer — sharing closure state between both concerns:
+
+```ts
+import * as zarr from "zarrita";
+
+const hdf5VirtualZarr = zarr.defineStoreExtension(
+  (inner, opts: { root: string }) => {
+    let parsed = parseHdf5(opts.root); // shared closure state
+    return {
+      async get(key, options) {
+        if (isVirtualMetadataKey(key, parsed)) {
+          return synthesizeJson(key, parsed);
+        }
+        return inner.get(key, options);
+      },
+      arrayExtensions: [
+        zarr.defineArrayExtension((_inner) => ({
+          async getChunk(coords) { return parsed.readChunk(coords); },
+        })),
+      ],
+    };
+  },
+);
+
+let store = await zarr.extendStore(raw, (s) =>
+  hdf5VirtualZarr(s, { root: "/my_image" }),
+);
+
+// Downstream code knows nothing about the adapter — just opens and reads.
+let arr = await zarr.open(store, { kind: "array", path: "/my_image" });
+await zarr.get(arr, [null, zarr.slice(0, 10)]);
+```
+
+**Merge semantics.** When store extensions are stacked, each layer's
+`arrayExtensions` are concatenated with the inner store's — inner-first,
+outer-last. So if an inner layer contributes `[A]` and an outer layer
+contributes `[B]`, the composed store exposes `[A, B]`, and `zarr.open`
+applies them so that B wraps A (symmetric with how the store extensions
+themselves compose).
+
+**Raw lambdas.** `extendStore` also accepts any `(store) => newStore` function
+directly, bypassing `defineStoreExtension`. Raw lambdas are responsible for
+spreading `...inner.arrayExtensions` themselves if they want auto-apply to
+reach older contributed extensions.
+
+**Groups.** `zarr.open(store, { kind: "group" })` does not wrap the group
+(there are no chunks to intercept), but the store reference flows through,
+so nested `zarr.open(group.resolve("child"))` calls still auto-apply.

--- a/packages/zarrita/__tests__/array-extension.test.ts
+++ b/packages/zarrita/__tests__/array-extension.test.ts
@@ -116,3 +116,91 @@ describe("extendArray", () => {
 		expect(order).toEqual(["b", "a"]);
 	});
 });
+
+describe("zarr.open auto-apply of store arrayExtensions", () => {
+	it("applies a single array extension contributed by a store extension", async () => {
+		let calls: number[][] = [];
+		let withTrace = defineArrayExtension((array) => ({
+			async getChunk(coords, options) {
+				calls.push(coords);
+				return array.getChunk(coords, options);
+			},
+		}));
+		let withTracedArray = zarr.defineStoreExtension(() => ({
+			arrayExtensions: [(a) => withTrace(a)],
+		}));
+		let store = withTracedArray(new zarr.FileSystemStore(fixturesRoot));
+		let arr = await zarr.open.v3(zarr.root(store).resolve("1d.chunked.i2"), {
+			kind: "array",
+		});
+		await arr.getChunk([0]);
+		expect(calls).toEqual([[0]]);
+	});
+
+	it("merges inner-first, outer-last across stacked store extensions", async () => {
+		let order: string[] = [];
+		let withA = defineArrayExtension((array) => ({
+			async getChunk(coords, options) {
+				order.push("a");
+				return array.getChunk(coords, options);
+			},
+		}));
+		let withB = defineArrayExtension((array) => ({
+			async getChunk(coords, options) {
+				order.push("b");
+				return array.getChunk(coords, options);
+			},
+		}));
+		let storeExtA = zarr.defineStoreExtension(() => ({
+			arrayExtensions: [(a) => withA(a)],
+		}));
+		let storeExtB = zarr.defineStoreExtension(() => ({
+			arrayExtensions: [(a) => withB(a)],
+		}));
+		let store = await zarr.extendStore(
+			new zarr.FileSystemStore(fixturesRoot),
+			storeExtA,
+			storeExtB,
+		);
+		// Merged list is visible as a plain field on the composed store.
+		expect(
+			(store as { arrayExtensions?: unknown[] }).arrayExtensions,
+		).toHaveLength(2);
+		let arr = await zarr.open.v3(zarr.root(store).resolve("1d.chunked.i2"), {
+			kind: "array",
+		});
+		await arr.getChunk([0]);
+		// Outer store extension (B) becomes the outermost array wrapper, so
+		// its getChunk runs first and calls through to A.
+		expect(order).toEqual(["b", "a"]);
+	});
+
+	it("auto-applies on arrays resolved via a group", async () => {
+		let calls: number[][] = [];
+		let withTrace = defineArrayExtension((array) => ({
+			async getChunk(coords, options) {
+				calls.push(coords);
+				return array.getChunk(coords, options);
+			},
+		}));
+		let withTracedArray = zarr.defineStoreExtension(() => ({
+			arrayExtensions: [(a) => withTrace(a)],
+		}));
+		let store = withTracedArray(new zarr.FileSystemStore(fixturesRoot));
+		let group = await zarr.open.v3(zarr.root(store), { kind: "group" });
+		let arr = await zarr.open.v3(group.resolve("1d.chunked.i2"), {
+			kind: "array",
+		});
+		await arr.getChunk([0]);
+		expect(calls).toEqual([[0]]);
+	});
+
+	it("returns the array as-is when the store has no arrayExtensions", async () => {
+		let store = new zarr.FileSystemStore(fixturesRoot);
+		let arr = await zarr.open.v3(zarr.root(store).resolve("1d.chunked.i2"), {
+			kind: "array",
+		});
+		// No Proxy wrapping — the returned Array is the concrete class instance.
+		expect(arr).toBeInstanceOf(zarr.Array);
+	});
+});

--- a/packages/zarrita/src/extension/define-array.ts
+++ b/packages/zarrita/src/extension/define-array.ts
@@ -3,6 +3,15 @@ import type { Array } from "../hierarchy.js";
 import type { DataType } from "../metadata.js";
 import { assertFactoryResult, createProxy } from "./define.js";
 
+/**
+ * A function that wraps a `zarr.Array`, returning a (possibly asynchronous)
+ * extended array. This is the shape of the list declared on a store
+ * extension's `arrayExtensions` field and auto-applied by `zarr.open`.
+ */
+export type ArrayExtension = (
+	array: Array<DataType, Readable>,
+) => Array<DataType, Readable> | Promise<Array<DataType, Readable>>;
+
 /** Array keys whose overrides are intercepted by the extension. */
 type ArrayOverrideKeys = "getChunk";
 

--- a/packages/zarrita/src/extension/define.ts
+++ b/packages/zarrita/src/extension/define.ts
@@ -1,4 +1,5 @@
 import type { AsyncReadable } from "@zarrita/storage";
+import type { ArrayExtension } from "./define-array.js";
 
 /** Store keys stripped from Extensions to avoid poisoning Options. */
 type StoreKeys = "get" | "getRange";
@@ -70,7 +71,16 @@ export function createProxy<T extends object>(
 	});
 }
 
-type FactoryResult = Partial<AsyncReadable> & Record<string, unknown>;
+type FactoryResult = Partial<AsyncReadable> & {
+	/**
+	 * Array extensions carried on the store, auto-applied by `zarr.open` to
+	 * every `zarr.Array` it returns. When stores are composed via
+	 * `extendStore`, each layer's `arrayExtensions` are merged inner-first
+	 * so that later layers wrap earlier ones — symmetric with how store
+	 * extensions themselves compose.
+	 */
+	arrayExtensions?: ReadonlyArray<ArrayExtension>;
+} & Record<string, unknown>;
 
 export function assertFactoryResult(
 	value: unknown,
@@ -78,6 +88,26 @@ export function assertFactoryResult(
 	if (value == null || typeof value !== "object") {
 		throw new Error("Extension factory must return an object of overrides");
 	}
+}
+
+/**
+ * Merge the inner store's `arrayExtensions` (if any) with the list returned
+ * by the factory. Inner-first, outer-last: if the inner store contributed
+ * `[A]` and the factory adds `[B]`, the merged list is `[A, B]` — so when
+ * `zarr.open` applies them via `extendArray(arr, A, B)`, the outer (B)
+ * wraps the inner (A), mirroring how store extensions themselves compose.
+ */
+function mergeArrayExtensions(
+	inner: AsyncReadable,
+	overrides: Record<string | symbol, unknown>,
+): Record<string | symbol, unknown> {
+	let innerExts = (inner as AsyncReadable & FactoryResult).arrayExtensions;
+	let freshExts = overrides.arrayExtensions as
+		| ReadonlyArray<ArrayExtension>
+		| undefined;
+	if (!innerExts?.length) return overrides;
+	if (!freshExts?.length) return { ...overrides, arrayExtensions: innerExts };
+	return { ...overrides, arrayExtensions: [...innerExts, ...freshExts] };
 }
 
 /**
@@ -118,10 +148,10 @@ export function defineStoreExtension(
 		if (result instanceof Promise) {
 			return result.then((overrides) => {
 				assertFactoryResult(overrides);
-				return createProxy(store, overrides);
+				return createProxy(store, mergeArrayExtensions(store, overrides));
 			});
 		}
 		assertFactoryResult(result);
-		return createProxy(store, result);
+		return createProxy(store, mergeArrayExtensions(store, result));
 	};
 }

--- a/packages/zarrita/src/index.ts
+++ b/packages/zarrita/src/index.ts
@@ -31,7 +31,10 @@ export {
 	withMaybeConsolidation as tryWithConsolidated,
 } from "./extension/consolidation.js";
 export { defineStoreExtension } from "./extension/define.js";
-export { defineArrayExtension } from "./extension/define-array.js";
+export {
+	type ArrayExtension,
+	defineArrayExtension,
+} from "./extension/define-array.js";
 export { extendArray } from "./extension/extend-array.js";
 export { extendStore } from "./extension/extend-store.js";
 export type {

--- a/packages/zarrita/src/open.ts
+++ b/packages/zarrita/src/open.ts
@@ -1,5 +1,7 @@
 import type { Readable } from "@zarrita/storage";
 import { InvalidMetadataError, NotFoundError } from "./errors.js";
+import type { ArrayExtension } from "./extension/define-array.js";
+import { extendArray } from "./extension/extend-array.js";
 import { Array, Group, Location } from "./hierarchy.js";
 import type {
 	ArrayMetadata,
@@ -14,6 +16,30 @@ import {
 	v2ToV3ArrayMetadata,
 	v2ToV3GroupMetadata,
 } from "./util.js";
+
+/**
+ * If the backing store carries `arrayExtensions` (typically contributed by
+ * a virtual-format adapter built on `defineStoreExtension`), wrap the array
+ * with them before handing it back. Inner-first, outer-last: the outermost
+ * store extension's array extension becomes the outermost array wrapper.
+ */
+async function maybeExtend<D extends DataType, S extends Readable>(
+	array: Array<D, S>,
+): Promise<Array<D, S>> {
+	let exts = (
+		array.store as Readable & {
+			arrayExtensions?: ReadonlyArray<ArrayExtension>;
+		}
+	).arrayExtensions;
+	if (!exts?.length) return array;
+	// Fixed-arity overloads of `extendArray` don't model variadic spreads,
+	// so thread the rest-parameter implementation directly.
+	let variadic = extendArray as (
+		array: Array<D, S>,
+		...extensions: ArrayExtension[]
+	) => Array<D, S> | Promise<Array<D, S>>;
+	return await variadic(array, ...exts);
+}
 
 export let VERSION_COUNTER = createVersionCounter();
 function createVersionCounter() {
@@ -94,10 +120,12 @@ async function openArrayV2<Store extends Readable>(
 		throw new NotFoundError("v2 array", { path });
 	}
 	VERSION_COUNTER.increment(location.store, "v2");
-	return new Array(
-		location.store,
-		location.path,
-		v2ToV3ArrayMetadata(jsonDecodeObject(meta), attrs),
+	return maybeExtend(
+		new Array(
+			location.store,
+			location.path,
+			v2ToV3ArrayMetadata(jsonDecodeObject(meta), attrs),
+		),
 	);
 }
 
@@ -133,7 +161,7 @@ async function _openV3<Store extends Readable>(
 		metaDoc.fill_value = ensureCorrectScalar(metaDoc);
 	}
 	return metaDoc.node_type === "array"
-		? new Array(store, location.path, metaDoc)
+		? maybeExtend(new Array(store, location.path, metaDoc))
 		: new Group(store, location.path, metaDoc);
 }
 


### PR DESCRIPTION
A store extension factory may now declare an `arrayExtensions` field on its returned overrides. `zarr.defineStoreExtension` merges each layer's list with the inner store's (inner-first, outer-last), and `zarr.open` applies the resulting list to every `zarr.Array` it returns, so downstream consumers don't need to call `zarr.extendArray` at each call site.

This is the primitive for virtual-format adapters that pair a transport-layer store extension (synthesizing metadata keys) with a data-layer array extension (supplying decoded chunks) from a single factory with shared closure state:

```ts
const hdf5VirtualZarr = zarr.defineStoreExtension((inner, opts: { root: string }) => {
  let parsed = parseHdf5(opts.root);
  return {
    async get(key, options) {
      if (isVirtualMetadataKey(key, parsed)) return synthesizeJson(key, parsed);
      return inner.get(key, options);
    },
    arrayExtensions: [
      zarr.defineArrayExtension((_inner) => ({
        async getChunk(coords) { return parsed.readChunk(coords); },
      })),
    ],
  };
});

let store = await zarr.extendStore(raw, (s) => hdf5VirtualZarr(s, { root: "/img" }));
let arr = await zarr.open(store, { kind: "array", path: "/img" }); // auto-wrapped
```

Also exports a new public type `zarr.ArrayExtension` for authoring these lists.