### PR TITLE
Support the fixed_length_utf32 v3 extension data type

### DIFF
--- a/.changeset/fixed-length-utf32.md
+++ b/.changeset/fixed-length-utf32.md
@@ -1,0 +1,5 @@
+---
+"zarrita": minor
+---
+
+Support the `fixed_length_utf32` v3 extension data type

--- a/packages/zarrita/__tests__/open.test.ts
+++ b/packages/zarrita/__tests__/open.test.ts
@@ -20,7 +20,7 @@ import {
 	vi,
 } from "vitest";
 
-import { NotFoundError } from "../src/errors.js";
+import { InvalidMetadataError, NotFoundError } from "../src/errors.js";
 import { root } from "../src/hierarchy.js";
 import type {
 	ArrayMetadata,
@@ -1634,6 +1634,75 @@ describe("v3", async () => {
 			data: new Uint8Array([40]),
 			shape: [1],
 			stride: [1],
+		});
+	});
+
+	describe("v3 fixed_length_utf32", () => {
+		// Zarr v3 extension data types are objects rather than plain strings.
+		// NumPy's `<U{n}` lands here when xarray writes a v3 store, so this is the
+		// shape of a string coordinate produced by the Python stack.
+		let meta = {
+			zarr_format: 3,
+			node_type: "array",
+			shape: [3],
+			data_type: {
+				name: "fixed_length_utf32",
+				configuration: { length_bytes: 24 },
+			},
+			chunk_grid: { name: "regular", configuration: { chunk_shape: [3] } },
+			chunk_key_encoding: { name: "default" },
+			codecs: [{ name: "bytes", configuration: { endian: "little" } }],
+			fill_value: "",
+			attributes: {},
+		};
+
+		function store() {
+			// Six code points per element, null-padded, little endian.
+			let codePoints = new Int32Array(3 * 6);
+			["hello", "world", "zarr"].forEach((word, i) => {
+				for (let j = 0; j < word.length; j++) {
+					codePoints[i * 6 + j] = word.codePointAt(j) as number;
+				}
+			});
+			let entries = new Map<AbsolutePath, Uint8Array>();
+			entries.set("/zarr.json", new TextEncoder().encode(JSON.stringify(meta)));
+			entries.set("/c/0", new Uint8Array(codePoints.buffer));
+			return entries;
+		}
+
+		it("exposes the data type tagged with its length", async () => {
+			let arr = await open.v3(root(store()), { kind: "array" });
+			expect(arr.dtype).toBe("fixed_length_utf32:24");
+			expect(arr.shape).toEqual([3]);
+		});
+
+		it("reads the strings, stripping the null padding", async () => {
+			let arr = await open.v3(root(store()), { kind: "array" });
+			let chunk = await arr.getChunk([0]);
+			expect(globalThis.Array.from(chunk.data as Iterable<string>)).toEqual([
+				"hello",
+				"world",
+				"zarr",
+			]);
+		});
+
+		it("rejects a length that is not whole UTF-32 code points", async () => {
+			let entries = store();
+			entries.set(
+				"/zarr.json",
+				new TextEncoder().encode(
+					JSON.stringify({
+						...meta,
+						data_type: {
+							name: "fixed_length_utf32",
+							configuration: { length_bytes: 6 },
+						},
+					}),
+				),
+			);
+			await expect(open.v3(root(entries), { kind: "array" })).rejects.toThrow(
+				InvalidMetadataError,
+			);
 		});
 	});
 });

--- a/packages/zarrita/__tests__/util.test.ts
+++ b/packages/zarrita/__tests__/util.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../src/typedarray.js";
 import {
 	byteswapInplace,
+	coerceV3DataType,
 	ensureCorrectScalar,
 	getCtr,
 	getStrides,
@@ -39,6 +40,7 @@ describe("getCtr", () => {
 			["v2:U6", UnicodeStringArray],
 			["v2:S6", ByteStringArray],
 			["string", Array],
+			["fixed_length_utf32:24", UnicodeStringArray],
 		])("%s -> %o", (dtype, ctr) => {
 			const T = getCtr(dtype);
 			expect(new T(1)).toBeInstanceOf(ctr);
@@ -73,6 +75,7 @@ describe("getCtr", () => {
 			["v2:U6", UnicodeStringArray],
 			["v2:S6", ByteStringArray],
 			["string", Array],
+			["fixed_length_utf32:24", UnicodeStringArray],
 		])("%s -> %o", (dtype, ctr) => {
 			const T = getCtr(dtype);
 			expect(new T(1)).toBeInstanceOf(ctr);
@@ -129,6 +132,7 @@ describe("isDataType", () => {
 		["v2:S6", false],
 		["v2:object", false],
 		["string", false],
+		["fixed_length_utf32:24", false],
 	])("isDataType(%s, 'number') -> %s", (dtype, expected) => {
 		expect(isDataType(dtype, "number")).toBe(expected);
 	});
@@ -150,6 +154,7 @@ describe("isDataType", () => {
 		["v2:S6", false],
 		["v2:object", false],
 		["string", false],
+		["fixed_length_utf32:24", false],
 	])("isDataType(%s, 'boolean') -> %s", (dtype, expected) => {
 		expect(isDataType(dtype, "boolean")).toBe(expected);
 	});
@@ -171,6 +176,7 @@ describe("isDataType", () => {
 		["v2:S6", false],
 		["v2:object", false],
 		["string", false],
+		["fixed_length_utf32:24", false],
 	])("isDataType(%s, 'bigint') -> %s", (dtype, expected) => {
 		expect(isDataType(dtype, "bigint")).toBe(expected);
 	});
@@ -192,6 +198,7 @@ describe("isDataType", () => {
 		["v2:S6", true],
 		["v2:object", false],
 		["string", true],
+		["fixed_length_utf32:24", true],
 	])("isDataType(%s, 'string') -> %s", (dtype, expected) => {
 		expect(isDataType(dtype, "string")).toBe(expected);
 	});
@@ -213,6 +220,7 @@ describe("isDataType", () => {
 		"v2:S6",
 		"v2:object",
 		"string",
+		"fixed_length_utf32:24",
 	])("isDataType(%s, %s) -> true", (dtype) => {
 		expect(isDataType(dtype, dtype)).toBe(true);
 	});
@@ -711,5 +719,33 @@ describe("v2ToV3ArrayMetadata", () => {
 			  },
 			]
 		`);
+	});
+});
+
+describe("coerceV3DataType", () => {
+	test("passes built-in data types through", () => {
+		expect(coerceV3DataType("int32")).toBe("int32");
+		expect(coerceV3DataType("string")).toBe("string");
+	});
+
+	test("tags fixed_length_utf32 with its length", () => {
+		expect(
+			coerceV3DataType({
+				name: "fixed_length_utf32",
+				configuration: { length_bytes: 24 },
+			}),
+		).toBe("fixed_length_utf32:24");
+	});
+
+	test.each([
+		{ name: "fixed_length_utf32" },
+		{ name: "fixed_length_utf32", configuration: {} },
+		{ name: "fixed_length_utf32", configuration: { length_bytes: "24" } },
+		// Not a whole number of UTF-32 code points.
+		{ name: "fixed_length_utf32", configuration: { length_bytes: 6 } },
+		{ name: "numpy.datetime64", configuration: { unit: "s" } },
+		null,
+	])("rejects %j", (dataType) => {
+		expect(() => coerceV3DataType(dataType)).toThrow(zarr.InvalidMetadataError);
 	});
 });

--- a/packages/zarrita/src/metadata.ts
+++ b/packages/zarrita/src/metadata.ts
@@ -44,6 +44,13 @@ export type ByteStr = `v2:S${number}`;
 /** @category String */
 export type String = "string";
 
+/**
+ * The v3 `fixed_length_utf32` extension dtype, tagged with its `length_bytes`.
+ *
+ * @category String
+ */
+export type FixedLengthUtf32 = `fixed_length_utf32:${number}`;
+
 /** @category Object */
 export type ObjectType = "v2:object";
 
@@ -60,7 +67,7 @@ export type NumberDataType =
 
 export type BigintDataType = Int64 | Uint64;
 
-export type StringDataType = UnicodeStr | ByteStr | String;
+export type StringDataType = UnicodeStr | ByteStr | String | FixedLengthUtf32;
 
 export type DataType =
 	| NumberDataType
@@ -159,7 +166,7 @@ export type TypedArray<D extends DataType> = D extends Int8 ? Int8Array
 	: D extends Float32 ? Float32Array
 	: D extends Float64 ? Float64Array
 	: D extends Bool ? BoolArray
-	: D extends UnicodeStr ? UnicodeStringArray
+	: D extends UnicodeStr | FixedLengthUtf32 ? UnicodeStringArray
 	: D extends ByteStr ? ByteStringArray
 	: D extends String ? Array<string>
 	: D extends ObjectType ? Array<unknown>

--- a/packages/zarrita/src/open.ts
+++ b/packages/zarrita/src/open.ts
@@ -32,6 +32,7 @@ import type {
 	GroupMetadata,
 } from "./metadata.js";
 import {
+	coerceV3DataType,
 	ensureCorrectScalar,
 	jsonDecodeObject,
 	rethrowUnless,
@@ -180,6 +181,7 @@ async function _openV3<Store extends Readable>(
 	}
 	let metaDoc: ArrayMetadata<DataType> | GroupMetadata = jsonDecodeObject(meta);
 	if (metaDoc.node_type === "array") {
+		metaDoc.data_type = coerceV3DataType(metaDoc.data_type);
 		metaDoc.fill_value = ensureCorrectScalar(metaDoc);
 	}
 	return metaDoc.node_type === "array"

--- a/packages/zarrita/src/util.ts
+++ b/packages/zarrita/src/util.ts
@@ -96,6 +96,12 @@ export function getCtr<D extends DataType>(
 			Number(chars),
 		);
 	}
+	let utf32 = dataType.match(/^fixed_length_utf32:(\d+)$/);
+	if (utf32) {
+		// Same layout as v2 `<U{n}`: fixed-width, null-padded UTF-32 code points.
+		// @ts-expect-error
+		return UnicodeStringArray.bind(null, Number(utf32[1]) / 4);
+	}
 	// Handle v3 variable-length string type
 	if (dataType === "string") {
 		return globalThis.Array as unknown as TypedArrayConstructor<D>;
@@ -387,7 +393,10 @@ export function isDataType<Query extends DataTypeQuery>(
 	let isBoolean = dtype === "bool";
 	if (query === "boolean") return isBoolean;
 	let isString =
-		dtype.startsWith("v2:U") || dtype.startsWith("v2:S") || dtype === "string";
+		dtype.startsWith("v2:U") ||
+		dtype.startsWith("v2:S") ||
+		dtype.startsWith("fixed_length_utf32:") ||
+		dtype === "string";
 	if (query === "string") return isString;
 	let isBigint = dtype === "int64" || dtype === "uint64";
 	if (query === "bigint") return isBigint;
@@ -409,6 +418,36 @@ export function isShardingCodec(
 	codec: CodecMetadata,
 ): codec is ShardingCodecMetadata {
 	return codec?.name === "sharding_indexed";
+}
+
+/**
+ * Flatten a v3 `data_type` into a `DataType`.
+ *
+ * Built-in v3 data types are plain strings, but extension data types are
+ * objects like `{ name, configuration }`. We fold the configuration into the
+ * name so the result stays a string, as the rest of the library assumes.
+ */
+export function coerceV3DataType(dataType: unknown): DataType {
+	if (typeof dataType === "string") {
+		return dataType as DataType;
+	}
+	if (
+		typeof dataType === "object" &&
+		dataType !== null &&
+		"name" in dataType &&
+		dataType.name === "fixed_length_utf32"
+	) {
+		let { length_bytes: lengthBytes } =
+			("configuration" in dataType
+				? (dataType.configuration as { length_bytes?: unknown })
+				: undefined) ?? {};
+		if (typeof lengthBytes === "number" && lengthBytes % 4 === 0) {
+			return `fixed_length_utf32:${lengthBytes}`;
+		}
+	}
+	throw new InvalidMetadataError(
+		`Unsupported data type: ${JSON.stringify(dataType)}`,
+	);
 }
 
 export function ensureCorrectScalar<D extends DataType>(


### PR DESCRIPTION
Built-in v3 data types are plain strings, but extension data types are objects like `{ name, configuration }`. `getCtr` assumed a string and called `.match()` on it, so opening an array whose `data_type` is `fixed_length_utf32` failed with `dataType.match is not a function`.

Fold the configuration into the name when v3 array metadata is read, so the data type stays a string as the rest of the library assumes, and surfaces as `fixed_length_utf32:{length_bytes}`. The on-disk layout is the same as v2 `<U{n}` (fixed-width, null-padded UTF-32 code points), so `UnicodeStringArray` already decodes it and `BytesCodec` already handles its element size and byte swapping.

Unrecognized data types now raise `InvalidMetadataError` rather than a `TypeError` from deeper in the call stack.

NumPy `<U` string coordinates land as this data type when xarray writes a v3 store, so it is common in stores produced by the Python stack.

This also closes #428