### PR TITLE
Fix transpose codec on dimension-reducing selections

### DIFF
--- a/.changeset/transpose-reduced-rank-selection.md
+++ b/.changeset/transpose-reduced-rank-selection.md
@@ -1,0 +1,5 @@
+---
+"zarrita": patch
+---
+
+Fix transpose codec on dimension-reducing selections

--- a/packages/zarrita/__tests__/transpose.test.ts
+++ b/packages/zarrita/__tests__/transpose.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+import * as zarr from "../src/index.js";
+
+/** Read a chunk's values in logical (C) order, honoring its strides. */
+function toLogical<D extends zarr.DataType>(chunk: zarr.Chunk<D>): unknown[] {
+	let { data, shape, stride } = chunk;
+	let total = shape.reduce((a, b) => a * b, 1);
+	let index = new globalThis.Array(shape.length).fill(0);
+	let out: unknown[] = [];
+	for (let n = 0; n < total; n++) {
+		let offset = index.reduce((acc, v, d) => acc + v * stride[d], 0);
+		out.push((data as ArrayLike<unknown>)[offset]);
+		for (let d = shape.length - 1; d >= 0; d--) {
+			if (++index[d] < shape[d]) break;
+			index[d] = 0;
+		}
+	}
+	return out;
+}
+
+async function make(codecs: zarr.CodecMetadata[]) {
+	let arr = await zarr.create(zarr.root(new Map()).resolve("/a"), {
+		shape: [4, 4, 4],
+		chunkShape: [2, 2, 2],
+		dtype: "uint8",
+		codecs,
+	});
+	// element (i,j,k) = 16*i + 4*j + k
+	let full = new Uint8Array(64).map((_, i) => i);
+	await zarr.set(arr, null, {
+		data: full,
+		shape: [4, 4, 4],
+		stride: [16, 4, 1],
+	});
+	return arr;
+}
+
+describe("transpose codec", () => {
+	// Integer indexing drops dimensions, so the output rank is lower than the
+	// transpose order's rank. The output strides must not blow up on that
+	// mismatch. See https://github.com/manzt/zarrita.js/issues/427.
+	it("reads slices that drop dimensions from a transposed array", async () => {
+		let plain = await make([
+			{ name: "bytes", configuration: { endian: "little" } },
+		]);
+		let transposed = await make([
+			{ name: "transpose", configuration: { order: [2, 1, 0] } },
+			{ name: "bytes", configuration: { endian: "little" } },
+		]);
+
+		let selections = [
+			[0, null, null],
+			[null, 1, null],
+			[null, null, 2],
+			[0, 1, null],
+			[1, null, 2],
+		];
+
+		for (let sel of selections) {
+			let expected = await zarr.get(plain, sel);
+			let actual = await zarr.get(transposed, sel);
+			expect(actual.shape, JSON.stringify(sel)).toEqual(expected.shape);
+			// Compare logically — the transposed array's output layout differs
+			// from the plain array's, but the values at each coordinate match.
+			expect(toLogical(actual), JSON.stringify(sel)).toEqual(
+				toLogical(expected),
+			);
+		}
+	});
+
+	// A full read of a transposed array returns data in its native order:
+	// for order [2,1,0] on shape [4,4,4] the stride is [1,4,16]. A read that
+	// drops a dimension should stay consistent and return the native order
+	// *projected* onto the surviving axes, not silently fall back to
+	// C-contiguous. Dropping axis 0 keeps axes [1,2], whose relative order in
+	// [2,1,0] is [2,1] -> projected order [1,0] -> stride [1,4].
+	it("preserves native order on dimension-reducing reads", async () => {
+		let transposed = await make([
+			{ name: "transpose", configuration: { order: [2, 1, 0] } },
+			{ name: "bytes", configuration: { endian: "little" } },
+		]);
+
+		let whole = await zarr.get(transposed, null);
+		expect(whole.stride).toEqual([1, 4, 16]);
+
+		let slice = await zarr.get(transposed, [0, null, null]);
+		expect(slice.stride).toEqual([1, 4]);
+	});
+});

--- a/packages/zarrita/src/hierarchy.ts
+++ b/packages/zarrita/src/hierarchy.ts
@@ -72,6 +72,38 @@ function getArrayOrder(
 	return maybeTransposeCodec?.configuration?.order ?? "C";
 }
 
+/**
+ * Project a full-rank axis permutation onto a subset of axes, preserving the
+ * relative order of the surviving axes. `axes` lists the original axis indices
+ * that survive (ascending, matching the output shape). For order `[2, 1, 0]`
+ * and surviving axes `[1, 2]` (axis 0 dropped) this yields `[1, 0]`: of the
+ * kept axes, axis 2 comes before axis 1 in the original order.
+ */
+function projectOrder(
+	order: globalThis.Array<number>,
+	axes: number[],
+): number[] {
+	let rank = new Map(axes.map((axis, i) => [axis, i]));
+	return order.filter((axis) => rank.has(axis)).map((axis) => rank.get(axis)!);
+}
+
+function makeStrideGetter(
+	nativeOrder: "C" | "F" | globalThis.Array<number>,
+): (shape: number[], axes?: number[]) => number[] {
+	return (shape, axes) => {
+		// An explicit transpose order is defined over the array's full rank.
+		// A selection that drops dimensions (e.g. integer indexing) yields an
+		// output of lower rank; project the order onto the surviving axes so
+		// the output keeps the array's native order rather than silently
+		// reverting to C-contiguous. See #427.
+		let order =
+			globalThis.Array.isArray(nativeOrder) && axes
+				? projectOrder(nativeOrder, axes)
+				: nativeOrder;
+		return getStrides(shape, order);
+	};
+}
+
 const CONTEXT_MARKER = Symbol("zarrita.context");
 
 export function getContext<T>(obj: { [CONTEXT_MARKER]: T }): T {
@@ -101,9 +133,7 @@ function createContext<D extends DataType>(
 				codecs: configuration.codecs,
 				fillValue: metadata.fill_value,
 			}),
-			getStrides(shape: number[]) {
-				return getStrides(shape, nativeOrder);
-			},
+			getStrides: makeStrideGetter(nativeOrder),
 			getChunkBytes: createShardedChunkGetter(
 				location,
 				metadata.chunk_grid.configuration.chunk_shape,
@@ -124,9 +154,7 @@ function createContext<D extends DataType>(
 			codecs: metadata.codecs,
 			fillValue: metadata.fill_value,
 		}),
-		getStrides(shape: number[]) {
-			return getStrides(shape, nativeOrder);
-		},
+		getStrides: makeStrideGetter(nativeOrder),
 		async getChunkBytes(chunkCoords, options) {
 			let chunkKey = sharedContext.encodeChunkKey(chunkCoords);
 			let chunkPath = location.resolve(chunkKey).path;
@@ -144,8 +172,13 @@ interface ArrayContext<D extends DataType> {
 	encodeChunkKey(chunkCoords: number[]): string;
 	/** The TypedArray constructor for this array chunks. */
 	TypedArray: TypedArrayConstructor<D>;
-	/** A function to get the strides for a given shape, using the array order */
-	getStrides(shape: number[]): number[];
+	/**
+	 * Get the strides for a given output shape, using the array's native order.
+	 * `axes` lists the original axis indices the shape corresponds to (used to
+	 * project a transpose order onto a dimension-reducing selection); omit it
+	 * for a full-rank shape.
+	 */
+	getStrides(shape: number[], axes?: number[]): number[];
 	/** The fill value for this array. */
 	fillValue: Scalar<D> | null;
 	/** A function to get the bytes for a given chunk. */

--- a/packages/zarrita/src/indexing/get.ts
+++ b/packages/zarrita/src/indexing/get.ts
@@ -84,7 +84,7 @@ export async function get<
 	let out = setter.prepare(
 		data,
 		indexer.shape,
-		context.getStrides(indexer.shape),
+		context.getStrides(indexer.shape, indexer.outputAxes),
 	);
 
 	let queue = opts.createQueue?.() ?? createQueue();

--- a/packages/zarrita/src/indexing/indexer.ts
+++ b/packages/zarrita/src/indexing/indexer.ts
@@ -200,6 +200,12 @@ interface ChunkProjection {
 export class BasicIndexer {
 	dimIndexers: (SliceDimIndexer | IntDimIndexer)[];
 	shape: number[];
+	/**
+	 * Original axis indices that survive the selection (slices, not integer
+	 * indices), in ascending order — i.e. the input axis each output dimension
+	 * came from. Used to project the array's native order onto the output.
+	 */
+	outputAxes: number[];
 
 	constructor({ selection, shape, chunkShape }: BasicIndexerProps) {
 		// setup per-dimension indexers
@@ -216,6 +222,10 @@ export class BasicIndexer {
 		this.shape = this.dimIndexers
 			.filter((ixr) => ixr instanceof SliceDimIndexer)
 			.map((sixr) => sixr.nitems);
+		this.outputAxes = this.dimIndexers
+			.map((ixr, axis) => ({ ixr, axis }))
+			.filter(({ ixr }) => ixr instanceof SliceDimIndexer)
+			.map(({ axis }) => axis);
 	}
 
 	*[Symbol.iterator](): IterableIterator<ChunkProjection> {


### PR DESCRIPTION
Closes #427

A transpose codec's order is defined over the array's full rank. When a
selection drops dimensions (e.g. integer indexing), the output has lower
rank than the order, so `getStrides` asserts "Order length must match the
number of dimensions." and the read fails.

Project the native order onto the surviving axes so a dimension-reducing
read keeps the array's native layout instead of throwing. `BasicIndexer`
now exposes the original axis index of each output dimension, and the
array context's `getStrides` uses those to remap the order. A full read of
a transposed array and a slice of it now report consistent strides and the
full-rank path is unchanged.
