### PR TITLE
Use node 24 in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,8 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: https://registry.npmjs.org/
-      - run: npm install -g npm@latest
       - uses: pnpm/action-setup@v6
         with:
           run_install: true


### PR DESCRIPTION
npm 12 dropped node 20 support so the npm install -g npm@latest step started failing on main. Node 24 bundles npm 11, which already handles provenance, so the upgrade step goes away entirely.