### PR TITLE
Drop FileSystemStore from the zarrita root barrel

### DIFF
--- a/.changeset/drop-filesystemstore-from-barrel.md
+++ b/.changeset/drop-filesystemstore-from-barrel.md
@@ -1,0 +1,12 @@
+---
+"zarrita": patch
+---
+
+Drop `FileSystemStore` from the `zarrita` root barrel, which accidentally landed in 0.7.0 as part of #384. Node users who still want `FileSystemStore` can import it directly:
+
+```ts
+import { FileSystemStore } from "@zarrita/storage";
+// or
+import FileSystemStore from "@zarrita/storage/fs";
+```
+

--- a/packages/zarrita/__tests__/array-extension.test.ts
+++ b/packages/zarrita/__tests__/array-extension.test.ts
@@ -1,5 +1,6 @@
 import * as path from "node:path";
 import * as url from "node:url";
+import { FileSystemStore } from "@zarrita/storage";
 import { describe, expect, it } from "vitest";
 import { defineArrayExtension } from "../src/extension/define-array.js";
 import * as zarr from "../src/index.js";
@@ -8,7 +9,7 @@ let __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 let fixturesRoot = path.resolve(__dirname, "../../../fixtures/v3/data.zarr");
 
 async function openFixture(name: string) {
-	let store = new zarr.FileSystemStore(fixturesRoot);
+	let store = new FileSystemStore(fixturesRoot);
 	return zarr.open.v3(zarr.root(store).resolve(name), { kind: "array" });
 }
 
@@ -129,7 +130,7 @@ describe("zarr.open auto-apply of store arrayExtensions", () => {
 		let withTracedArray = zarr.defineStoreExtension(() => ({
 			arrayExtensions: [(a) => withTrace(a)],
 		}));
-		let store = withTracedArray(new zarr.FileSystemStore(fixturesRoot));
+		let store = withTracedArray(new FileSystemStore(fixturesRoot));
 		let arr = await zarr.open.v3(zarr.root(store).resolve("1d.chunked.i2"), {
 			kind: "array",
 		});
@@ -158,7 +159,7 @@ describe("zarr.open auto-apply of store arrayExtensions", () => {
 			arrayExtensions: [(a) => withB(a)],
 		}));
 		let store = await zarr.extendStore(
-			new zarr.FileSystemStore(fixturesRoot),
+			new FileSystemStore(fixturesRoot),
 			storeExtA,
 			storeExtB,
 		);
@@ -186,7 +187,7 @@ describe("zarr.open auto-apply of store arrayExtensions", () => {
 		let withTracedArray = zarr.defineStoreExtension(() => ({
 			arrayExtensions: [(a) => withTrace(a)],
 		}));
-		let store = withTracedArray(new zarr.FileSystemStore(fixturesRoot));
+		let store = withTracedArray(new FileSystemStore(fixturesRoot));
 		let group = await zarr.open.v3(zarr.root(store), { kind: "group" });
 		let arr = await zarr.open.v3(group.resolve("1d.chunked.i2"), {
 			kind: "array",
@@ -196,7 +197,7 @@ describe("zarr.open auto-apply of store arrayExtensions", () => {
 	});
 
 	it("returns the array as-is when the store has no arrayExtensions", async () => {
-		let store = new zarr.FileSystemStore(fixturesRoot);
+		let store = new FileSystemStore(fixturesRoot);
 		let arr = await zarr.open.v3(zarr.root(store).resolve("1d.chunked.i2"), {
 			kind: "array",
 		});

--- a/packages/zarrita/__tests__/public-api.test.ts
+++ b/packages/zarrita/__tests__/public-api.test.ts
@@ -9,7 +9,6 @@ test("public API surface", () => {
 		  "ByteStringArray",
 		  "CodecPipelineError",
 		  "FetchStore",
-		  "FileSystemStore",
 		  "Group",
 		  "InvalidMetadataError",
 		  "InvalidSelectionError",

--- a/packages/zarrita/__tests__/signal.test.ts
+++ b/packages/zarrita/__tests__/signal.test.ts
@@ -1,10 +1,11 @@
 import * as path from "node:path";
 import * as url from "node:url";
-import type {
-	AbsolutePath,
-	AsyncReadable,
-	GetOptions,
-	RangeQuery,
+import {
+	type AbsolutePath,
+	type AsyncReadable,
+	FileSystemStore,
+	type GetOptions,
+	type RangeQuery,
 } from "@zarrita/storage";
 import { describe, expect, it } from "vitest";
 import * as zarr from "../src/index.js";
@@ -36,7 +37,7 @@ function recordingStore<S extends AsyncReadable>(inner: S) {
 
 describe("signal propagation through zarr.get", () => {
 	it("passes signal to store.get for a simple array", async () => {
-		let fsStore = new zarr.FileSystemStore(fixturesRoot);
+		let fsStore = new FileSystemStore(fixturesRoot);
 		let { store, calls } = recordingStore(fsStore);
 		let arr = await zarr.open.v3(
 			zarr.root(store).resolve("1d.contiguous.raw.i2"),
@@ -52,7 +53,7 @@ describe("signal propagation through zarr.get", () => {
 	});
 
 	it("aborting signal rejects a pending zarr.get", async () => {
-		let fsStore = new zarr.FileSystemStore(fixturesRoot);
+		let fsStore = new FileSystemStore(fixturesRoot);
 		let arr = await zarr.open.v3(
 			zarr.root(fsStore).resolve("1d.contiguous.raw.i2"),
 			{ kind: "array" },
@@ -65,7 +66,7 @@ describe("signal propagation through zarr.get", () => {
 	});
 
 	it("propagates signal through a sharded chunk getter (#306)", async () => {
-		let fsStore = new zarr.FileSystemStore(fixturesRoot);
+		let fsStore = new FileSystemStore(fixturesRoot);
 		let { store, calls } = recordingStore(fsStore);
 		let arr = await zarr.open.v3(
 			zarr.root(store).resolve("1d.chunked.compressed.sharded.i2"),
@@ -79,7 +80,7 @@ describe("signal propagation through zarr.get", () => {
 	});
 
 	it("still accepts the deprecated `opts` shim", async () => {
-		let fsStore = new zarr.FileSystemStore(fixturesRoot);
+		let fsStore = new FileSystemStore(fixturesRoot);
 		let arr = await zarr.open.v3(
 			zarr.root(fsStore).resolve("1d.contiguous.raw.i2"),
 			{ kind: "array" },
@@ -92,7 +93,7 @@ describe("signal propagation through zarr.get", () => {
 	});
 
 	it("merges `signal` and deprecated `opts.signal` via AbortSignal.any", async () => {
-		let fsStore = new zarr.FileSystemStore(fixturesRoot);
+		let fsStore = new FileSystemStore(fixturesRoot);
 		let arr = await zarr.open.v3(
 			zarr.root(fsStore).resolve("1d.contiguous.raw.i2"),
 			{ kind: "array" },
@@ -129,7 +130,7 @@ describe("zarr.set cancels on signal", () => {
 
 describe("signal propagation through extendStore pipeline", () => {
 	it("reaches the inner store through multiple extensions", async () => {
-		let fsStore = new zarr.FileSystemStore(fixturesRoot);
+		let fsStore = new FileSystemStore(fixturesRoot);
 		let { store: recorder, calls } = recordingStore(fsStore);
 		let composed = await zarr.extendStore(recorder, (s) =>
 			zarr.withRangeCoalescing(s),

--- a/packages/zarrita/src/index.ts
+++ b/packages/zarrita/src/index.ts
@@ -27,7 +27,7 @@
 // re-export all the storage interface types
 export type * from "@zarrita/storage";
 // re-export fetch store from storage
-export { FetchStore, FileSystemStore } from "@zarrita/storage";
+export { default as FetchStore } from "@zarrita/storage/fetch";
 // core
 export { registry } from "./codecs.js";
 export { create } from "./create.js";


### PR DESCRIPTION
Fixes #409

This re-export snuck into the barrel as part of #384. These changes restore the 0.6.x barrel shape: FetchStore-only, via the subpath. Node users who want FileSystemStore can still import it directly from `@zarrita/storage/fs` or `@zarrita/storage`.