### PR TITLE
Apply the stride when an integer index terminates the copy

### DIFF
--- a/.changeset/transposed-integer-index.md
+++ b/.changeset/transposed-integer-index.md
@@ -1,0 +1,5 @@
+---
+"zarrita": patch
+---
+
+Fix reads and writes through an integer index on a transposed array

--- a/packages/zarrita/__tests__/indexing/transposed-integer-index.test.ts
+++ b/packages/zarrita/__tests__/indexing/transposed-integer-index.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import * as zarr from "../../src/index.js";
+
+/**
+ * An integer index drops a dimension, and the copy for that dimension is a
+ * single element, so it terminates the walk through `setFromChunkBinary`.
+ * Those two terminal cases addressed the element by its index alone, which is
+ * its offset only when the axis has stride 1 — true of the last axis of a
+ * C-contiguous chunk, and not true of an array with a transpose `order`.
+ */
+
+const SHAPE = [3, 4, 5];
+const STRIDE = [20, 5, 1];
+
+async function transposed() {
+	const store = new Map<string, Uint8Array>();
+	const arr = await zarr.create(zarr.root(store).resolve("/a"), {
+		shape: SHAPE,
+		chunkShape: SHAPE,
+		dtype: "int32",
+		codecs: [
+			{ name: "transpose", configuration: { order: [2, 1, 0] } },
+			{ name: "bytes", configuration: { endian: "little" } },
+		],
+	});
+	// element (i,j,k) = 20*i + 5*j + k
+	const data = new Int32Array(60).map((_, i) => i);
+	await zarr.set(arr, null, { data, shape: SHAPE, stride: STRIDE });
+	return arr;
+}
+
+/** Read a chunk's values in logical (C) order, honoring its strides. */
+function toLogical<D extends zarr.DataType>(chunk: zarr.Chunk<D>): unknown[] {
+	const { data, shape, stride } = chunk;
+	const total = shape.reduce((a, b) => a * b, 1);
+	const index = new globalThis.Array(shape.length).fill(0);
+	const out: unknown[] = [];
+	for (let n = 0; n < total; n++) {
+		out.push(
+			(data as ArrayLike<unknown>)[
+				index.reduce((acc, v, d) => acc + v * stride[d], 0)
+			],
+		);
+		for (let d = shape.length - 1; d >= 0; d--) {
+			if (++index[d] < shape[d]) break;
+			index[d] = 0;
+		}
+	}
+	return out;
+}
+
+describe("integer index into a transposed array", () => {
+	it("reads the indexed element, not the one at that offset", async () => {
+		const arr = await transposed();
+		// the last axis has stride 12 here, so index 3 is offset 36, not 3
+		expect(toLogical(await zarr.get(arr, [null, null, 3]))).toEqual([
+			3, 8, 13, 18, 23, 28, 33, 38, 43, 48, 53, 58,
+		]);
+		expect(toLogical(await zarr.get(arr, [1, null, 3]))).toEqual([
+			23, 28, 33, 38,
+		]);
+		expect(toLogical(await zarr.get(arr, [null, 2, 3]))).toEqual([13, 33, 53]);
+		expect(await zarr.get(arr, [1, 2, 3])).toBe(33);
+	});
+
+	it("writes to the indexed element", async () => {
+		const arr = await transposed();
+		// a chunk rather than a scalar, so this goes through the copy under test
+		await zarr.set(arr, [null, null, 3], {
+			data: new Int32Array(12).fill(-1),
+			shape: [3, 4],
+			stride: [4, 1],
+		});
+		const whole = toLogical(await zarr.get(arr, null)) as number[];
+		const changed = whole
+			.map((v, i) => (v === -1 ? i : -1))
+			.filter((i) => i >= 0);
+		// exactly the elements whose last index is 3
+		expect(changed).toEqual([3, 8, 13, 18, 23, 28, 33, 38, 43, 48, 53, 58]);
+	});
+});

--- a/packages/zarrita/src/indexing/ops.ts
+++ b/packages/zarrita/src/indexing/ops.ts
@@ -221,9 +221,11 @@ function setFromChunkBinary(
 	const [sstride, ...sstrides] = src.stride;
 	if (proj.from === null) {
 		if (projs.length === 0) {
+			// NB: the last dimension is only at stride 1 for a C-contiguous
+			// chunk; an array with a transpose `order` has some other axis there
 			dest.data.set(
 				src.data.subarray(0, bytesPerElement),
-				proj.to * bytesPerElement,
+				dstride * proj.to * bytesPerElement,
 			);
 			return;
 		}
@@ -240,7 +242,7 @@ function setFromChunkBinary(
 	}
 	if (proj.to === null) {
 		if (projs.length === 0) {
-			let offset = proj.from * bytesPerElement;
+			let offset = sstride * proj.from * bytesPerElement;
 			dest.data.set(src.data.subarray(offset, offset + bytesPerElement), 0);
 			return;
 		}


### PR DESCRIPTION
*Written by Claude Code on behalf of @cmdcolin, who reviewed it before it was opened. Everything below was run, not estimated.*

An integer index drops a dimension and selects a single element, which terminates the walk through `setFromChunkBinary`. Both terminal cases addressed that element by its index alone:

```js
let offset = proj.from * bytesPerElement;
```

That is the element's offset only when the axis has stride 1. The last axis of a C-contiguous chunk does, which is why this held up — but an array with a transpose `order` has some other axis there.

On a `(3, 4, 5)` array with `order: [2, 1, 0]`, the last axis has stride 12, so `get(arr, [null, null, 3])` read the elements at offset 3 instead of 36:

```js
// element (i,j,k) holds 20i + 5j + k
await zarr.get(arr, [null, null, 3]);
// want [3, 8, 13, 18, 23, 28, 33, 38, 43, 48, 53, 58]
// got  [5, 10, 15, 20, 25, 30, 35, 40, 45, 50, 55, 60]
await zarr.get(arr, [1, 2, 3]); // want 33, got 35
```

A full read of the same array is correct element for element, so it is specifically the dimension-dropping path.

`set()` swaps `from` and `to` and goes through the mirrored branch, which had the same omission, so writing through an integer index landed on the wrong element too. Both are fixed here.

### Tests

`__tests__/indexing/transposed-integer-index.test.ts` covers the read (integer on the last axis, alone and combined with other integers, including the all-integer scalar case) and the write (setting a chunk, not a scalar, so it goes through this copy rather than `setScalarBinary`). Both fail on `main`.

I also ran a 240-case differential fuzz over random shapes, chunkings, selections and transpose orders against an oracle derived from coordinates rather than from zarrita:

| | failures of 240 |
| --- | --- |
| `main` | 21 |
| `main` + this PR | 20 |
| `main` + #444 | 10 |
| `main` + both | 0 |

Most of that case set exercises the write path, which is why #444 accounts for more of it; the two are independent. (Harness: https://github.com/cmdcolin/zarrita.js/tree/bench-contiguous-copy/packages/zarrita/__tests__/bench — fixed seed, so the counts are specific to that case set.)

Independent of #444, though you need both to make arbitrary orders work end to end — that one is the write path, this one is the read.

