### PR TITLE
Fix writes through the transpose codec

### DIFF
--- a/.changeset/transpose-encode-order.md
+++ b/.changeset/transpose-encode-order.md
@@ -1,0 +1,5 @@
+---
+"zarrita": patch
+---
+
+Fix writes through the transpose codec when the order is not its own inverse

--- a/packages/zarrita/__tests__/transpose.test.ts
+++ b/packages/zarrita/__tests__/transpose.test.ts
@@ -74,6 +74,46 @@ describe("transpose codec", () => {
 	// *projected* onto the surviving axes, not silently fall back to
 	// C-contiguous. Dropping axis 0 keeps axes [1,2], whose relative order in
 	// [2,1,0] is [2,1] -> projected order [1,0] -> stride [1,4].
+	// `decode` describes the stored bytes as being laid out in `order`, so
+	// `encode` has to produce that same layout. It converted to the inverse
+	// permutation, which is the same thing only when the order is its own
+	// inverse — as [2,1,0] and "C"/"F" are, so nothing here caught it.
+	it("round trips an order that is not its own inverse", async () => {
+		for (let order of [
+			[2, 0, 1],
+			[1, 2, 0],
+		]) {
+			let arr = await make([
+				{ name: "transpose", configuration: { order } },
+				{ name: "bytes", configuration: { endian: "little" } },
+			]);
+			let whole = await zarr.get(arr, null);
+			expect(toLogical(whole), JSON.stringify(order)).toEqual([
+				...globalThis.Array(64).keys(),
+			]);
+		}
+	});
+
+	// Building the transposed copy used `chunk.constructor` — `Object`, since a
+	// chunk is a plain object — rather than the constructor of its data, so the
+	// copy was a Number wrapper, every write to it was dropped, and a zero byte
+	// chunk was stored.
+	it("writes a chunk of the expected size when it has to reorder", async () => {
+		let store = new Map<string, Uint8Array>();
+		let arr = await zarr.create(zarr.root(store).resolve("/a"), {
+			shape: [2, 3, 4],
+			chunkShape: [2, 3, 4],
+			dtype: "int32",
+			codecs: [
+				{ name: "transpose", configuration: { order: [2, 0, 1] } },
+				{ name: "bytes", configuration: { endian: "little" } },
+			],
+		});
+		let data = new Int32Array(24).map((_, i) => i);
+		await zarr.set(arr, null, { data, shape: [2, 3, 4], stride: [12, 4, 1] });
+		expect(store.get("/a/c/0/0/0")?.length).toBe(24 * 4);
+	});
+
 	it("preserves native order on dimension-reducing reads", async () => {
 		let transposed = await make([
 			{ name: "transpose", configuration: { order: [2, 1, 0] } },

--- a/packages/zarrita/__tests__/transpose.test.ts
+++ b/packages/zarrita/__tests__/transpose.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { TransposeCodec } from "../src/codecs/transpose.js";
 import * as zarr from "../src/index.js";
 
 /** Read a chunk's values in logical (C) order, honoring its strides. */
@@ -112,6 +113,21 @@ describe("transpose codec", () => {
 		let data = new Int32Array(24).map((_, i) => i);
 		await zarr.set(arr, null, { data, shape: [2, 3, 4], stride: [12, 4, 1] });
 		expect(store.get("/a/c/0/0/0")?.length).toBe(24 * 4);
+	});
+
+	// The copy walked `src` linearly, which assumes it is laid out with the
+	// first axis fastest. It is reached whenever the chunk handed to `encode`
+	// is not already in the target layout — including when two strides tie,
+	// which a length-1 dimension causes.
+	it("encodes a chunk that is not already in the target layout", () => {
+		// (i,j) holds 3i + j, laid out C-contiguous
+		let data = new Int32Array(6).map((_, i) => i);
+		let codec = new TransposeCodec({ order: [1, 0] }, { shape: [2, 3] });
+		let out = codec.encode({ data, shape: [2, 3], stride: [3, 1] });
+		expect(out.stride).toEqual([1, 2]);
+		expect(globalThis.Array.from(out.data as Int32Array)).toEqual([
+			0, 3, 1, 4, 2, 5,
+		]);
 	});
 
 	it("preserves native order on dimension-reducing reads", async () => {

--- a/packages/zarrita/src/codecs/transpose.ts
+++ b/packages/zarrita/src/codecs/transpose.ts
@@ -48,13 +48,14 @@ function emptyLike<D extends DataType>(
 		chunk.data instanceof ByteStringArray ||
 		chunk.data instanceof UnicodeStringArray
 	) {
-		data = new (chunk.constructor as TypedArrayConstructor<D>)(
-			// @ts-expect-error
-			chunk.data.length,
+		// these take the character width ahead of the length
+		data = new (chunk.data.constructor as TypedArrayConstructor<D>)(
+			// @ts-expect-error - the two argument form is not on the shared type
 			chunk.data.chars,
+			chunk.data.length,
 		);
 	} else {
-		data = new (chunk.constructor as TypedArrayConstructor<D>)(
+		data = new (chunk.data.constructor as TypedArrayConstructor<D>)(
 			chunk.data.length,
 		);
 	}
@@ -123,37 +124,31 @@ type Order = "C" | "F" | Array<number>;
 export class TransposeCodec {
 	kind = "array_to_array";
 	#order: Array<number>;
-	#inverseOrder: Array<number>;
 
 	constructor(configuration: { order?: Order }, meta: { shape: number[] }) {
 		let value = configuration.order ?? "C";
 		let rank = meta.shape.length;
 		let order = new Array<number>(rank);
-		let inverseOrder = new Array<number>(rank);
 
 		if (value === "C") {
 			for (let i = 0; i < rank; ++i) {
 				order[i] = i;
-				inverseOrder[i] = i;
 			}
 		} else if (value === "F") {
 			for (let i = 0; i < rank; ++i) {
 				order[i] = rank - i - 1;
-				inverseOrder[i] = rank - i - 1;
 			}
 		} else {
 			order = value;
-			order.forEach((x, i) => {
-				assert(
-					inverseOrder[x] === undefined,
-					`Invalid permutation: ${JSON.stringify(value)}`,
-				);
-				inverseOrder[x] = i;
+			// every axis appears exactly once
+			let seen = new Array<boolean>(rank);
+			order.forEach((x) => {
+				assert(!seen[x], `Invalid permutation: ${JSON.stringify(value)}`);
+				seen[x] = true;
 			});
 		}
 
 		this.#order = order;
-		this.#inverseOrder = inverseOrder;
 	}
 
 	static fromConfig(
@@ -164,11 +159,14 @@ export class TransposeCodec {
 	}
 
 	encode<D extends DataType>(arr: Chunk<D>): Chunk<D> {
-		if (matchesOrder(arr, this.#inverseOrder)) {
+		// `decode` hands back a chunk laid out in `#order`, so that is what the
+		// stored bytes have to be. Converting to `#inverseOrder` here agreed
+		// with `decode` only when the permutation was its own inverse.
+		if (matchesOrder(arr, this.#order)) {
 			// can skip making a copy
 			return arr;
 		}
-		return convertArrayOrder(arr, this.#inverseOrder);
+		return convertArrayOrder(arr, this.#order);
 	}
 
 	decode<D extends DataType>(arr: Chunk<D>): Chunk<D> {

--- a/packages/zarrita/src/codecs/transpose.ts
+++ b/packages/zarrita/src/codecs/transpose.ts
@@ -78,9 +78,13 @@ function convertArrayOrder<D extends DataType>(
 	let srcData = proxy(src.data);
 	let outData = proxy(out.data);
 
-	for (let srcIdx = 0; srcIdx < size; srcIdx++) {
+	for (let n = 0; n < size; n++) {
+		// walking `src` linearly assumed it was laid out with the first axis
+		// fastest; address it through its own strides instead
+		let srcIdx = 0;
 		let outIdx = 0;
 		for (let dim = 0; dim < nDims; dim++) {
+			srcIdx += index[dim] * src.stride[dim];
 			outIdx += index[dim] * out.stride[dim];
 		}
 		outData[outIdx] = srcData[srcIdx];


### PR DESCRIPTION
*Written by Claude Code on behalf of @cmdcolin, who reviewed it before it was opened. Everything below was run, not estimated.*

Writing to an array with a transpose codec stores garbage whenever the `order` is not its own inverse. Three separate causes, all hidden by the fact that `"C"`, `"F"` and `[2, 1, 0]` — the orders the tests use — *are* their own inverses, which sends `encode` down its no-copy fast path.

**`emptyLike` built the reordered copy from the wrong constructor.**

```js
data = new (chunk.constructor as TypedArrayConstructor<D>)(chunk.data.length);
```

A chunk is a plain `{data, shape, stride}` object, so `chunk.constructor` is `Object`, not the constructor of its data. `new Object(24)` is a `Number` wrapper; every write to it is silently dropped, and a **zero-byte chunk** is stored. It also passed `(length, chars)` to `ByteStringArray`/`UnicodeStringArray`, whose constructors take the character width first.

**`encode` and `decode` disagreed about which permutation describes the stored bytes.**

`decode` returns `stride: getStrides(arr.shape, this.#order)`, so the bytes on disk are laid out in `#order`. But `encode` converted to `#inverseOrder`. The v3 fixtures are generated by Python zarr and pin `decode`, so `encode` is the side that was wrong.

**`convertArrayOrder` ignored the source's strides.**

It walked `src.data` linearly while incrementing the index with the first axis fastest, which is correct only when `src` happens to be laid out that way; `src.stride` was never consulted. This is reachable even with an involutive order — a length-1 dimension makes two strides tie, `getOrder`'s sort picks one of them, and the comparison against the target fails even though the layouts are equivalent, so the conversion runs when it did not need to and gets it wrong.

With the first two fixed, `#inverseOrder` has no remaining use. The permutation validity check it also performed stays, as a local.

### Reproducing

```js
const arr = await zarr.create(store, {
  shape: [2, 3, 4],
  chunkShape: [2, 3, 4],
  dtype: "int32",
  codecs: [
    { name: "transpose", configuration: { order: [2, 0, 1] } },
    { name: "bytes", configuration: { endian: "little" } },
  ],
});
await zarr.set(arr, null, { data, shape: [2, 3, 4], stride: [12, 4, 1] });
store.get("/a/c/0/0/0").length; // 0 before, 96 after
```

On `main` a `(5, 11, 9, 5)` array with order `[2, 0, 3, 1]` round trips 3 of its 2475 elements correctly. With this, all of them.

### Tests

Two cases in `transpose.test.ts`: a round trip through the 3-cycles `[2, 0, 1]` and `[1, 2, 0]`, and an assertion that the stored chunk is the size it should be, which pins the constructor bug on its own. Both fail on `main` and pass here; the rest of the suite is unchanged.

### Checking there is nothing left

Alongside the tests here I ran a 240-case differential fuzz over random shapes, chunkings, selections and transpose orders, comparing against an oracle derived from coordinates rather than from zarrita:

| | failures of 240 |
| --- | --- |
| `main` | 21 |
| `main` + this PR | 10 |
| `main` + #445 | 20 |
| `main` + both | 0 |

The 10 that remain here are all the read-side bug in #445. (The harness is at https://github.com/cmdcolin/zarrita.js/tree/bench-contiguous-copy/packages/zarrita/__tests__/bench — note the fixed seed, so the counts are specific to that case set.)

So #444 and #445 are independent, but you need both for arbitrary orders to work end to end — this one is the write path, that one is the read.

