### PR TITLE
Rename `zarr.sel` helper to `zarr.select`

### DIFF
--- a/.changeset/add-sel-helper.md
+++ b/.changeset/add-sel-helper.md
@@ -2,13 +2,13 @@
 "zarrita": minor
 ---
 
-Add `sel` helper for named-dimension selection. Converts a record of dimension names to the positional selection array that `get` and `set` accept, using the array's `dimensionNames` metadata. Throws for unknown dimension names.
+Add `select` helper for named-dimension selection. Converts a record of dimension names to the positional selection array that `get` and `set` accept, using the array's `dimensionNames` metadata. Throws for unknown dimension names.
 
 ```ts
 let arr = await zarr.open(store, { kind: "array" });
 // arr.dimensionNames -> ["time", "lat", "lon"]
 
-let selection = zarr.sel(arr, { lat: zarr.slice(100, 200), time: 0 });
+let selection = zarr.select(arr, { lat: zarr.slice(100, 200), time: 0 });
 // -> [0, slice(100, 200), null]
 
 let result = await zarr.get(arr, selection);

--- a/docs/migration/v0.7.md
+++ b/docs/migration/v0.7.md
@@ -31,7 +31,7 @@ a first-class [`fillValue` getter](#also-new), and a handful of
   use the new `fetch` option instead.
 - **New**: [custom `fetch`](#custom-fetch-on-fetchstore),
   [`AbortSignal` cancellation](#cancellation-with-abortsignal),
-  [named-dimension selection (`sel`)](#named-dimension-selection),
+  [named-dimension selection (`select`)](#named-dimension-selection),
   [composable store and array extensions](#composable-store-and-array-extensions)
   (`defineStoreExtension`, `defineArrayExtension`),
   [v3 consolidated metadata](#v3-consolidated-metadata-experimental),
@@ -109,12 +109,12 @@ await zarr.get(arr, [null], { signal: controller.signal });
 ### Named-dimension selection
 
 `Array` now exposes a `dimensionNames` getter (v3 metadata, or
-`_ARRAY_DIMENSIONS` on v2), and the new `sel` helper converts a
+`_ARRAY_DIMENSIONS` on v2), and the new `select` helper converts a
 record of dimension names into a positional selection array:
 
 ```ts
 // arr.dimensionNames -> ["time", "lat", "lon"]
-let selection = zarr.sel(arr, { lat: zarr.slice(100, 200), time: 0 });
+let selection = zarr.select(arr, { lat: zarr.slice(100, 200), time: 0 });
 let result = await zarr.get(arr, selection);
 ```
 

--- a/packages/zarrita/__tests__/public-api.test.ts
+++ b/packages/zarrita/__tests__/public-api.test.ts
@@ -32,7 +32,7 @@ test("public API surface", () => {
 		  "open",
 		  "registry",
 		  "root",
-		  "sel",
+		  "select",
 		  "set",
 		  "slice",
 		  "tryWithConsolidated",

--- a/packages/zarrita/__tests__/util.test.ts
+++ b/packages/zarrita/__tests__/util.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, test, vi } from "vitest";
 import * as zarr from "../src/index.js";
-import { sel, slice } from "../src/indexing/util.js";
+import { select, slice } from "../src/indexing/util.js";
 import type { ArrayMetadata, DataType } from "../src/metadata.js";
 import {
 	BoolArray,
@@ -266,7 +266,7 @@ describe("ensureCorrectScalar", () => {
 	});
 });
 
-describe("sel", () => {
+describe("select", () => {
 	async function make_array(dimensionNames?: string[]) {
 		let h = zarr.root();
 		return zarr.create(h.resolve("/test"), {
@@ -279,7 +279,7 @@ describe("sel", () => {
 
 	test("maps named dimensions to positional selection", async () => {
 		let arr = await make_array(["time", "lat", "lon"]);
-		expect(sel(arr, { lat: slice(10, 20), time: 0 })).toStrictEqual([
+		expect(select(arr, { lat: slice(10, 20), time: 0 })).toStrictEqual([
 			0,
 			{ start: 10, stop: 20, step: null },
 			null,
@@ -288,17 +288,19 @@ describe("sel", () => {
 
 	test("unspecified dimensions default to null", async () => {
 		let arr = await make_array(["time", "lat", "lon"]);
-		expect(sel(arr, { lon: 5 })).toStrictEqual([null, null, 5]);
+		expect(select(arr, { lon: 5 })).toStrictEqual([null, null, 5]);
 	});
 
 	test("throws for unknown dimension name", async () => {
 		let arr = await make_array(["time", "lat", "lon"]);
-		expect(() => sel(arr, { bad: 0 })).toThrow(/Unknown dimension name: "bad"/);
+		expect(() => select(arr, { bad: 0 })).toThrow(
+			/Unknown dimension name: "bad"/,
+		);
 	});
 
 	test("throws when array has no dimension_names", async () => {
 		let arr = await make_array();
-		expect(() => sel(arr, { time: 0 })).toThrow(
+		expect(() => select(arr, { time: 0 })).toThrow(
 			/does not have dimension_names/,
 		);
 	});

--- a/packages/zarrita/src/index.ts
+++ b/packages/zarrita/src/index.ts
@@ -56,7 +56,7 @@ export type {
 	Slice,
 } from "./indexing/types.js";
 export {
-	sel,
+	select,
 	slice,
 	sliceIndices as _zarrita_internal_sliceIndices,
 } from "./indexing/util.js";

--- a/packages/zarrita/src/indexing/util.ts
+++ b/packages/zarrita/src/indexing/util.ts
@@ -137,7 +137,7 @@ export function slice(
 }
 
 /** @category Utility */
-export function sel<D extends DataType, Store extends Readable>(
+export function select<D extends DataType, Store extends Readable>(
 	arr: ZarrArray<D, Store>,
 	selection: Record<string, Slice | number | null>,
 ): (Slice | number | null)[] {


### PR DESCRIPTION
The named-dimension selection helper was shipped as `zarr.sel` in the unreleased v0.7 changeset, mirroring xarray's shorthand. Spelling it out as `zarr.select` reads better at call sites in a JS/TS context where the shorter name doesn't carry the same convention.

```ts
let selection = zarr.select(arr, { lat: zarr.slice(100, 200), time: 0 });
let result = await zarr.get(arr, selection);
```

The rename is safe to land directly since `sel` has not yet been released; the v0.7 changeset and migration guide are updated in place.