### PR TITLE
Add store-extension authoring conventions to docs

### DIFF
--- a/docs/store-extensions.md
+++ b/docs/store-extensions.md
@@ -3,17 +3,15 @@
 **zarrita** has two symmetric extension points for composing behavior on top
 of a base store or array: **store extensions** and **array extensions**.
 
-| Layer | Intercepts | Primitive | Composer |
-| --- | --- | --- | --- |
-| Transport | `store.get(key, range)` | `zarr.defineStoreExtension` | `zarr.extendStore` |
-| Data | `array.getChunk(coords)` | `zarr.defineArrayExtension` | `zarr.extendArray` |
+| Layer     | Intercepts                              | Primitive                   | Composer           |
+| --------- | --------------------------------------- | --------------------------- | ------------------ |
+| Transport | `store.get(key)` and `store.getRange()` | `zarr.defineStoreExtension` | `zarr.extendStore` |
+| Data      | `array.getChunk(coords)`                | `zarr.defineArrayExtension` | `zarr.extendArray` |
 
-Store extensions are for transport concerns (caching bytes, batching range
-requests, short-circuiting metadata, request transformation). Array extensions
-are for data concerns (caching decoded chunks, prefetch priority, observability).
-If you're not sure which layer you need: if your code deals in paths and
-bytes, it's a store extension; if it deals in chunk coordinates, it's an
-array extension.
+**Store extensions** are for transport concerns (caching bytes, batching range
+requests, short-circuiting metadata, request transformation). **Array
+extensions** are for data concerns (caching decoded chunks, prefetch priority,
+observability).
 
 ## Store extensions
 
@@ -53,43 +51,37 @@ let consolidated = await zarr.withConsolidation(
 
 The factory receives the inner store and user options, and returns an object
 of method overrides and extensions. Anything not returned is delegated to the
-inner store via `Proxy`.
+inner store via `Proxy`. Only `get` and `getRange` are interceptable; any
+other keys on the factory result become extensions on the wrapped store.
 
 ```ts
 import * as zarr from "zarrita";
 
-const withCaching = zarr.defineStoreExtension(
-  (store, opts: { maxSize?: number } = {}) => {
-    let cache = new Map<zarr.AbsolutePath, Uint8Array>();
-    return {
-      async get(key, options) {
-        let hit = cache.get(key);
-        if (hit) return hit;
-        let result = await store.get(key, options);
-        if (result) cache.set(key, result);
-        return result;
-      },
-      clear() {
-        cache.clear();
-      },
-    };
-  },
+const withTrace = zarr.defineStoreExtension(
+  (store, extOptions: { log: (key: string) => void }) => ({
+    async get(key, options) {
+      extOptions.log(key);
+      return store.get(key, options);
+    },
+  }),
 );
 
-let store = withCaching(new zarr.FetchStore("https://..."), { maxSize: 256 });
-store.clear(); // new method from the extension
+let store = withTrace(new zarr.FetchStore("https://..."), {
+  log: (key) => console.log("fetching", key),
+});
 ```
 
-Only `get` and `getRange` are interceptable; any other keys on the factory
-result become extensions on the wrapped store.
+See [Composition and naming conventions](#composition-and-naming-conventions)
+below for how to expose state from more elaborate extensions without polluting
+the store's top-level surface.
 
 Extensions can be **sync or async**. If the factory returns a `Promise`, the
 wrapper returns a `Promise` too:
 
 ```ts
 const withMetadata = zarr.defineStoreExtension(
-  async (store, opts: { key: zarr.AbsolutePath }) => {
-    let bytes = await store.get(opts.key);
+  async (store, extOptions: { key: zarr.AbsolutePath }) => {
+    let bytes = await store.get(extOptions.key);
     let meta = JSON.parse(new TextDecoder().decode(bytes));
     return {
       metadata() { return meta; },
@@ -101,6 +93,88 @@ let store = await withMetadata(rawStore, { key: "/meta.json" });
 store.metadata(); // loaded during initialization
 ```
 
+### Composition over inheritance
+
+Top-level fields on factory results are shallow-merged across composition
+layers, so an extension *can* put methods directly on the wrapped store.
+`withConsolidatedMetadata` does this with `contents()`. It's a first-party
+liberty, used sparingly: the extension system is built around the idea that
+a composed store is still an `AsyncReadable`, and callers that type a
+parameter as `AsyncReadable` should be able to accept one without knowing
+what was layered on.
+
+For your own extensions, prefer in order:
+
+1. **Externalize the state.** If the caller can own what you'd otherwise
+   track internally, pass it in as an option. The store's type stays exactly
+   `AsyncReadable`.
+2. **If you must expose state, put the whole surface on one namespace key.**
+   Name it after what the extension *is*. The composed type becomes
+   `AsyncReadable & { events: EventsHandle }` — a store composed with a
+   handle, not a store that *inherits* new methods.
+
+`get`, `getRange`, and `arrayExtensions` are reserved.
+
+**Externalized state.** A logging wrapper has nothing of its own to hold:
+
+```ts
+const withLogging = zarr.defineStoreExtension(
+  (store, opts: { log: (msg: string) => void }) => ({
+    async get(key, options) {
+      opts.log(`get ${key}`);
+      return store.get(key, options);
+    },
+  }),
+);
+```
+
+The caller owns the `log` function. Nothing on the store.
+
+**Namespaced composition.** Some state genuinely can't be externalized — an
+event subscription registry is the canonical case. The listener set is
+dynamic, callers need to add and remove handlers at runtime, and you don't
+want `store.subscribe` / `store.unsubscribe` / `store.notify` scattered
+across the top-level type. Put the whole API on one key:
+
+```ts
+type StoreEvent =
+  | { type: "get"; key: zarr.AbsolutePath; durationMs: number }
+  | { type: "error"; key: zarr.AbsolutePath; error: unknown };
+
+const withEvents = zarr.defineStoreExtension((store) => {
+  let listeners = new Set<(event: StoreEvent) => void>();
+  return {
+    async get(key, options) {
+      let started = performance.now();
+      try {
+        let value = await store.get(key, options);
+        for (let fn of listeners) {
+          fn({ type: "get", key, durationMs: performance.now() - started });
+        }
+        return value;
+      } catch (error) {
+        for (let fn of listeners) fn({ type: "error", key, error });
+        throw error;
+      }
+    },
+    events: {
+      subscribe(fn: (event: StoreEvent) => void): () => void {
+        listeners.add(fn);
+        return () => listeners.delete(fn);
+      },
+    },
+  };
+});
+
+let store = withEvents(base);
+let unsubscribe = store.events.subscribe((e) => {
+  if (e.type === "error") console.error("store error", e);
+});
+```
+
+Downstream code that only reads bytes can still type its parameter as plain
+`AsyncReadable` and ignore the `events` handle entirely.
+
 ## Array extensions
 
 Array extensions are the symmetric extension point for **chunk-layer** concerns:
@@ -111,13 +185,13 @@ or bytes. Think chunk caching, prefetch priority, or observability hooks.
 import * as zarr from "zarrita";
 
 const withChunkCache = zarr.defineArrayExtension(
-  (array, opts: { cache: Map<string, zarr.Chunk<zarr.DataType>> }) => ({
+  (array, extOptions: { cache: Map<string, zarr.Chunk<zarr.DataType>> }) => ({
     async getChunk(coords, options) {
       let key = coords.join(",");
-      let hit = opts.cache.get(key);
+      let hit = extOptions.cache.get(key);
       if (hit) return hit;
       let chunk = await array.getChunk(coords, options);
-      opts.cache.set(key, chunk);
+      extOptions.cache.set(key, chunk);
       return chunk;
     },
   }),
@@ -131,25 +205,25 @@ let arr = await zarr.extendArray(
 await zarr.get(arr, null); // cache hits are served from the Map
 ```
 
-Only `getChunk` is interceptable in v1 — `shape`, `dtype`, `attrs`, `chunks`,
+Only `getChunk` is interceptable — `shape`, `dtype`, `attrs`, `chunks`,
 `store`, and `path` are part of the array's identity and are always delegated
 to the inner array. Any other keys on the factory result become extensions on
 the wrapped array.
 
 The factory sees `zarr.Array<DataType, Readable>` (the widest form) so it can
-be written once and applied to any concrete `Array<D, S>`. At the call site
-the outer generics are preserved, so downstream `zarr.get(wrapped)` calls
-return the right specific type.
+be written once and applied to any concrete `Array<D, S>`. At the call site the
+outer generics are preserved, so downstream `zarr.get(wrapped)` calls return
+the right specific type.
 
 Like `extendStore`, `extendArray` always returns a `Promise` so extensions can
 perform async initialization.
 
 ## Auto-applying array extensions from a store
 
-A store extension can declare an `arrayExtensions` field on its factory
-result. `zarr.open` reads that list from the composed store and wraps every
-`zarr.Array` it returns with those extensions — so downstream consumers
-don't need to remember to call `zarr.extendArray` at each call site.
+A store extension can declare an `arrayExtensions` field on its factory result.
+`zarr.open` reads that list from the composed store and wraps every
+`zarr.Array` it returns with those extensions — so downstream consumers don't
+need to remember to call `zarr.extendArray` at each call site.
 
 This is the primitive for **virtual-format adapters** (hdf5-as-virtual-zarr,
 tiff-as-virtual-zarr, parquet-as-virtual-zarr): a single factory parses the
@@ -170,8 +244,10 @@ const hdf5VirtualZarr = zarr.defineStoreExtension(
         return inner.get(key, options);
       },
       arrayExtensions: [
-        zarr.defineArrayExtension((_inner) => ({
-          async getChunk(coords) { return parsed.readChunk(coords); },
+        zarr.defineArrayExtension(() => ({
+          async getChunk(coords) {
+            return parsed.readChunk(coords);
+          },
         })),
       ],
     };
@@ -190,9 +266,9 @@ await zarr.get(arr, [null, zarr.slice(0, 10)]);
 **Merge semantics.** When store extensions are stacked, each layer's
 `arrayExtensions` are concatenated with the inner store's — inner-first,
 outer-last. So if an inner layer contributes `[A]` and an outer layer
-contributes `[B]`, the composed store exposes `[A, B]`, and `zarr.open`
-applies them so that B wraps A (symmetric with how the store extensions
-themselves compose).
+contributes `[B]`, the composed store exposes `[A, B]`, and `zarr.open` applies
+them so that B wraps A (symmetric with how the store extensions themselves
+compose).
 
 **Raw lambdas.** `extendStore` also accepts any `(store) => newStore` function
 directly, bypassing `defineStoreExtension`. Raw lambdas are responsible for
@@ -200,5 +276,5 @@ spreading `...inner.arrayExtensions` themselves if they want auto-apply to
 reach older contributed extensions.
 
 **Groups.** `zarr.open(store, { kind: "group" })` does not wrap the group
-(there are no chunks to intercept), but the store reference flows through,
-so nested `zarr.open(group.resolve("child"))` calls still auto-apply.
+(there are no chunks to intercept), but the store reference flows through, so
+nested `zarr.open(group.resolve("child"))` calls still auto-apply.


### PR DESCRIPTION
Document the rules around composition, field merging, and how third-party extensions should namespace their exposed state to avoid collisions. Clarify that zarrita reserves a small set of top-level keys (get, getRange, arrayExtensions) and that everything else at the top level is merged across composition layers on a last-wins basis.

First-party extensions (withConsolidation, withRangeBatching) are coordinated in the tree and may continue to expose top-level fields. Third-party extensions are encouraged to namespace their state under a single field named after the extension (e.g. cache, metrics) so stacking them doesn't collide.