### PR TITLE
Fix BytesCodec.decode buffer misalignment issue

### DIFF
--- a/.changeset/twenty-meals-wonder.md
+++ b/.changeset/twenty-meals-wonder.md
@@ -1,0 +1,5 @@
+---
+"zarrita": patch
+---
+
+Fixed buffer misalignment issue in BytesCodec.decode, ensuring that the start offset for a buffer passed into the TypedArray constructor is a multiple of the number of bytes per element.

--- a/packages/zarrita/__tests__/bytes.test.ts
+++ b/packages/zarrita/__tests__/bytes.test.ts
@@ -37,4 +37,24 @@ describe("BytesCodec", () => {
 
 		expect(data).toEqual(snapshot);
 	});
+
+	it("decodes a view whose byteOffset isn't a multiple of BYTES_PER_ELEMENT", () => {
+		// uint64 (BigUint64Array) needs 8-byte alignment. A store can hand back
+		// a Uint8Array view into a larger buffer (e.g. a shard's suffix bytes)
+		// whose byteOffset doesn't land on an 8-byte boundary; the TypedArray
+		// constructor throws `RangeError: start offset ... should be a multiple
+		// of 8` unless we copy into a fresh, aligned buffer first.
+		let codec = BytesCodec.fromConfig(
+			{ endian: "little" },
+			{ dataType: "uint64" as const, shape: [2], codecs: [] },
+		);
+		let backing = new Uint8Array(17);
+		backing.set([1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0], 1);
+		let bytes = backing.subarray(1, 17);
+		expect(bytes.byteOffset).toBe(1);
+
+		let chunk = codec.decode(bytes);
+
+		expect(Array.from(chunk.data)).toEqual([1n, 2n]);
+	});
 });

--- a/packages/zarrita/src/codecs/bytes.ts
+++ b/packages/zarrita/src/codecs/bytes.ts
@@ -73,6 +73,13 @@ export class BytesCodec<D extends Exclude<DataType, "v2:object" | "string">> {
 			bytes = bytes.slice();
 			byteswapInplace(bytes, bytesPerElement(this.#TypedArray));
 		}
+		if (bytes.byteOffset % this.#BYTES_PER_ELEMENT !== 0) {
+			// Typed array views must start at an offset that's a multiple of
+			// their element size. The store may hand back a view into a larger
+			// buffer (e.g. a shard's suffix bytes) that doesn't happen to land
+			// on such a boundary, so copy into a fresh, aligned buffer.
+			bytes = bytes.slice();
+		}
 		return {
 			data: new this.#TypedArray(
 				bytes.buffer,


### PR DESCRIPTION
For this array, [values.zip](https://github.com/user-attachments/files/30997265/values.zip), I ran into this error when trying to read the array via a FetchStore. I could not reproduce the issue with the FileSystemStore in a unit test, but added a test that uses the BytesCodec directly.


```
CodecPipelineError: Failed to decode chunk via codec "bytes"
    ZarritaError errors.ts:30
    CodecPipelineError errors.ts:111
    runStep codecs.ts:105
    decode codecs.ts:128
Caused by: RangeError: start offset of BigUint64Array should be a multiple of 8
    decode bytes.ts:77
    chunk codecs.ts:129
    runStep codecs.ts:103
    decode codecs.ts:128
```