### PR TITLE
Add snapshot test for zarrita public API surface

### DIFF
--- a/packages/zarrita/__tests__/public-api.test.ts
+++ b/packages/zarrita/__tests__/public-api.test.ts
@@ -1,0 +1,45 @@
+import { expect, test } from "vitest";
+import * as zarrita from "zarrita";
+
+test("public API surface", () => {
+	expect(Object.keys(zarrita).sort()).toMatchInlineSnapshot(`
+		[
+		  "Array",
+		  "BoolArray",
+		  "ByteStringArray",
+		  "CodecPipelineError",
+		  "FetchStore",
+		  "FileSystemStore",
+		  "Group",
+		  "InvalidMetadataError",
+		  "InvalidSelectionError",
+		  "Location",
+		  "NotFoundError",
+		  "UnicodeStringArray",
+		  "UnknownCodecError",
+		  "UnsupportedError",
+		  "_zarrita_internal_get",
+		  "_zarrita_internal_getStrides",
+		  "_zarrita_internal_set",
+		  "_zarrita_internal_sliceIndices",
+		  "create",
+		  "defineArrayExtension",
+		  "defineStoreExtension",
+		  "extendArray",
+		  "extendStore",
+		  "get",
+		  "isZarritaError",
+		  "open",
+		  "registry",
+		  "root",
+		  "sel",
+		  "set",
+		  "slice",
+		  "tryWithConsolidated",
+		  "withConsolidated",
+		  "withConsolidation",
+		  "withMaybeConsolidation",
+		  "withRangeBatching",
+		]
+	`);
+});


### PR DESCRIPTION
Guard against accidental additions or removals from the top-level `zarrita` entrypoint. The test imports the package as a namespace and inline-snapshots the sorted list of runtime exports, so any change to the public surface shows up as an explicit snapshot diff in review.