### PR TITLE
Fix sharded reads when `index_codecs` has no checksum

### DIFF
--- a/.changeset/fix-sharding-no-checksum.md
+++ b/.changeset/fix-sharding-no-checksum.md
@@ -1,0 +1,5 @@
+---
+"zarrita": patch
+---
+
+Fix sharded v3 reads when `index_codecs` does not include `crc32c`. The shard-index suffix length is now derived from the index codec pipeline instead of assuming a 4-byte checksum.

--- a/packages/zarrita/__tests__/open.test.ts
+++ b/packages/zarrita/__tests__/open.test.ts
@@ -4,7 +4,9 @@ import * as url from "node:url";
 import { Float16Array } from "@petamoriken/float16";
 import {
 	type AbsolutePath,
+	type AsyncReadable,
 	FileSystemStore,
+	type RangeQuery,
 	ZipFileStore,
 } from "@zarrita/storage";
 import {
@@ -1524,6 +1526,89 @@ describe("v3", async () => {
 				shape: [1, 1, 1],
 				stride: [1, 1, 1],
 			});
+		});
+	});
+
+	it("reads sharded array when index_codecs has no checksum (#424)", async () => {
+		// Hand-built sharded array where index_codecs is just `bytes` (no
+		// crc32c). The shard layout is: 4 raw data bytes followed by a 64-byte
+		// index (4 chunks * 16 bytes per offset/length pair).
+		let shard = new Uint8Array(4 + 4 * 16);
+		shard.set([10, 20, 30, 40], 0);
+		let view = new DataView(shard.buffer);
+		for (let i = 0; i < 4; i++) {
+			view.setBigUint64(4 + i * 16, BigInt(i), true);
+			view.setBigUint64(4 + i * 16 + 8, 1n, true);
+		}
+
+		let entries = new Map<AbsolutePath, Uint8Array>();
+		let enc = new TextEncoder();
+		entries.set(
+			"/zarr.json",
+			enc.encode(
+				JSON.stringify({
+					zarr_format: 3,
+					node_type: "array",
+					shape: [4],
+					data_type: "uint8",
+					chunk_grid: {
+						name: "regular",
+						configuration: { chunk_shape: [4] },
+					},
+					chunk_key_encoding: {
+						name: "default",
+						configuration: { separator: "/" },
+					},
+					fill_value: 0,
+					codecs: [
+						{
+							name: "sharding_indexed",
+							configuration: {
+								chunk_shape: [1],
+								codecs: [
+									{ name: "bytes", configuration: { endian: "little" } },
+								],
+								index_codecs: [
+									{ name: "bytes", configuration: { endian: "little" } },
+								],
+								index_location: "end",
+							},
+						},
+					],
+					attributes: {},
+				}),
+			),
+		);
+		entries.set("/c/0", shard);
+
+		let memStore: AsyncReadable = {
+			get(key) {
+				return Promise.resolve(entries.get(key));
+			},
+			getRange(key: AbsolutePath, range: RangeQuery) {
+				let bytes = entries.get(key);
+				if (!bytes) return Promise.resolve(undefined);
+				if ("suffixLength" in range) {
+					return Promise.resolve(
+						bytes.slice(bytes.length - range.suffixLength),
+					);
+				}
+				return Promise.resolve(
+					bytes.slice(range.offset, range.offset + range.length),
+				);
+			},
+		};
+
+		let arr = await open.v3(root(memStore), { kind: "array" });
+		expect(await arr.getChunk([0])).toStrictEqual({
+			data: new Uint8Array([10]),
+			shape: [1],
+			stride: [1],
+		});
+		expect(await arr.getChunk([3])).toStrictEqual({
+			data: new Uint8Array([40]),
+			shape: [1],
+			stride: [1],
 		});
 	});
 });

--- a/packages/zarrita/src/codecs.ts
+++ b/packages/zarrita/src/codecs.ts
@@ -36,6 +36,10 @@ type Codec = _Codec & {
 	// implement this to describe the metadata after encoding. The pipeline
 	// calls it so that subsequent codecs (especially bytes) see the correct type.
 	getEncodedMeta?: (meta: ChunkMetadata<DataType>) => ChunkMetadata<DataType>;
+	// Maps a decoded byte size to the encoded byte size when that's a
+	// deterministic function of the input. Used by sharding to compute the
+	// shard-index suffix length without fetching the index first.
+	computeEncodedSize?: (decodedSize: number) => number;
 };
 
 function createDefaultRegistry(): Map<string, () => Promise<CodecEntry>> {
@@ -82,6 +86,7 @@ export function createCodecPipeline<Dtype extends DataType>(
 ): {
 	encode(chunk: Chunk<Dtype>): Promise<Uint8Array>;
 	decode(bytes: Uint8Array): Promise<Chunk<Dtype>>;
+	computeEncodedSize(decodedSize: number): Promise<number>;
 } {
 	// Lazily load codecs on first use. The promise is shared by all methods.
 	let codecsPromise: ReturnType<typeof loadCodecs<Dtype>> | undefined;
@@ -129,7 +134,32 @@ export function createCodecPipeline<Dtype extends DataType>(
 			}
 			return chunk;
 		},
+		async computeEncodedSize(decodedSize: number): Promise<number> {
+			let codecs = await getCodecs();
+			let size = applyEncodedSize(
+				codecs.arrayToBytes.name,
+				codecs.arrayToBytes.codec,
+				decodedSize,
+			);
+			for (const { name, codec } of codecs.bytesToBytes) {
+				size = applyEncodedSize(name, codec, size);
+			}
+			return size;
+		},
 	};
+}
+
+function applyEncodedSize(
+	name: string,
+	codec: { computeEncodedSize?: (n: number) => number },
+	size: number,
+): number {
+	if (!codec.computeEncodedSize) {
+		throw new InvalidMetadataError(
+			`Codec "${name}" cannot compute its encoded size; it is not a fixed-size codec and cannot be used in a sharding index pipeline`,
+		);
+	}
+	return codec.computeEncodedSize(size);
 }
 
 type ArrayToArrayCodec<D extends DataType> = {
@@ -140,11 +170,13 @@ type ArrayToArrayCodec<D extends DataType> = {
 type ArrayToBytesCodec<D extends DataType> = {
 	encode: (data: Chunk<D>) => Promise<Uint8Array> | Uint8Array;
 	decode: (data: Uint8Array) => Promise<Chunk<D>> | Chunk<D>;
+	computeEncodedSize?: (decodedSize: number) => number;
 };
 
 type BytesToBytesCodec = {
 	encode: (data: Uint8Array) => Promise<Uint8Array>;
 	decode: (data: Uint8Array) => Promise<Uint8Array>;
+	computeEncodedSize?: (decodedSize: number) => number;
 };
 
 type Named<T> = { name: string; codec: T };

--- a/packages/zarrita/src/codecs/bytes.ts
+++ b/packages/zarrita/src/codecs/bytes.ts
@@ -61,6 +61,10 @@ export class BytesCodec<D extends Exclude<DataType, "v2:object" | "string">> {
 		return bytes;
 	}
 
+	computeEncodedSize(decodedSize: number): number {
+		return decodedSize;
+	}
+
 	decode(bytes: Uint8Array): Chunk<D> {
 		if (LITTLE_ENDIAN_OS && this.#endian === "big") {
 			byteswapInplace(bytes, bytesPerElement(this.#TypedArray));

--- a/packages/zarrita/src/codecs/crc32c.ts
+++ b/packages/zarrita/src/codecs/crc32c.ts
@@ -9,4 +9,7 @@ export class Crc32cCodec {
 	decode(arr: Uint8Array): Uint8Array {
 		return new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength - 4);
 	}
+	computeEncodedSize(decodedSize: number): number {
+		return decodedSize + 4;
+	}
 }

--- a/packages/zarrita/src/codecs/sharding.ts
+++ b/packages/zarrita/src/codecs/sharding.ts
@@ -25,8 +25,11 @@ export function createShardedChunkGetter(
 		fillValue: null,
 	});
 
-	let checksumSize = 4;
-	let indexSize = 16 * indexShape.reduce((a, b) => a * b, 1);
+	// The shard index is a uint64 array with shape [...indexShape, 2]
+	// (offset, length) per inner chunk. Its on-disk size depends on the
+	// index_codecs pipeline — e.g. crc32c appends 4 bytes — so we ask the
+	// pipeline rather than hardcoding any constant.
+	let rawIndexSize = 16 * indexShape.reduce((a, b) => a * b, 1);
 	let cache: Record<string, Promise<Chunk<"uint64"> | null>> = {};
 	return async (chunkCoord: number[], options?: GetOptions) => {
 		let shardCoord = chunkCoord.map((d, i) => Math.floor(d / indexShape[i]));
@@ -34,13 +37,8 @@ export function createShardedChunkGetter(
 
 		if (!(shardPath in cache)) {
 			cache[shardPath] = (async () => {
-				let bytes = await getRange(
-					shardPath,
-					{
-						suffixLength: indexSize + checksumSize,
-					},
-					options,
-				);
+				let suffixLength = await indexCodec.computeEncodedSize(rawIndexSize);
+				let bytes = await getRange(shardPath, { suffixLength }, options);
 				return bytes ? await indexCodec.decode(bytes) : null;
 			})().catch((err) => {
 				delete cache[shardPath];


### PR DESCRIPTION
Fixes #424

The sharding codec hardcoded a 4-byte checksum in the suffix-range request used to fetch the shard index, which silently corrupted reads of any v3 sharded array whose `index_codecs` did not include `crc32c`. The wrong suffix length pulled the last 4 bytes of the data region into the index buffer, shifting every offset/length pair and producing nonsense byte ranges.

Rather than special-case `crc32c`, this matches what zarr-python and zarrs do: each codec reports its own size impact, and the sharding codec asks the index pipeline for the encoded size.

New fixed-size index codecs only need to implement `computeEncodedSize`: 

```ts
class Crc32cCodec {
  computeEncodedSize(decodedSize: number): number {
	return decodedSize + 4;
  }
}
```

Codecs that don't implement it (compressors and the like) raise a clear error if used in an index pipeline, which matches zarrs's explicit rejection of variable-size index codecs.