### PR TITLE
Stop `BytesCodec` from mutating its input buffer

### DIFF
--- a/.changeset/big-endian-cache-mutation.md
+++ b/.changeset/big-endian-cache-mutation.md
@@ -1,0 +1,5 @@
+---
+"zarrita": patch
+---
+
+Fix `BytesCodec` mutating its input buffer in place when byte-swapping big-endian data. Combined with `withByteCaching`, this corrupted cached chunks so repeated reads alternated between correct and incorrect values. The codec now copies before swapping on both encode and decode.

--- a/packages/zarrita/__tests__/bytes.test.ts
+++ b/packages/zarrita/__tests__/bytes.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { BytesCodec } from "../src/codecs/bytes.js";
+
+let meta = (dataType: "int32") => ({ dataType, shape: [2], codecs: [] });
+
+describe("BytesCodec", () => {
+	it("does not mutate the input buffer when byteswapping big-endian", () => {
+		let codec = BytesCodec.fromConfig({ endian: "big" }, meta("int32"));
+		let bytes = new Uint8Array([0, 0, 0, 1, 0, 0, 0, 2]);
+		let original = bytes.slice();
+
+		codec.decode(bytes);
+
+		expect(bytes).toEqual(original);
+	});
+
+	it("decodes the same buffer identically on repeated reads", () => {
+		let codec = BytesCodec.fromConfig({ endian: "big" }, meta("int32"));
+		// A byte cache hands back the same Uint8Array on every hit. See #431.
+		let bytes = new Uint8Array([0, 0, 0, 1, 0, 0, 0, 2]);
+
+		let first = Array.from(codec.decode(bytes).data);
+		let second = Array.from(codec.decode(bytes).data);
+		let third = Array.from(codec.decode(bytes).data);
+
+		expect(first).toEqual([1, 2]);
+		expect(second).toEqual(first);
+		expect(third).toEqual(first);
+	});
+
+	it("does not mutate the source array buffer when encoding big-endian", () => {
+		let codec = BytesCodec.fromConfig({ endian: "big" }, meta("int32"));
+		let data = new Int32Array([1, 2]);
+		let snapshot = data.slice();
+
+		codec.encode({ data, shape: [2], stride: [1] });
+
+		expect(data).toEqual(snapshot);
+	});
+});

--- a/packages/zarrita/src/codecs/bytes.ts
+++ b/packages/zarrita/src/codecs/bytes.ts
@@ -56,6 +56,7 @@ export class BytesCodec<D extends Exclude<DataType, "v2:object" | "string">> {
 	encode(arr: Chunk<D>): Uint8Array {
 		let bytes = new Uint8Array(arr.data.buffer);
 		if (LITTLE_ENDIAN_OS && this.#endian === "big") {
+			bytes = bytes.slice();
 			byteswapInplace(bytes, bytesPerElement(this.#TypedArray));
 		}
 		return bytes;
@@ -63,6 +64,9 @@ export class BytesCodec<D extends Exclude<DataType, "v2:object" | "string">> {
 
 	decode(bytes: Uint8Array): Chunk<D> {
 		if (LITTLE_ENDIAN_OS && this.#endian === "big") {
+			// Copy before swapping so we never mutate the input in place; it
+			// may be a shared buffer (e.g. from `withByteCaching`). See #431.
+			bytes = bytes.slice();
 			byteswapInplace(bytes, bytesPerElement(this.#TypedArray));
 		}
 		return {


### PR DESCRIPTION
Fixes #431

BytesCodec byte-swaps big-endian data in place. When an uncompressed chunk is served from `withByteCaching`, the store hands back the same Uint8Array on every cache hit, so each decode re-swaps the cached buffer. The result is that repeated reads of the same chunk alternate between correct and corrupt values.

These changes copy before swapping on both encode and decode so the codec never mutates a buffer it doesn't own. The extra copy only happens on the big-endian-on-little-endian path; the common path is untouched.