### PR TITLE
Copy a selection in one go when it is contiguous on both sides

### DIFF
--- a/.changeset/coalesce-contiguous-copy.md
+++ b/.changeset/coalesce-contiguous-copy.md
@@ -1,0 +1,5 @@
+---
+"zarrita": patch
+---
+
+Copy a selection in one go when it is contiguous in both the chunk and the output

--- a/packages/zarrita/__tests__/indexing/contiguous-copy.test.ts
+++ b/packages/zarrita/__tests__/indexing/contiguous-copy.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from "vitest";
+
+import * as zarr from "../../src/index.js";
+
+/**
+ * Slicing the outermost dimension while taking the rest whole selects one
+ * unbroken run of memory per chunk, which is copied with a single `set`.
+ * These pin the cases where that shortcut must *not* be taken, since taking
+ * it wrongly returns the wrong values rather than throwing.
+ */
+
+async function filled(shape: number[], chunkShape: number[], order?: number[]) {
+	const store = new Map<string, Uint8Array>();
+	const codecs: Record<string, unknown>[] = [];
+	if (order) {
+		codecs.push({ name: "transpose", configuration: { order } });
+	}
+	codecs.push({ name: "bytes", configuration: { endian: "little" } });
+	const arr = await zarr.create(store as never, {
+		shape,
+		chunkShape,
+		dtype: "int32",
+		// biome-ignore lint/suspicious/noExplicitAny: inline codec metadata
+		codecs: codecs as any,
+	});
+	const size = shape.reduce((a, b) => a * b, 1);
+	const data = new Int32Array(size);
+	for (let i = 0; i < size; i++) {
+		data[i] = i;
+	}
+	const stride = shape.map((_, i) =>
+		shape.slice(i + 1).reduce((a, b) => a * b, 1),
+	);
+	await zarr.set(arr, null, { data, shape, stride });
+	return arr;
+}
+
+describe("contiguous copy", () => {
+	it("takes trailing dimensions whole, across a chunk boundary", async () => {
+		// two rows either side of the boundary, every column of each
+		const arr = await filled([4, 3, 2], [2, 3, 2]);
+		const res = await zarr.get(arr, [zarr.slice(1, 3), null, null]);
+		expect(res.shape).toStrictEqual([2, 3, 2]);
+		expect(res.data).toStrictEqual(
+			new Int32Array([6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]),
+		);
+	});
+
+	it("is not contiguous when an inner dimension is split across chunks", async () => {
+		const arr = await filled([4, 4], [4, 2]);
+		const res = await zarr.get(arr, [zarr.slice(1, 3), null]);
+		expect(res.data).toStrictEqual(new Int32Array([4, 5, 6, 7, 8, 9, 10, 11]));
+	});
+
+	it("is not contiguous when an inner dimension is taken in part", async () => {
+		const arr = await filled([4, 4], [4, 4]);
+		const res = await zarr.get(arr, [zarr.slice(1, 3), zarr.slice(1, 3)]);
+		expect(res.data).toStrictEqual(new Int32Array([5, 6, 9, 10]));
+	});
+
+	it("is not contiguous when the step is not 1", async () => {
+		const arr = await filled([8], [8]);
+		const res = await zarr.get(arr, [zarr.slice(0, 8, 2)]);
+		expect(res.data).toStrictEqual(new Int32Array([0, 2, 4, 6]));
+	});
+
+	it("is not contiguous when the step is not 1 in an inner dimension", async () => {
+		const arr = await filled([2, 4], [2, 4]);
+		const res = await zarr.get(arr, [null, zarr.slice(0, 4, 2)]);
+		expect(res.data).toStrictEqual(new Int32Array([0, 2, 4, 6]));
+	});
+
+	it("is not contiguous when an integer index drops the outer dimension", async () => {
+		const arr = await filled([4, 3], [2, 3]);
+		const res = await zarr.get(arr, [1, null]);
+		expect(res.shape).toStrictEqual([3]);
+		expect(res.data).toStrictEqual(new Int32Array([3, 4, 5]));
+	});
+
+	it("is not contiguous when an integer index drops an inner dimension", async () => {
+		const arr = await filled([4, 3], [2, 3]);
+		const res = await zarr.get(arr, [null, 1]);
+		expect(res.shape).toStrictEqual([4]);
+		expect(res.data).toStrictEqual(new Int32Array([1, 4, 7, 10]));
+	});
+
+	it("is not contiguous when a dropped dimension leaves a unit-length trail", async () => {
+		// the trailing run is one element, so the strides alone cannot tell the
+		// dropped dimension apart from a whole one
+		const arr = await filled([4, 1], [4, 1]);
+		const res = await zarr.get(arr, [1, null]);
+		expect(res.shape).toStrictEqual([1]);
+		expect(res.data).toStrictEqual(new Int32Array([1]));
+	});
+
+	it("takes the array's own order into account, not the selection's shape", async () => {
+		// laid out with the first axis fastest, so a row is *not* a run of
+		// memory even though the trailing dimension is taken whole
+		const arr = await filled([4, 3], [4, 3], [1, 0]);
+		const res = await zarr.get(arr, [zarr.slice(1, 3), null]);
+		expect(res.stride).toStrictEqual([1, 2]);
+		// stride [1, 2] means row 1 is at [0], [2], [4]
+		expect(res.data).toStrictEqual(new Int32Array([3, 6, 4, 7, 5, 8]));
+	});
+});

--- a/packages/zarrita/src/indexing/ops.ts
+++ b/packages/zarrita/src/indexing/ops.ts
@@ -210,12 +210,68 @@ function setScalarBinary(
 	}
 }
 
+/**
+ * If every remaining dimension is a step-1 slice whose elements are laid out
+ * back to back in both `src` and `dest`, the whole selection is one unbroken
+ * run of memory on both sides and can be copied with a single `set`.
+ *
+ * That holds when each stride is the product of the lengths inside it, which
+ * is checked from the innermost dimension outward. The condition is on the
+ * strides rather than on which dimensions were taken whole, so an array whose
+ * `order` is not C-contiguous simply fails it rather than being copied wrongly.
+ *
+ * Returns the run's size and its start offset in each side, or `null` if the
+ * caller has to recurse.
+ */
+function contiguousSpan(
+	projections: Projection[],
+	destStride: number[],
+	srcStride: number[],
+) {
+	// a selection that drops dimensions leaves the two sides at different
+	// ranks, so the strides no longer line up with the projections; the
+	// recursion strips those dimensions off before this can apply
+	if (
+		projections.length !== destStride.length ||
+		projections.length !== srcStride.length
+	) {
+		return null;
+	}
+	let size = 1;
+	let destOffset = 0;
+	let srcOffset = 0;
+	for (let i = projections.length - 1; i >= 0; i--) {
+		const proj = projections[i];
+		// an integer index drops a dimension, so the two sides stop lining up
+		if (proj.from === null || proj.to === null) return null;
+		if (destStride[i] !== size || srcStride[i] !== size) return null;
+		const [from, to, step] = proj.to;
+		const [sfrom, , sstep] = proj.from;
+		if (step !== 1 || sstep !== 1) return null;
+		destOffset += size * from;
+		srcOffset += size * sfrom;
+		size *= indicesLen(from, to, step);
+	}
+	return { size, destOffset, srcOffset };
+}
+
 function setFromChunkBinary(
 	dest: { data: Uint8Array; stride: number[] },
 	src: { data: Uint8Array; stride: number[] },
 	bytesPerElement: number,
 	projections: Projection[],
 ) {
+	// NB: we have a contiguous block of memory
+	// so we can just copy over all the data at once.
+	const span = contiguousSpan(projections, dest.stride, src.stride);
+	if (span !== null) {
+		const offset = span.srcOffset * bytesPerElement;
+		dest.data.set(
+			src.data.subarray(offset, offset + span.size * bytesPerElement),
+			span.destOffset * bytesPerElement,
+		);
+		return;
+	}
 	const [proj, ...projs] = projections;
 	const [dstride, ...dstrides] = dest.stride;
 	const [sstride, ...sstrides] = src.stride;
@@ -259,18 +315,7 @@ function setFromChunkBinary(
 	const [sfrom, _, sstep] = proj.from;
 	const len = indicesLen(from, to, step);
 	if (projs.length === 0) {
-		// NB: we have a contiguous block of memory
-		// so we can just copy over all the data at once.
-		if (step === 1 && sstep === 1 && dstride === 1 && sstride === 1) {
-			let offset = sfrom * bytesPerElement;
-			let size = len * bytesPerElement;
-			dest.data.set(
-				src.data.subarray(offset, offset + size),
-				from * bytesPerElement,
-			);
-			return;
-		}
-		// Otherwise, we have to copy over each element individually.
+		// not contiguous, so we have to copy over each element individually.
 		for (let i = 0; i < len; i++) {
 			let offset = sstride * (sfrom + sstep * i) * bytesPerElement;
 			dest.data.set(


### PR DESCRIPTION
*Written by Claude Code on behalf of @cmdcolin, who reviewed it before it was opened. The measurements and the sabotage checks described below were run, not estimated.*

`get(arr, [slice(a, b), null, null])` — slice the outermost dimension, take the rest whole — selects one unbroken run of memory per chunk. But `setFromChunkBinary` walks the selection a dimension at a time and reaches its contiguous fast path only at the innermost level, by which point the run has been split into pieces.

The array I hit this on is [VCF Zarr](https://github.com/sgkit-dev/vcf-zarr-spec)'s `call_genotype`, which is `(variants, samples, ploidy)`. Drawing one screen of a genome browser reads a few thousand consecutive rows with every sample in each, so on `(4000, 2504, 2)` that is 3.4M two-element copies for 1375 rows.

This checks for the run before recursing: walk the projections from the innermost dimension outward while each stride is the product of the lengths inside it, then copy the whole span with a single `set`. The existing innermost fast path is the one-dimensional case of that, so it comes out.

The condition is on the **strides** rather than on which dimensions were taken whole — an array with a transpose `order` is not laid out the way its shape suggests, so it fails the check and recurses exactly as before. I didn't want to reintroduce the class of thing #435 just fixed.

### Numbers

node 24.13.0, Linux, local filesystem. Six iterations, the first discarded as warm-up; each pair verified to produce an identical checksum.

**1000 Genomes phase 3, chr22**, as `vcf2zarr` writes it: `call_genotype` is `(10176, 2504, 2)` int8 in `(1000, 2504, 2)` chunks under blosc/zstd level 7 with bitshuffle. The read is one 40 kb window of the chromosome — 1375 records overlap it, spanning rows 2701 to 8046 because a 151 kb structural variant reaches in from further left, so the slab is 5345 rows, 26,767,760 values:

| | runs (ms) | median |
| --- | --- | --- |
| before | 7126, 9877, 7630, 7074, 6625 | 7126 ms |
| after | 145, 143, 115, 116, 103 | 116 ms |

**~61x.** Blosc decompression is real work and is most of what remains.

**Synthetic**, `(4000, 2504, 2)` int8 with the `bytes` codec only, so nothing is decompressed and the timing is the copy alone. 1375 rows:

| | runs (ms) | median |
| --- | --- | --- |
| before | 1592, 1413, 1503, 1620, 1615 | 1592 ms |
| after | 5, 5, 10, 5, 4 | 5 ms |

**~318x**, the ceiling for this change.

Run-to-run spread on a shared machine is wide — an earlier pass gave 8247 to 153 ms on the real store. The ratio moves with load; the order of magnitude does not.

The harnesses, the two commands that build the 1000 Genomes store, and the fuzz below are on a separate branch so this PR stays to the change itself: **https://github.com/cmdcolin/zarrita.js/tree/bench-contiguous-copy/packages/zarrita/__tests__/bench**

### Tests

The new cases pin the shapes that must *not* coalesce, since taking the shortcut wrongly returns bad data rather than throwing: an inner dimension split across chunks, an inner dimension taken in part, `step != 1` in the outer and in an inner dimension, an integer index dropping the outer or an inner dimension, a unit-length trailing dimension, and an array whose `order` is not C.

I checked they are load-bearing by breaking each condition in the implementation in turn and confirming the suite fails — the step check and each of the two stride checks are caught by two tests apiece.

Separately, a 240-case differential fuzz over random shapes, chunkings, selections and transpose orders, checked against an oracle derived from coordinates rather than from zarrita: `main` fails 21 of them and `main` plus this PR fails the same 21, so the change is behavior preserving. Those 21 are pre-existing transpose bugs, unrelated to this and fixed by #444 and #445.

One note on the rank check at the top of `contiguousSpan`. A dimension-reducing selection already leaves `destStride` shorter than `projections`, so an out-of-range lookup would bail on its own, but that felt like relying on an accident; the explicit check states the precondition instead. Those selections still coalesce one level down, once the recursion has stripped the dropped dimension off.


